### PR TITLE
Fix e2e assertion for disabled remote protocols

### DIFF
--- a/tests/e2e/session-linkage.spec.ts
+++ b/tests/e2e/session-linkage.spec.ts
@@ -210,7 +210,7 @@ test('remote profiles keep unfinished protocols disabled and can test SFTP', asy
   )
   await expect(
     page.locator('[data-testid="remote-profile-protocol-select"] option[value="s3"]'),
-  ).toBeDisabled()
+  ).toHaveJSProperty('disabled', true)
   await page.getByTestId('select-remote-profile-prod-sftp').click()
   await page.getByTestId('test-remote-profile').click()
   await expect


### PR DESCRIPTION
## Summary
- Follow-up to #38: Playwright `toBeDisabled()` on `<option>` failed on CI Windows Chromium.
- Assert `disabled` via `toHaveJSProperty` instead.

## Test plan
- [ ] CI e2e session-linkage remote profiles test