### PR TITLE
Fix v1.1.0 Intel Mac OpenSSL cross-compile and Windows ssh2 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,7 +412,7 @@ jobs:
           const fs = require('fs')
           const platforms = [
             'macos-aarch64-apple-darwin',
-            'macos-x86_64-apple-darwin',
+            'macos-15-intel',
             'linux-ubuntu-22.04',
             'windows-latest',
           ]
@@ -453,9 +453,9 @@ jobs:
           - platform: macos-latest
             args: --target aarch64-apple-darwin
             rust-target: aarch64-apple-darwin
-          - platform: macos-latest
-            args: --target x86_64-apple-darwin
-            rust-target: x86_64-apple-darwin
+          - platform: macos-15-intel
+            args: ''
+            rust-target: ''
           - platform: ubuntu-22.04
             args: ''
             rust-target: ''
@@ -513,7 +513,7 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           tauriScript: corepack pnpm tauri
           args: ${{ matrix.args }}
-          assetNamePattern: '[name]_[version]_[platform]_[arch][setup][ext]'
+          releaseAssetNamePattern: '[name]_[version]_[platform]_[arch][setup][ext]'
           retryAttempts: 2
           # Installers go only to the GitHub Release. Do not set uploadWorkflowArtifacts
           # unless those Actions artifacts also get installer_artifact_retention_days.

--- a/src-tauri/crates/remote-core/src/network.rs
+++ b/src-tauri/crates/remote-core/src/network.rs
@@ -4,10 +4,11 @@ use crate::{
     RemoteProviderResult,
 };
 use std::cell::RefCell;
+use std::fs;
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::path::Path;
-use std::time::Duration;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub fn protocol_is_implemented(protocol: RemoteProtocol) -> bool {
     matches!(
@@ -306,18 +307,60 @@ fn authenticate_sftp(
         RemoteCredentialMaterial::PrivateKey {
             private_key,
             passphrase,
-        } => session
-            .userauth_pubkey_memory(
-                username,
-                None,
-                private_key.expose_secret(),
-                passphrase.as_ref().map(|value| value.expose_secret()),
-            )
-            .map_err(|error| RemoteProviderError::Backend(error.to_string())),
+        } => authenticate_sftp_private_key(
+            session,
+            username,
+            private_key.expose_secret(),
+            passphrase.as_ref().map(|value| value.expose_secret()),
+        ),
         RemoteCredentialMaterial::BearerToken(_) => Err(RemoteProviderError::Backend(
             "SFTP does not support bearer token authentication".to_owned(),
         )),
     }
+}
+
+fn authenticate_sftp_private_key(
+    session: &ssh2::Session,
+    username: &str,
+    private_key: &str,
+    passphrase: Option<&str>,
+) -> RemoteProviderResult<()> {
+    let key_file = stage_private_key_file(private_key)?;
+    session
+        .userauth_pubkey_file(username, None, key_file.path(), passphrase)
+        .map_err(|error| RemoteProviderError::Backend(error.to_string()))
+}
+
+struct StagedPrivateKey {
+    path: PathBuf,
+}
+
+impl StagedPrivateKey {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for StagedPrivateKey {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn stage_private_key_file(private_key: &str) -> RemoteProviderResult<StagedPrivateKey> {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let path = std::env::temp_dir().join(format!(
+        "opendiff-sftp-key-{}-{stamp}.pem",
+        std::process::id()
+    ));
+    fs::write(&path, private_key).map_err(|error| {
+        RemoteProviderError::Backend(format!("could not stage SFTP private key: {error}"))
+    })?;
+    crate::persist::restrict_file_permissions(&path);
+    Ok(StagedPrivateKey { path })
 }
 
 fn credential_username(credential: &RemoteCredential) -> RemoteProviderResult<&str> {
@@ -386,5 +429,49 @@ mod tests {
         assert!(!protocol_is_implemented(RemoteProtocol::S3));
         assert!(protocol_is_implemented(RemoteProtocol::Sftp));
         assert!(protocol_is_implemented(RemoteProtocol::WebDav));
+    }
+
+    #[test]
+    fn stages_sftp_private_key_to_a_restricted_temp_file() {
+        let pem =
+            "-----BEGIN OPENSSH PRIVATE KEY-----\ntest-key\n-----END OPENSSH PRIVATE KEY-----\n";
+        let staged = stage_private_key_file(pem).expect("key should stage");
+        let path = staged.path().to_path_buf();
+
+        assert_eq!(fs::read_to_string(&path).expect("staged key"), pem);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+
+        drop(staged);
+        assert!(
+            !path.exists(),
+            "staged private key must be removed after auth"
+        );
+    }
+
+    #[test]
+    fn sftp_private_key_auth_uses_the_portable_pubkey_file_path() {
+        let profile = RemoteProfile::new(
+            "closed-sftp-key",
+            "Closed SFTP key",
+            RemoteProtocol::Sftp,
+            RemoteEndpoint::new("127.0.0.1").with_port(1),
+            CredentialReference::profile_store("closed-sftp-key"),
+        );
+        let credential = RemoteCredential::private_key(
+            "deploy",
+            "-----BEGIN OPENSSH PRIVATE KEY-----\ntest-key\n-----END OPENSSH PRIVATE KEY-----\n",
+            None::<String>,
+        );
+        let error = test_network_connection(&profile, &credential).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RemoteProviderError::Backend(message) if message.contains("connect failed")
+        ));
     }
 }

