### PR TITLE
Fix Linux/macOS release: gate Windows PS helper

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1714,6 +1714,7 @@ fn resolve_shell_extension_executable(executable_path: Option<String>) -> String
     })
 }
 
+#[cfg(windows)]
 fn apply_windows_powershell_script(script: &str, temp_name: &str) -> Result<(), AppErrorPayload> {
     let temp = std::env::temp_dir().join(temp_name);
     fs::write(&temp, script).map_err(|error| {


### PR DESCRIPTION
## Summary
`apply_windows_powershell_script` is only called under `#[cfg(windows)]`, so Linux/macOS release builds failed with `-D warnings` / dead_code.

## Test plan
- [ ] CI green
- After merge: move `v1.1.2` tag and re-run Release so Linux/macOS assets land