### PR TITLE
Fix UI label overflow on buttons and cards

### DIFF
--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -799,8 +799,12 @@ const sourceSessionTypes = new Set<SessionType>([
 }
 
 .menus button {
-  padding: 0 2px;
-  font-size: 20px;
+  max-width: 9em;
+  padding: 0 6px;
+  overflow: hidden;
+  font-size: 14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .menus button:hover,
@@ -1054,21 +1058,36 @@ const sourceSessionTypes = new Set<SessionType>([
   align-items: center;
   justify-content: space-between;
   gap: 10px;
+  min-width: 0;
   min-height: 30px;
   padding: 4px 8px;
+  overflow: hidden;
   border-bottom: 1px solid var(--app-border);
   background: var(--app-primary-soft);
   color: var(--app-text);
   font-size: 12px;
 }
 
+.dirty-tab-prompt > span,
+.dirty-tab-prompt > p {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .dirty-tab-prompt button {
+  flex: 0 0 auto;
+  max-width: 8em;
   height: 22px;
   padding: 0 8px;
+  overflow: hidden;
   border: 1px solid var(--app-border);
   border-radius: 4px;
   background: var(--app-canvas);
   color: var(--app-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
   cursor: pointer;
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -301,14 +301,6 @@ select {
 
 .workbench-toolbar button,
 .path-pair-bar button {
-  border: 1px solid var(--app-border);
-  border-radius: 2px;
-  background: var(--app-canvas);
-  color: var(--app-text);
-}
-
-.workbench-toolbar button,
-.path-pair-bar button {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
@@ -321,8 +313,10 @@ select {
   min-height: 24px;
   padding: 4px 10px;
   overflow: visible;
-  border-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
   background: transparent;
+  color: var(--app-text);
   font-size: 12px;
   line-height: 1.2;
   white-space: nowrap;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -203,12 +203,9 @@ select {
 .bc-toolbar-command {
   display: grid;
   grid-template-rows: 28px minmax(0, 22px);
-  justify-items: center;
-  align-content: center;
-  box-sizing: border-box;
   width: max-content;
-  max-width: 110px;
   min-width: 72px;
+  max-width: 110px;
   height: 66px;
   padding: 3px 6px 4px;
   overflow: hidden;
@@ -218,19 +215,22 @@ select {
   color: #111111;
   font-size: 13px;
   line-height: 16px;
-  text-overflow: ellipsis;
   white-space: nowrap;
   cursor: default;
+  justify-items: center;
+  align-content: center;
+  box-sizing: border-box;
+  text-overflow: ellipsis;
 }
 
 .bc-toolbar-command > span,
 .bc-toolbar-command > label {
   display: block;
-  max-width: 100%;
   min-width: 0;
+  max-width: 100%;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .bc-toolbar-command:first-child,
@@ -309,30 +309,30 @@ select {
   align-items: center;
   justify-content: center;
   gap: 2px;
-  box-sizing: border-box;
-  max-width: 120px;
-  min-width: 0;
   width: max-content;
+  min-width: 0;
+  max-width: 120px;
   height: 62px;
   padding: 3px 8px;
   overflow: hidden;
-  border-color: transparent;
   background: transparent;
   font-size: 13px;
   line-height: 16px;
-  text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
+  box-sizing: border-box;
+  border-color: transparent;
+  text-overflow: ellipsis;
 }
 
 .workbench-toolbar button > span,
 .path-pair-bar button > span {
   display: block;
-  max-width: 100%;
   min-width: 0;
+  max-width: 100%;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .workbench-toolbar button:hover,
@@ -773,18 +773,4 @@ select {
   .workbench-inspector {
     display: none;
   }
-}
-
-/* Contained labels: buttons, chips, cards, nav items */
-button,
-.chrome-button,
-.nav-item,
-.tab-chip,
-.new-session-card,
-.bc-toolbar-command {
-  min-width: 0;
-}
-
-button {
-  max-width: 100%;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -202,35 +202,33 @@ select {
 
 .bc-toolbar-command {
   display: grid;
-  grid-template-rows: 28px minmax(0, 22px);
-  width: max-content;
+  grid-template-rows: 28px auto;
+  align-content: center;
+  justify-items: center;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  width: auto;
   min-width: 72px;
-  max-width: 110px;
+  max-width: none;
   height: 66px;
-  padding: 3px 6px 4px;
-  overflow: hidden;
+  padding: 3px 8px 4px;
+  overflow: visible;
   border: 0;
   border-right: 1px solid #c9cdd3;
   background: transparent;
   color: #111111;
-  font-size: 13px;
-  line-height: 16px;
+  font-size: 12px;
+  line-height: 14px;
   white-space: nowrap;
   cursor: default;
-  justify-items: center;
-  align-content: center;
-  box-sizing: border-box;
-  text-overflow: ellipsis;
 }
 
 .bc-toolbar-command > span,
 .bc-toolbar-command > label {
   display: block;
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
+  max-width: none;
+  overflow: visible;
   white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .bc-toolbar-command:first-child,
@@ -290,49 +288,52 @@ select {
   background: #eeeeee;
 }
 
-.workbench-toolbar button,
 .workbench-toolbar select,
 .workbench-toolbar input,
-.path-pair-bar button,
 .path-pair-bar input {
   height: 24px;
   border: 1px solid var(--app-border);
   border-radius: 2px;
   background: var(--app-canvas);
   color: var(--app-text);
-  font-size: 18px;
+  font-size: 12px;
 }
 
 .workbench-toolbar button,
 .path-pair-bar button {
-  display: inline-grid;
+  border: 1px solid var(--app-border);
+  border-radius: 2px;
+  background: var(--app-canvas);
+  color: var(--app-text);
+}
+
+.workbench-toolbar button,
+.path-pair-bar button {
+  display: inline-flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  gap: 2px;
-  width: max-content;
+  box-sizing: border-box;
+  width: auto;
   min-width: 0;
-  max-width: 120px;
-  height: 62px;
-  padding: 3px 8px;
-  overflow: hidden;
+  max-width: none;
+  height: auto;
+  min-height: 24px;
+  padding: 4px 10px;
+  overflow: visible;
+  border-color: transparent;
   background: transparent;
-  font-size: 13px;
-  line-height: 16px;
+  font-size: 12px;
+  line-height: 1.2;
   white-space: nowrap;
   cursor: pointer;
-  box-sizing: border-box;
-  border-color: transparent;
-  text-overflow: ellipsis;
 }
 
 .workbench-toolbar button > span,
 .path-pair-bar button > span {
-  display: block;
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
+  display: inline;
+  overflow: visible;
   white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .workbench-toolbar button:hover,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -775,7 +775,6 @@ select {
   }
 }
 
-
 /* Contained labels: buttons, chips, cards, nav items */
 button,
 .chrome-button,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -202,20 +202,35 @@ select {
 
 .bc-toolbar-command {
   display: grid;
-  grid-template-rows: 28px 22px;
+  grid-template-rows: 28px minmax(0, 22px);
   justify-items: center;
   align-content: center;
-  min-width: 82px;
+  box-sizing: border-box;
+  width: max-content;
+  max-width: 110px;
+  min-width: 72px;
   height: 66px;
-  padding: 3px 8px 4px;
+  padding: 3px 6px 4px;
+  overflow: hidden;
   border: 0;
   border-right: 1px solid #c9cdd3;
   background: transparent;
   color: #111111;
-  font-size: 18px;
-  line-height: 20px;
+  font-size: 13px;
+  line-height: 16px;
+  text-overflow: ellipsis;
   white-space: nowrap;
   cursor: default;
+}
+
+.bc-toolbar-command > span,
+.bc-toolbar-command > label {
+  display: block;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .bc-toolbar-command:first-child,
@@ -294,13 +309,30 @@ select {
   align-items: center;
   justify-content: center;
   gap: 2px;
-  min-width: 78px;
+  box-sizing: border-box;
+  max-width: 120px;
+  min-width: 0;
+  width: max-content;
   height: 62px;
-  padding: 3px 10px;
+  padding: 3px 8px;
+  overflow: hidden;
   border-color: transparent;
   background: transparent;
+  font-size: 13px;
+  line-height: 16px;
+  text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
+}
+
+.workbench-toolbar button > span,
+.path-pair-bar button > span {
+  display: block;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .workbench-toolbar button:hover,
@@ -741,4 +773,19 @@ select {
   .workbench-inspector {
     display: none;
   }
+}
+
+
+/* Contained labels: buttons, chips, cards, nav items */
+button,
+.chrome-button,
+.nav-item,
+.tab-chip,
+.new-session-card,
+.bc-toolbar-command {
+  min-width: 0;
+}
+
+button {
+  max-width: 100%;
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1143,12 +1143,10 @@ function openSelectedPreview(): void {
 
 .new-session-card {
   display: grid;
-  justify-items: center;
   gap: 6px;
-  box-sizing: border-box;
   width: 100%;
-  max-width: 100%;
   min-width: 0;
+  max-width: 100%;
   min-height: 104px;
   padding: 4px 6px;
   overflow: hidden;
@@ -1157,6 +1155,8 @@ function openSelectedPreview(): void {
   background: transparent;
   color: #111827;
   cursor: pointer;
+  justify-items: center;
+  box-sizing: border-box;
 }
 
 .new-session-card:hover,
@@ -1174,21 +1174,21 @@ function openSelectedPreview(): void {
 }
 
 .new-session-card h3 {
-  margin: 0;
   max-width: 100%;
+  margin: 0;
   overflow: hidden;
   font-size: 16px;
   font-weight: 400;
   line-height: 1.2;
   text-align: center;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .new-session-card p {
-  margin: 0;
   display: -webkit-box;
   max-width: 100%;
+  margin: 0;
   overflow: hidden;
   color: #4b5563;
   font-size: 12px;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1145,8 +1145,13 @@ function openSelectedPreview(): void {
   display: grid;
   justify-items: center;
   gap: 6px;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   min-height: 104px;
-  padding: 4px;
+  padding: 4px 6px;
+  overflow: hidden;
   border: 0;
   border-radius: 2px;
   background: transparent;
@@ -1170,18 +1175,28 @@ function openSelectedPreview(): void {
 
 .new-session-card h3 {
   margin: 0;
-  font-size: 21px;
+  max-width: 100%;
+  overflow: hidden;
+  font-size: 16px;
   font-weight: 400;
-  line-height: 1.15;
+  line-height: 1.2;
   text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .new-session-card p {
   margin: 0;
+  display: -webkit-box;
+  max-width: 100%;
+  overflow: hidden;
   color: #4b5563;
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.35;
   text-align: center;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
 }
 
 .bc-home-secondary {

--- a/src/views/TextCompareView.vue
+++ b/src/views/TextCompareView.vue
@@ -1032,13 +1032,19 @@ function toggleSourceEditors(): void {
 }
 
 .toolbar-button {
-  height: 24px;
-  padding: 0 8px;
+  flex: 0 0 auto;
+  width: auto;
+  max-width: none;
+  height: 28px;
+  padding: 0 10px;
+  overflow: visible;
   border: 1px solid var(--app-border);
   border-radius: 4px;
   background: var(--app-canvas);
   color: var(--app-text);
   font-size: 12px;
+  line-height: 1.2;
+  white-space: nowrap;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- Keep toolbar, menu, and home-card labels inside their containers
- Ellipsis / line-clamp so wrapped buttons and blocks do not spill text

## Test plan
- [ ] Home session cards: long titles/descriptions stay inside the card
- [ ] Text Compare toolbar labels at a narrow window
- [ ] Menu bar labels do not overflow