### PR TITLE
Hide unfinished controls without unimplemented labels

### DIFF
--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -202,7 +202,7 @@ describe('FolderCompareView', () => {
     expect(useTabsStore().tabs.some((tab) => tab.route === '/compare/text')).toBe(true)
   })
 
-  it('labels open-with and align-with as unimplemented instead of status-only no-ops', async () => {
+  it('keeps unfinished open-with and align-with actions disabled without unimplemented labels', async () => {
     const wrapper = mountFolderCompareView()
 
     await runCompare(wrapper)
@@ -219,10 +219,12 @@ describe('FolderCompareView', () => {
     expect(vscode.attributes('disabled')).toBeDefined()
     expect(alignWith.attributes('disabled')).toBeDefined()
     expect(breakAlignment.attributes('disabled')).toBeDefined()
-    expect(openWith.text()).toContain('unimplemented')
-    expect(associated.text()).toContain('unimplemented')
-    expect(vscode.text()).toContain('unimplemented')
-    expect(alignWith.text()).toContain('unimplemented')
+    expect(openWith.text()).toBe('Open With')
+    expect(associated.text()).toBe('Associated App')
+    expect(vscode.text()).toBe('Visual Studio Code')
+    expect(alignWith.text()).toBe('Align With')
+    expect(breakAlignment.text()).toBe('Break Alignment')
+    expect(openWith.text()).not.toContain('unimplemented')
     expect(wrapper.find('[data-testid="folder-open-action-status"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="folder-alignment-action-status"]').exists()).toBe(false)
   })

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -1040,7 +1040,7 @@ function handleTreeScroll(event: Event): void {
             secondary
             data-testid="open-with-selected-file"
             disabled
-            >{{ $t('ui.openWith') }} ({{ $t('ui.unimplemented') }})</NButton
+            >{{ $t('ui.openWith') }}</NButton
           >
           <NButton
             v-for="application in enabledExternalApplications"
@@ -1050,14 +1050,14 @@ function handleTreeScroll(event: Event): void {
             :data-testid="`open-with-custom-${application.id}`"
             disabled
           >
-            {{ application.name }} ({{ $t('ui.unimplemented') }})
+            {{ application.name }}
           </NButton>
           <NButton
             size="small"
             secondary
             data-testid="open-associated-file"
             disabled
-            >{{ $t('ui.associatedApp') }} ({{ $t('ui.unimplemented') }})</NButton
+            >{{ $t('ui.associatedApp') }}</NButton
           >
           <NButton
             size="small"
@@ -1425,14 +1425,14 @@ function handleTreeScroll(event: Event): void {
           secondary
           data-testid="align-with-selected-file"
           disabled
-          >{{ $t('ui.alignWith') }} ({{ $t('ui.unimplemented') }})</NButton
+          >{{ $t('ui.alignWith') }}</NButton
         >
         <NButton
           size="small"
           secondary
           data-testid="break-selected-alignment"
           disabled
-          >{{ $t('ui.breakAlignment') }} ({{ $t('ui.unimplemented') }})</NButton
+          >{{ $t('ui.breakAlignment') }}</NButton
         >
       </section>
 

--- a/src/views/HomeView.test.ts
+++ b/src/views/HomeView.test.ts
@@ -181,7 +181,8 @@ describe('HomeView', () => {
     expect(wrapper.find('[data-testid="home-edit-selected"]').attributes('disabled')).toBeDefined()
     expect(wrapper.find('[data-testid="home-tree-add"]').attributes('disabled')).toBeDefined()
     expect(wrapper.find('[data-testid="home-tree-remove"]').attributes('disabled')).toBeDefined()
-    expect(wrapper.find('[data-testid="home-edit-selected"]').text()).toContain('unimplemented')
+    expect(wrapper.find('[data-testid="home-edit-selected"]').text()).toBe('Edit')
+    expect(wrapper.find('[data-testid="home-edit-selected"]').text()).not.toContain('unimplemented')
   })
 
   it('shows saved sessions in a dense recent sessions table', () => {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -566,8 +566,7 @@ function openSelectedPreview(): void {
             type="button"
             disabled
             data-testid="home-tree-add"
-            :title="$t('ui.unimplemented')"
-            :aria-label="$t('ui.unimplemented')"
+            :aria-label="$t('ui.add')"
           >
             +
           </button>
@@ -575,8 +574,7 @@ function openSelectedPreview(): void {
             type="button"
             disabled
             data-testid="home-tree-remove"
-            :title="$t('ui.unimplemented')"
-            :aria-label="$t('ui.unimplemented')"
+            :aria-label="$t('ui.remove')"
           >
             −
           </button>
@@ -612,7 +610,7 @@ function openSelectedPreview(): void {
               disabled
               data-testid="home-edit-selected"
             >
-              {{ $t('ui.edit') }} ({{ $t('ui.unimplemented') }})
+              {{ $t('ui.edit') }}
             </button>
           </div>
         </section>

--- a/src/views/RemoteProfileView.test.ts
+++ b/src/views/RemoteProfileView.test.ts
@@ -150,7 +150,9 @@ describe('RemoteProfileView', () => {
     expect(save.text()).toBe('Save')
     expect(save.text()).not.toContain('unimplemented')
     expect(
-      wrapper.find('[data-testid="remote-profile-protocol-select"] option[value="s3"]').attributes('disabled'),
+      wrapper
+        .find('[data-testid="remote-profile-protocol-select"] option[value="s3"]')
+        .attributes('disabled'),
     ).toBeDefined()
 
     await save.trigger('click')

--- a/src/views/RemoteProfileView.test.ts
+++ b/src/views/RemoteProfileView.test.ts
@@ -136,7 +136,7 @@ describe('RemoteProfileView', () => {
     expect(deleteRemoteProfile).toHaveBeenCalledWith('release-ftp')
   })
 
-  it('disables save for unimplemented remote protocols', async () => {
+  it('disables save for unfinished remote protocols without unimplemented labels', async () => {
     const wrapper = mount(RemoteProfileView, {
       global: { plugins: [createPinia()] },
     })
@@ -147,7 +147,11 @@ describe('RemoteProfileView', () => {
     const save = wrapper.find('[data-testid="save-remote-profile"]')
 
     expect(save.attributes('disabled')).toBeDefined()
-    expect(save.text()).toContain('unimplemented')
+    expect(save.text()).toBe('Save')
+    expect(save.text()).not.toContain('unimplemented')
+    expect(
+      wrapper.find('[data-testid="remote-profile-protocol-select"] option[value="s3"]').attributes('disabled'),
+    ).toBeDefined()
 
     await save.trigger('click')
     await flushPromises()

--- a/src/views/RemoteProfileView.vue
+++ b/src/views/RemoteProfileView.vue
@@ -476,9 +476,7 @@ function credentialKindLabel(kind: CredentialReferenceKind): string {
                 :disabled="!canSaveProfile"
                 @click="saveProfile"
               >
-                {{
-                  canSaveProfile ? $t('ui.save') : `${$t('ui.save')} (${$t('ui.unimplemented')})`
-                }}
+                {{ $t('ui.save') }}
               </button>
             </div>
           </div>
@@ -506,18 +504,37 @@ function credentialKindLabel(kind: CredentialReferenceKind): string {
                 data-testid="remote-profile-protocol-select"
               >
                 <option value="ftp">{{ $t('ui.ftp') }}</option>
-                <option value="ftps">{{ $t('ui.ftps') }} ({{ $t('ui.unimplemented') }})</option>
+                <option
+                  value="ftps"
+                  disabled
+                >
+                  {{ $t('ui.ftps') }}
+                </option>
                 <option value="sftp">{{ $t('ui.sftp') }}</option>
                 <option value="web-dav">{{ $t('ui.webDav') }}</option>
-                <option value="s3">{{ $t('ui.s3') }} ({{ $t('ui.unimplemented') }})</option>
-                <option value="dropbox">
-                  {{ $t('ui.dropbox') }} ({{ $t('ui.unimplemented') }})
+                <option
+                  value="s3"
+                  disabled
+                >
+                  {{ $t('ui.s3') }}
                 </option>
-                <option value="one-drive">
-                  {{ $t('ui.onedrive') }} ({{ $t('ui.unimplemented') }})
+                <option
+                  value="dropbox"
+                  disabled
+                >
+                  {{ $t('ui.dropbox') }}
                 </option>
-                <option value="subversion">
-                  {{ $t('ui.subversion') }} ({{ $t('ui.unimplemented') }})
+                <option
+                  value="one-drive"
+                  disabled
+                >
+                  {{ $t('ui.onedrive') }}
+                </option>
+                <option
+                  value="subversion"
+                  disabled
+                >
+                  {{ $t('ui.subversion') }}
                 </option>
               </select>
             </label>

--- a/tests/e2e/session-linkage.spec.ts
+++ b/tests/e2e/session-linkage.spec.ts
@@ -37,7 +37,7 @@ test('text compare CTA issues diff_text', async ({ page }) => {
   await expect.poll(async () => (await lastInvoke(page, 'diff_text'))?.command).toBe('diff_text')
 })
 
-test('folder compare CTA issues compare_folder_paths and keeps unimplemented disabled', async ({
+test('folder compare CTA issues compare_folder_paths and keeps unfinished actions disabled', async ({
   page,
 }) => {
   await page.goto('/compare/folder')
@@ -202,10 +202,15 @@ test('reports and scripts issue export and run_script', async ({ page }) => {
   await expect.poll(async () => (await lastInvoke(page, 'run_script'))?.command).toBe('run_script')
 })
 
-test('remote profiles keep unimplemented protocols labeled and can test SFTP', async ({ page }) => {
+test('remote profiles keep unfinished protocols disabled and can test SFTP', async ({ page }) => {
   await page.goto('/settings/remote-profiles')
   await expect(page.getByTestId('remote-profile-protocol-select')).toBeVisible()
-  await expect(page.getByTestId('remote-profile-protocol-select')).toContainText('unimplemented')
+  await expect(page.getByTestId('remote-profile-protocol-select')).not.toContainText(
+    'unimplemented',
+  )
+  await expect(
+    page.locator('[data-testid="remote-profile-protocol-select"] option[value="s3"]'),
+  ).toBeDisabled()
   await page.getByTestId('select-remote-profile-prod-sftp').click()
   await page.getByTestId('test-remote-profile').click()
   await expect


### PR DESCRIPTION
## Summary
- Remove visible `unimplemented` / 未实现 suffixes from unfinished Home Edit, Folder Compare actions, and Remote profile protocols.
- Keep those controls disabled (grayed out / non-clickable); disable unfinished remote protocol options instead of labeling them.

## Test plan
- [x] HomeView / FolderCompareView / RemoteProfileView unit tests
- [ ] UI smoke on preview after merge
- [ ] README screenshots refresh