--- a/src-tauri/crates/remote-core/src/persist.rs
+++ b/src-tauri/crates/remote-core/src/persist.rs
@@ -186,17 +186,18 @@ fn io_error(error: std::io::Error) -> ProfileStoreError {
     ProfileStoreError::Io(error.to_string())
 }
 
-fn restrict_file_permissions(path: &Path) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if let Ok(metadata) = fs::metadata(path) {
-            let mut permissions = metadata.permissions();
-            permissions.set_mode(0o600);
-            let _ = fs::set_permissions(path, permissions);
-        }
+#[cfg(unix)]
+pub(crate) fn restrict_file_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(metadata) = fs::metadata(path) {
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o600);
+        let _ = fs::set_permissions(path, permissions);
     }
 }
+
+#[cfg(not(unix))]
+pub(crate) fn restrict_file_permissions(_path: &Path) {}
 
 #[cfg(test)]
 mod tests {
@@ -275,6 +276,16 @@ mod tests {
             "prod-sftp"
         );
 
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn restrict_file_permissions_accepts_existing_files_on_every_platform() {
+        let root = unique_temp_dir("remote-perms");
+        let path = root.join("secret.json");
+        std::fs::write(&path, "{}").expect("fixture");
+        restrict_file_permissions(&path);
+        assert!(path.exists());
         let _ = std::fs::remove_dir_all(root);
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the two v1.1.0 Release job failures. Does **not** retag, bump the version, dispatch Release, or touch published Release assets. PR #23/#24 retention and prune behavior on master is unchanged.

### Failure 1: Intel Mac (`openssl-sys` cross-compile)

`macos-latest` is ARM. The Intel job used `--target x86_64-apple-darwin`, so `ssh2` / `libssh2-sys` / `openssl-sys` tried to cross-compile and failed (`pkg-config has not been configured to support cross-compilation`).

**Change:** run Intel natively on `macos-15-intel` with empty `args` / `rust-target` (same as Windows/Linux). Keep Apple Silicon on `macos-latest` with `--target aarch64-apple-darwin`.

Also rename invalid tauri-action input `assetNamePattern` → `releaseAssetNamePattern` (same pattern). The v1.1.0 log already warned about this.

### Failure 2: Windows (`RUSTFLAGS: -D warnings`)

`userauth_pubkey_memory` is cfg-gated off on Windows ssh2 (needs OpenSSL). Unused `path` in `restrict_file_permissions` is unix-only.

**Change:** stage the in-memory private key to a restricted temp file and call the portable `userauth_pubkey_file` API, then delete the file. SFTP is not stubbed. On non-unix, `restrict_file_permissions` takes `_path`.

## Type of change

- [x] Bug fix
- [x] Build, CI, or release

## Validation

- `RUSTFLAGS='-D warnings' rustup run stable cargo test -p remote-core --locked` — 46 passed
- Did not dispatch Release and did not retag `v1.1.0`

- [ ] `corepack pnpm quality`
- [ ] `corepack pnpm test`

## Checklist

- [x] I kept the change focused.
- [x] I added or updated tests where needed.
- [x] I checked that no sensitive data is included.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cc2666d-53aa-4df6-9b32-da9593efc2c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cc2666d-53aa-4df6-9b32-da9593efc2c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

