### PR TITLE
Contain UI labels so text cannot spill out of controls

### DIFF
--- a/src/app/dropLaunch.test.ts
+++ b/src/app/dropLaunch.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { createLaunchFromDrop, resolveDropLaunch } from './dropLaunch'
+
+describe('resolveDropLaunch', () => {
+  it('builds a text-compare launch for matching text files', () => {
+    const result = resolveDropLaunch(
+      [
+        { path: 'C:/work/left.txt', kind: 'file' },
+        { path: 'C:/work/right.txt', kind: 'file' },
+      ],
+      { autoRun: true, id: 'drop-1' },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.selection).toMatchObject({
+      sessionType: 'text-compare',
+      route: '/compare/text',
+      enabled: true,
+    })
+    expect(result.payload).toMatchObject({
+      id: 'drop-1',
+      source: 'drop',
+      sessionType: 'text-compare',
+      route: '/compare/text',
+      autoRun: true,
+      title: 'left.txt vs right.txt',
+      locations: {
+        left: { uri: 'C:/work/left.txt', kind: 'file', displayName: 'left.txt' },
+        right: { uri: 'C:/work/right.txt', kind: 'file', displayName: 'right.txt' },
+      },
+    })
+  })
+
+  it('builds a folder-compare launch for two directories', () => {
+    const result = resolveDropLaunch([
+      { path: 'C:/work/left', kind: 'directory' },
+      { path: 'C:/work/right', kind: 'directory' },
+    ])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.selection.sessionType).toBe('folder-compare')
+    expect(result.payload.locations.left?.kind).toBe('directory')
+    expect(result.payload.autoRun).toBe(true)
+  })
+
+  it('builds a text-patch launch for a single patch file without a right location', () => {
+    const result = resolveDropLaunch([{ path: 'C:/work/change.patch', kind: 'file' }])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.selection.sessionType).toBe('text-patch')
+    expect(result.payload.route).toBe('/patch/text')
+    expect(result.payload.locations.left?.uri).toBe('C:/work/change.patch')
+    expect(result.payload.locations.right).toBeUndefined()
+  })
+
+  it('falls back to hex-compare when file types mismatch', () => {
+    const result = resolveDropLaunch([
+      { path: 'C:/work/left.txt', kind: 'file' },
+      { path: 'C:/work/right.png', kind: 'file' },
+    ])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.selection.sessionType).toBe('hex-compare')
+    expect(result.payload.route).toBe('/compare/hex')
+  })
+
+  it('rejects invalid drop counts with a status reason', () => {
+    const result = resolveDropLaunch([{ path: 'C:/work/only.txt', kind: 'file' }])
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'Drop exactly two files or folders.',
+      classification: { kind: 'invalid' },
+    })
+  })
+})
+
+describe('createLaunchFromDrop', () => {
+  it('mirrors HomeView launch payload shape', () => {
+    const classification = {
+      kind: 'files' as const,
+      left: {
+        path: 'C:/a.ts',
+        kind: 'file' as const,
+        sourceKind: 'file' as const,
+        displayName: 'a.ts',
+      },
+      right: {
+        path: 'C:/b.ts',
+        kind: 'file' as const,
+        sourceKind: 'file' as const,
+        displayName: 'b.ts',
+      },
+    }
+    const selection = {
+      sessionType: 'text-compare' as const,
+      title: 'Text Compare',
+      titleKey: 'ui.textCompare',
+      enabled: true,
+      route: '/compare/text',
+    }
+
+    expect(
+      createLaunchFromDrop(classification, selection, { autoRun: false, id: 'fixed' }),
+    ).toEqual({
+      id: 'fixed',
+      source: 'drop',
+      sessionType: 'text-compare',
+      title: 'a.ts vs b.ts',
+      route: '/compare/text',
+      locations: {
+        left: { uri: 'C:/a.ts', displayName: 'a.ts', kind: 'file', readOnly: false },
+        right: { uri: 'C:/b.ts', displayName: 'b.ts', kind: 'file', readOnly: false },
+      },
+      autoRun: false,
+    })
+  })
+})

--- a/src/app/dropLaunch.ts
+++ b/src/app/dropLaunch.ts
@@ -1,0 +1,108 @@
+import {
+  classifyDropInputs,
+  type DropClassification,
+  type DropInput,
+  type ValidDropClassification,
+} from '@/app/dropInput'
+import { resolveDropInputsFromPaths } from '@/app/desktopDrop'
+import { selectSessionForDrop, type SessionSelection } from '@/app/sessionAutoSelect'
+import type { SessionLaunchLocation, SessionLaunchPayload } from '@/types/sessionLaunch'
+
+export interface DropLaunchReady {
+  ok: true
+  classification: ValidDropClassification
+  selection: SessionSelection & { route: string; enabled: true }
+  payload: SessionLaunchPayload
+}
+
+export interface DropLaunchRejected {
+  ok: false
+  reason: string
+  classification: DropClassification
+  selection?: SessionSelection
+}
+
+export type DropLaunchResult = DropLaunchReady | DropLaunchRejected
+
+export interface DropLaunchOptions {
+  autoRun?: boolean
+  id?: string
+}
+
+/** Classify drop inputs, pick a session, and build a launch payload when supported. */
+export function resolveDropLaunch(
+  inputs: DropInput[],
+  options: DropLaunchOptions = {},
+): DropLaunchResult {
+  const classification = classifyDropInputs(inputs)
+
+  if (classification.kind === 'invalid') {
+    return {
+      ok: false,
+      reason: classification.reason,
+      classification,
+    }
+  }
+
+  const selection = selectSessionForDrop(classification)
+
+  if (!selection.enabled || !selection.route) {
+    return {
+      ok: false,
+      reason: `${selection.title} is not available for this drop.`,
+      classification,
+      selection,
+    }
+  }
+
+  const route = selection.route
+
+  return {
+    ok: true,
+    classification,
+    selection: { ...selection, route, enabled: true },
+    payload: createLaunchFromDrop(classification, { ...selection, route }, options),
+  }
+}
+
+/** Resolve absolute desktop paths, then build a drop launch (async classify when Tauri). */
+export async function resolveDropLaunchFromPaths(
+  paths: string[],
+  options: DropLaunchOptions = {},
+): Promise<DropLaunchResult> {
+  const inputs = await resolveDropInputsFromPaths(paths)
+
+  return resolveDropLaunch(inputs, options)
+}
+
+/** Mirror of HomeView createLaunchFromDrop — build SessionLaunchPayload from a valid drop. */
+export function createLaunchFromDrop(
+  classification: ValidDropClassification,
+  selection: SessionSelection & { route: string },
+  options: DropLaunchOptions = {},
+): SessionLaunchPayload {
+  return {
+    id: options.id ?? crypto.randomUUID(),
+    source: 'drop',
+    sessionType: selection.sessionType,
+    title: `${classification.left.displayName} vs ${classification.right.displayName}`,
+    route: selection.route,
+    locations: {
+      left: dropItemToLaunchLocation(classification.left),
+      right:
+        classification.kind === 'patch'
+          ? undefined
+          : dropItemToLaunchLocation(classification.right),
+    },
+    autoRun: options.autoRun ?? true,
+  }
+}
+
+function dropItemToLaunchLocation(item: ValidDropClassification['left']): SessionLaunchLocation {
+  return {
+    uri: item.path,
+    displayName: item.displayName,
+    kind: item.sourceKind,
+    readOnly: false,
+  }
+}

--- a/src/components/session/SavedSessionNode.vue
+++ b/src/components/session/SavedSessionNode.vue
@@ -117,6 +117,13 @@ const emit = defineEmits<{
   color: var(--app-text);
 }
 
+.folder-row strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .session-row {
   color: var(--app-text-muted);
 }

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -6,6 +6,7 @@ import { createAppI18n, installI18n } from '@/i18n'
 import { useSettingsStore } from '@/stores/settings'
 import { useTabsStore } from '@/stores/tabs'
 import { useStatusBarStore } from '@/stores/statusBar'
+import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 
 const push = vi.fn()
 let routePath = '/compare/text'
@@ -20,12 +21,31 @@ vi.mock('vue-router', () => ({
   useRouter: () => ({ push }),
 }))
 
+const desktopDropHandlers: ((paths: string[]) => void | Promise<void>)[] = []
+
+vi.mock('@/app/desktopDrop', () => ({
+  listenDesktopPathDrop: vi.fn((onPaths: (paths: string[]) => void | Promise<void>) => {
+    desktopDropHandlers.push(onPaths)
+
+    return Promise.resolve(() => undefined)
+  }),
+  resolveDropInputsFromPaths: vi.fn((paths: string[]) =>
+    Promise.resolve(
+      paths.map((path) => ({
+        path,
+        kind: path.includes('.') && !path.endsWith('/') ? 'file' : 'directory',
+      })),
+    ),
+  ),
+}))
+
 describe('AppLayout command palette', () => {
   beforeEach(() => {
     localStorage.clear()
     setActivePinia(createPinia())
     routePath = '/compare/text'
     push.mockClear()
+    desktopDropHandlers.length = 0
   })
 
   it('searches and executes navigation commands', async () => {
@@ -224,6 +244,40 @@ describe('AppLayout command palette', () => {
     expect(wrapper.find('[data-testid="status-bar"]').text()).toContain('Differences: 4')
     expect(wrapper.find('[data-testid="status-bar"]').text()).toContain('Encoding: UTF-8 / LF')
     expect(wrapper.find('[data-testid="status-bar"]').text()).toContain('Filter: All rows')
+  })
+
+  it('launches a compare session from a global desktop path drop', async () => {
+    mountAppLayout()
+    const launchStore = useSessionLaunchStore()
+
+    expect(desktopDropHandlers).toHaveLength(1)
+
+    await desktopDropHandlers[0]?.(['C:/work/left.txt', 'C:/work/right.txt'])
+
+    expect(push).toHaveBeenCalledWith('/compare/text')
+    expect(launchStore.pendingLaunch).toMatchObject({
+      source: 'drop',
+      sessionType: 'text-compare',
+      route: '/compare/text',
+      autoRun: true,
+      locations: {
+        left: { uri: 'C:/work/left.txt', kind: 'file' },
+        right: { uri: 'C:/work/right.txt', kind: 'file' },
+      },
+    })
+  })
+
+  it('reports invalid desktop drops on the status bar without navigating', async () => {
+    mountAppLayout()
+    const statusBar = useStatusBarStore()
+    const launchStore = useSessionLaunchStore()
+
+    await desktopDropHandlers[0]?.(['C:/work/only.txt'])
+
+    expect(push).not.toHaveBeenCalled()
+    expect(launchStore.pendingLaunch).toBeUndefined()
+    expect(statusBar.report.comparisonStatus).toBe('Drop exactly two files or folders.')
+    expect(statusBar.report.source).toBe('drop')
   })
 
   it('shows tab context menu actions and closes others', async () => {

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -855,14 +855,18 @@ const sourceSessionTypes = new Set<SessionType>([
 }
 
 .menu-panel button {
+  min-width: 0;
   min-height: 28px;
   padding: 0 8px;
+  overflow: hidden;
   border: 0;
   border-radius: 4px;
   background: transparent;
   color: var(--app-text);
   font-size: 12px;
   text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   cursor: pointer;
 }
 
@@ -882,13 +886,17 @@ const sourceSessionTypes = new Set<SessionType>([
   align-items: center;
   gap: 7px;
   min-width: 0;
+  max-width: 100%;
   height: 40px;
   padding: 0 12px;
+  overflow: hidden;
   border: 0;
   background: #eef2f8;
   color: #111827;
   font-size: 20px;
   font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   cursor: pointer;
 }
 
@@ -898,8 +906,10 @@ const sourceSessionTypes = new Set<SessionType>([
   grid-row: 2;
   align-items: center;
   gap: 12px;
+  min-width: 0;
   height: 38px;
   padding: 0 10px;
+  overflow: auto hidden;
   border-top: 1px solid #e7e9ed;
   background: #ffffff;
 }
@@ -1029,8 +1039,11 @@ const sourceSessionTypes = new Set<SessionType>([
 }
 
 .sidebar-head span {
+  overflow: hidden;
   color: var(--app-text-muted);
   font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .session-search {
@@ -1290,7 +1303,7 @@ const sourceSessionTypes = new Set<SessionType>([
 
 .status-bar {
   display: grid;
-  grid-template-columns: 1fr auto auto auto;
+  grid-template-columns: minmax(0, 1fr) auto auto auto;
   align-items: center;
   gap: 18px;
   min-width: 0;
@@ -1303,6 +1316,7 @@ const sourceSessionTypes = new Set<SessionType>([
 }
 
 .status-bar span {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1373,6 +1387,10 @@ const sourceSessionTypes = new Set<SessionType>([
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .command-item:hover {
@@ -1385,6 +1403,7 @@ const sourceSessionTypes = new Set<SessionType>([
 }
 
 .command-item small {
+  flex: 0 0 auto;
   color: var(--app-text-muted);
   font-size: 11px;
 }

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRoute, useRouter, RouterView } from 'vue-router'
 import {
   ArrowDown,
@@ -34,6 +34,8 @@ import {
 } from '@lucide/vue'
 import { commandRegistry, filterCommands } from '@/app/commandRegistry'
 import { createCommandExecutor, getCommandsForPlacement } from '@/app/commandSystem'
+import { listenDesktopPathDrop } from '@/app/desktopDrop'
+import { resolveDropLaunchFromPaths } from '@/app/dropLaunch'
 import { sessionCatalog } from '@/app/sessionCatalog'
 import { useI18n } from '@/i18n'
 import { usePolicyStore } from '@/stores/policy'
@@ -77,6 +79,8 @@ const tabs = useTabsStore()
 const sessionLaunch = useSessionLaunchStore()
 const savedSessions = useSavedSessionsStore()
 
+let stopDesktopDrop: (() => void) | undefined
+
 onMounted(() => {
   void (async () => {
     try {
@@ -108,6 +112,34 @@ onMounted(() => {
       // ponytail: ignore missing shell launch outside Windows Explorer flow
     }
   })()
+
+  void listenDesktopPathDrop(async (paths) => {
+    const result = await resolveDropLaunchFromPaths(paths, { autoRun: true })
+
+    if (!result.ok) {
+      statusBar.reportStatus({
+        comparisonStatus: result.reason,
+        source: 'drop',
+      })
+
+      return
+    }
+
+    sessionLaunch.setPendingLaunch(result.payload)
+    tabs.openTab({
+      title: result.selection.title,
+      titleKey: result.selection.titleKey,
+      route: result.selection.route,
+      dirty: false,
+    })
+    void router.push(result.selection.route)
+  }).then((stop) => {
+    stopDesktopDrop = stop
+  })
+})
+
+onUnmounted(() => {
+  stopDesktopDrop?.()
 })
 
 const commandPaletteOpen = ref(false)

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -396,7 +396,7 @@ select {
 
 .bc-path-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 42px minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto auto minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 6px;
   min-height: 40px;
@@ -415,18 +415,26 @@ select {
   border-radius: 2px;
   background: #ffffff;
   color: #111111;
-  font-size: 20px;
+  font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .bc-path-row button {
+  box-sizing: border-box;
+  width: auto;
+  min-width: max-content;
+  max-width: none;
   height: 34px;
+  padding: 0 10px;
+  overflow: visible;
   border: 1px solid #bfc4cc;
   border-radius: 2px;
   background: #ffffff;
   color: #111111;
-  font-size: 18px;
+  font-size: 12px;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .workbench-inspector-stack {
@@ -594,6 +602,31 @@ select {
   gap: 6px !important;
   min-width: 0 !important;
   overflow: visible !important;
+}
+
+.folder-toolbar .folder-criteria {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+  gap: 8px 14px !important;
+  min-width: 0 !important;
+  overflow: visible !important;
+}
+
+.folder-toolbar .folder-criteria label {
+  display: inline-flex !important;
+  flex: 0 1 auto !important;
+  align-items: center !important;
+  gap: 6px !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+  white-space: normal !important;
+}
+
+.folder-toolbar .folder-criteria label span {
+  min-width: 0 !important;
+  overflow-wrap: anywhere !important;
+  white-space: normal !important;
 }
 
 .folder-root-summary,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -209,10 +209,10 @@ select {
   flex: 0 0 auto;
   width: auto;
   min-width: 72px;
-  max-width: none;
+  max-width: 120px;
   height: 66px;
   padding: 3px 8px 4px;
-  overflow: visible;
+  overflow: hidden;
   border: 0;
   border-right: 1px solid #c9cdd3;
   background: transparent;
@@ -226,8 +226,10 @@ select {
 .bc-toolbar-command > span,
 .bc-toolbar-command > label {
   display: block;
-  max-width: none;
-  overflow: visible;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -308,25 +310,29 @@ select {
   box-sizing: border-box;
   width: auto;
   min-width: 0;
-  max-width: none;
+  max-width: 12em;
   height: auto;
   min-height: 24px;
   padding: 4px 10px;
-  overflow: visible;
+  overflow: hidden;
   border: 1px solid transparent;
   border-radius: 2px;
   background: transparent;
   color: var(--app-text);
   font-size: 12px;
   line-height: 1.2;
+  text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
 }
 
 .workbench-toolbar button > span,
 .path-pair-bar button > span {
-  display: inline;
-  overflow: visible;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -361,7 +367,7 @@ select {
 
 .path-pair-field {
   display: grid;
-  grid-template-columns: auto 14px minmax(0, 1fr);
+  grid-template-columns: auto 14px minmax(0, 1fr) auto;
   align-items: center;
   gap: 6px;
   min-width: 0;
@@ -404,11 +410,14 @@ select {
   min-width: 0;
   height: 30px;
   padding: 0 8px;
+  overflow: hidden;
   border: 1px solid #bfc4cc;
   border-radius: 2px;
   background: #ffffff;
   color: #111111;
   font-size: 20px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .bc-path-row button {
@@ -824,7 +833,23 @@ select {
 /* P3 path UX + a11y lite */
 .bc-path-row input.path-input,
 .path-pair-field input,
-.path-field-row input {
+.path-field-row input,
+.hex-wrap-controls input[type='text'],
+.hex-wrap-controls input:not([type]),
+.folder-toolbar .path-pair input,
+.path-pair input,
+.output-path-input {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hex-wrap-controls label {
+  min-width: 0;
+}
+
+.hex-wrap-controls strong {
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -2111,6 +2111,7 @@ onUnmounted(() => {
 
 .path-pair input {
   width: 100%;
+  min-width: 0;
   height: 32px;
   padding: 0 9px;
   overflow: hidden;
@@ -2119,6 +2120,7 @@ onUnmounted(() => {
   background: var(--app-surface);
   color: var(--app-text);
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .folder-actions {
@@ -2222,17 +2224,27 @@ onUnmounted(() => {
 
 .folder-summary {
   display: grid;
-  grid-template-columns: repeat(3, 110px);
+  grid-template-columns: repeat(3, minmax(0, 110px));
   gap: 8px;
 }
 
 .folder-summary div {
   display: grid;
   gap: 2px;
+  min-width: 0;
   padding: 9px 10px;
+  overflow: hidden;
   border: 1px solid var(--app-border);
   border-radius: 8px;
   background: var(--app-surface);
+}
+
+.folder-summary strong,
+.folder-summary span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .folder-summary strong {

--- a/src/views/HexCompareView.vue
+++ b/src/views/HexCompareView.vue
@@ -255,6 +255,7 @@ async function runHexSave(): Promise<void> {
             v-model="leftPath"
             type="text"
             data-testid="hex-left-path"
+            :title="leftPath"
           />
         </label>
         <label>
@@ -263,6 +264,7 @@ async function runHexSave(): Promise<void> {
             v-model="rightPath"
             type="text"
             data-testid="hex-right-path"
+            :title="rightPath"
           />
         </label>
         <label>
@@ -600,9 +602,10 @@ h2 {
 
 .hex-wrap-controls {
   display: grid;
-  grid-template-columns: minmax(180px, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: end;
   gap: 10px;
+  min-width: 0;
   padding: 10px;
   border: 1px solid var(--app-border);
   border-radius: 8px;
@@ -612,6 +615,7 @@ h2 {
 .hex-wrap-controls label {
   display: grid;
   gap: 5px;
+  min-width: 0;
 }
 
 .hex-wrap-controls span {
@@ -621,16 +625,21 @@ h2 {
 
 .hex-wrap-controls input {
   width: 100%;
+  min-width: 0;
 }
 
 .hex-wrap-controls strong {
-  min-width: 102px;
+  min-width: 0;
+  max-width: 100%;
   padding: 7px 9px;
+  overflow: hidden;
   border: 1px solid var(--app-border);
   border-radius: 6px;
   background: var(--app-bg);
   font-size: 12px;
   text-align: center;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .hex-pane-grid {

--- a/src/views/HomeView.test.ts
+++ b/src/views/HomeView.test.ts
@@ -133,6 +133,45 @@ describe('HomeView', () => {
     expect(push).toHaveBeenCalledWith('/merge/text')
   })
 
+  it('auto-opens the suggested view when files are dropped on the HTML drop zone', async () => {
+    const wrapper = mountHomeView()
+    const launchStore = useSessionLaunchStore()
+    const dropZone = wrapper.find('.quick-input-zone')
+
+    const left = { name: 'left.txt', webkitRelativePath: '' }
+    const right = { name: 'right.txt', webkitRelativePath: '' }
+    const fileList = [left, right]
+    const files = {
+      0: left,
+      1: right,
+      length: 2,
+      item: (index: number) => fileList[index] ?? null,
+      *[Symbol.iterator]() {
+        yield left
+        yield right
+      },
+    }
+
+    await dropZone.trigger('drop', {
+      dataTransfer: {
+        files,
+        items: [],
+      },
+    })
+
+    expect(push).toHaveBeenCalledWith('/compare/text')
+    expect(launchStore.pendingLaunch).toMatchObject({
+      source: 'drop',
+      sessionType: 'text-compare',
+      route: '/compare/text',
+      autoRun: true,
+      locations: {
+        left: { uri: 'left.txt', kind: 'file' },
+        right: { uri: 'right.txt', kind: 'file' },
+      },
+    })
+  })
+
   it('opens the suggested view with dropped file paths as a launch payload', async () => {
     const wrapper = mountHomeView()
     const launchStore = useSessionLaunchStore()

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   Binary,
@@ -23,7 +23,7 @@ import {
 import { readClipboardTextSource } from '@/app/clipboardSource'
 import { pickNativePath } from '@/app/filePicker'
 import { classifyDropInputs } from '@/app/dropInput'
-import { listenDesktopPathDrop, resolveDropInputsFromPaths } from '@/app/desktopDrop'
+import { createLaunchFromDrop } from '@/app/dropLaunch'
 import { filterSavedSessions } from '@/app/savedSessions'
 import { selectSessionForDrop } from '@/app/sessionAutoSelect'
 import { sessionCatalog } from '@/app/sessionCatalog'
@@ -38,7 +38,7 @@ import { useSavedSessionsStore } from '@/stores/savedSessions'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
 import { useWorkspacesStore } from '@/stores/workspaces'
-import type { ClassifiedDropItem, DropClassification, DropInput } from '@/app/dropInput'
+import type { DropClassification, DropInput } from '@/app/dropInput'
 import type { SessionSelection } from '@/app/sessionAutoSelect'
 import type { SessionCatalogEntry } from '@/app/sessionCatalog'
 import type { SessionDocument, SessionType } from '@/types/session'
@@ -158,26 +158,6 @@ const historyItems = computed(() =>
   })),
 )
 
-let stopDesktopDrop: (() => void) | undefined
-
-onMounted(() => {
-  void listenDesktopPathDrop(async (paths) => {
-    isDragging.value = false
-
-    const inputs = await resolveDropInputsFromPaths(paths)
-
-    setDropInputs(inputs)
-    // ponytail: auto-run when paths ready
-    openSelectedDropSession()
-  }).then((stop) => {
-    stopDesktopDrop = stop
-  })
-})
-
-onUnmounted(() => {
-  stopDesktopDrop?.()
-})
-
 function openSession(entry: SessionCatalogEntry): void {
   if (!entry.implemented || !entry.route) {
     return
@@ -235,6 +215,8 @@ function handleDrop(event: DragEvent): void {
   event.preventDefault()
   isDragging.value = false
   setDropInputs(inputsFromDataTransfer(event.dataTransfer))
+  // ponytail: HTML drop zone also auto-opens when the drop is valid
+  openSelectedDropSession()
 }
 
 function setDropInputs(inputs: DropInput[]): void {
@@ -267,7 +249,7 @@ function openSelectedDropSession(): void {
     return
   }
 
-  sessionLaunch.setPendingLaunch(createLaunchFromDrop(selectedDropSession.value))
+  sessionLaunch.setPendingLaunch(buildDropLaunchPayload(selectedDropSession.value))
   tabs.openTab({
     title: selectedDropSession.value.title,
     titleKey: selectedDropSession.value.titleKey,
@@ -277,26 +259,18 @@ function openSelectedDropSession(): void {
   void router.push(selectedDropSession.value.route)
 }
 
-function createLaunchFromDrop(selection: SessionSelection): SessionLaunchPayload {
+function buildDropLaunchPayload(selection: SessionSelection): SessionLaunchPayload {
   if (dropResult.value.kind === 'invalid' || !selection.route) {
     throw new Error('Cannot create a launch payload from an invalid drop.')
   }
 
-  return {
-    id: crypto.randomUUID(),
-    source: 'drop',
-    sessionType: selection.sessionType,
-    title: `${dropResult.value.left.displayName} vs ${dropResult.value.right.displayName}`,
-    route: selection.route,
-    locations: {
-      left: dropItemToLaunchLocation(dropResult.value.left),
-      right:
-        dropResult.value.kind === 'patch'
-          ? undefined
-          : dropItemToLaunchLocation(dropResult.value.right),
+  return createLaunchFromDrop(
+    dropResult.value,
+    { ...selection, route: selection.route },
+    {
+      autoRun: true,
     },
-    autoRun: true,
-  }
+  )
 }
 
 async function openClipboardText(): Promise<void> {
@@ -340,15 +314,6 @@ function simulateTextDrop(): void {
 
 function simulatePatchDrop(): void {
   setDropInputs([{ path: 'C:/work/change.patch', kind: 'file' }])
-}
-
-function dropItemToLaunchLocation(item: ClassifiedDropItem): SessionLaunchLocation {
-  return {
-    uri: item.path,
-    displayName: item.displayName,
-    kind: item.sourceKind,
-    readOnly: false,
-  }
 }
 
 function sessionLocationToLaunchLocation(

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -648,9 +648,15 @@ function openSelectedPreview(): void {
           <div class="bc-selected-title">
             <FolderOpen :size="27" />
             <div>
-              <strong>{{ selectedSessionPreview.name }}</strong>
-              <span>{{ selectedSessionPreview.leftPath }}</span>
-              <span>{{ selectedSessionPreview.rightPath }}</span>
+              <strong :title="selectedSessionPreview.name">{{
+                selectedSessionPreview.name
+              }}</strong>
+              <span :title="selectedSessionPreview.leftPath">{{
+                selectedSessionPreview.leftPath
+              }}</span>
+              <span :title="selectedSessionPreview.rightPath">{{
+                selectedSessionPreview.rightPath
+              }}</span>
             </div>
           </div>
           <div class="bc-selected-actions">
@@ -774,9 +780,14 @@ function openSelectedPreview(): void {
               class="recovery-entry"
               data-testid="recovery-entry"
             >
-              <span>{{
-                $t('ui.recoverSession', { name: savedSessions.recoveryCandidates[0]?.name ?? '' })
-              }}</span>
+              <span
+                :title="
+                  $t('ui.recoverSession', { name: savedSessions.recoveryCandidates[0]?.name ?? '' })
+                "
+                >{{
+                  $t('ui.recoverSession', { name: savedSessions.recoveryCandidates[0]?.name ?? '' })
+                }}</span
+              >
               <button
                 type="button"
                 data-testid="restore-recovery"
@@ -1034,12 +1045,16 @@ function openSelectedPreview(): void {
 .bc-session-tree header {
   display: flex;
   align-items: center;
+  min-width: 0;
   padding: 0 18px;
+  overflow: hidden;
   border-bottom: 1px solid #c6ccd5;
   background: #eef1f5;
   color: #111827;
   font-size: 23px;
   line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .bc-tree-list {
@@ -1110,12 +1125,16 @@ function openSelectedPreview(): void {
 
 .bc-tree-footer input {
   width: 100%;
+  min-width: 0;
   height: 38px;
   padding: 0 10px;
+  overflow: hidden;
   border: 1px solid #c6ccd5;
   border-radius: 3px;
   background: #ffffff;
   color: #111827;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .bc-home-main {
@@ -1137,6 +1156,7 @@ function openSelectedPreview(): void {
   display: flex;
   align-items: flex-start;
   gap: 14px;
+  min-width: 0;
   color: #111827;
   font-size: 25px;
 }
@@ -1144,6 +1164,15 @@ function openSelectedPreview(): void {
 .bc-selected-title div {
   display: grid;
   gap: 12px;
+  min-width: 0;
+}
+
+.bc-selected-title strong,
+.bc-selected-title span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .bc-selected-title strong {
@@ -1163,12 +1192,16 @@ function openSelectedPreview(): void {
 
 .bc-selected-actions button {
   width: 154px;
+  max-width: 100%;
   height: 47px;
+  overflow: hidden;
   border: 1px solid #c7cdd6;
   border-radius: 3px;
   background: #ffffff;
   color: #111827;
   font-size: 22px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   cursor: pointer;
 }
 
@@ -1409,11 +1442,21 @@ tr:hover .row-actions,
   align-items: center;
   justify-content: space-between;
   gap: 10px;
+  min-width: 0;
   padding: 8px 10px;
   border: 1px solid var(--app-primary);
   border-radius: 4px;
   background: var(--app-primary-soft);
   font-size: 12px;
+}
+
+.recovery-entry > span,
+.save-prompt > span,
+.save-prompt > p {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .recovery-entry button,
@@ -1511,14 +1554,18 @@ tr:hover .row-actions,
 
 .home-primary-cta {
   min-width: 140px;
+  max-width: 100%;
   height: 40px;
   padding: 0 16px;
+  overflow: hidden;
   border: 1px solid #4aa3ff;
   border-radius: 4px;
   background: #c8e4ff;
   color: #111827;
   font-size: 16px;
+  white-space: nowrap;
   cursor: pointer;
+  text-overflow: ellipsis;
 }
 
 .home-primary-cta:focus-visible,
@@ -1531,12 +1578,16 @@ tr:hover .row-actions,
 .home-drop-cta {
   display: inline-flex;
   align-items: center;
+  max-width: 100%;
   min-height: 40px;
   padding: 0 14px;
+  overflow: hidden;
   border: 1px dashed #9aa3af;
   border-radius: 4px;
   color: #4b5563;
   font-size: 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media (width <= 900px) {

--- a/src/views/PictureCompareView.vue
+++ b/src/views/PictureCompareView.vue
@@ -731,20 +731,25 @@ h2 {
 
 .picture-pixel-preview {
   display: grid;
-  grid-template-columns: auto auto 18px auto;
+  grid-template-columns: minmax(0, auto) minmax(0, auto) 18px minmax(0, 1fr);
   align-items: center;
   align-content: end;
   gap: 8px;
+  min-width: 0;
   min-height: 32px;
   padding: 0 8px;
+  overflow: hidden;
   border: 1px solid var(--app-border);
   border-radius: 6px;
   background: var(--app-bg);
 }
 
 .picture-pixel-preview strong {
+  min-width: 0;
+  overflow: hidden;
   font-size: 12px;
   font-weight: 700;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -627,16 +627,27 @@ h1 {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  min-width: 0;
 }
 
 .settings-row div {
   display: grid;
   gap: 4px;
+  min-width: 0;
+}
+
+.settings-row strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-row span {
+  min-width: 0;
   color: var(--app-text-muted);
   font-size: 12px;
+  overflow-wrap: anywhere;
 }
 
 .locale-select {

--- a/src/views/TableCompareView.vue
+++ b/src/views/TableCompareView.vue
@@ -1020,8 +1020,12 @@ h2 {
 .table-column-rule strong,
 .table-column-rule small {
   grid-column: 2;
+  min-width: 0;
+  overflow: hidden;
   color: var(--app-text-muted);
   line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .table-column-rule small {

--- a/src/views/TextCompareView.vue
+++ b/src/views/TextCompareView.vue
@@ -1161,16 +1161,17 @@ function toggleSourceEditors(): void {
 .toolbar-button {
   flex: 0 0 auto;
   width: auto;
-  max-width: none;
+  max-width: 12em;
   height: 28px;
   padding: 0 10px;
-  overflow: visible;
+  overflow: hidden;
   border: 1px solid var(--app-border);
   border-radius: 4px;
   background: var(--app-canvas);
   color: var(--app-text);
   font-size: 12px;
   line-height: 1.2;
+  text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
 }

--- a/src/views/TextMergeView.vue
+++ b/src/views/TextMergeView.vue
@@ -226,6 +226,7 @@ function lineClass(line: string, paneId: MergePaneId): string {
           v-model="leftPath"
           class="output-path-input"
           data-testid="merge-left-path"
+          :title="leftPath"
           type="text"
           :aria-label="$t('ui.leftPath')"
         />
@@ -233,6 +234,7 @@ function lineClass(line: string, paneId: MergePaneId): string {
           v-model="centerPath"
           class="output-path-input"
           data-testid="merge-center-path"
+          :title="centerPath"
           type="text"
           :aria-label="$t('ui.base')"
         />
@@ -240,6 +242,7 @@ function lineClass(line: string, paneId: MergePaneId): string {
           v-model="rightPath"
           class="output-path-input"
           data-testid="merge-right-path"
+          :title="rightPath"
           type="text"
           :aria-label="$t('ui.rightPath')"
         />
@@ -247,6 +250,7 @@ function lineClass(line: string, paneId: MergePaneId): string {
           v-model="outputPath"
           class="output-path-input"
           data-testid="merge-output-path"
+          :title="outputPath"
           type="text"
           :aria-label="$t('ui.mergeOutputPath')"
         />
@@ -431,22 +435,30 @@ function lineClass(line: string, paneId: MergePaneId): string {
 }
 
 .status-chip {
+  max-width: min(280px, 100%);
   padding: 3px 7px;
+  overflow: hidden;
   border: 1px solid var(--app-border);
   border-radius: 6px;
   background: var(--app-surface);
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .output-path-input {
   width: 220px;
+  min-width: 0;
+  max-width: 100%;
   height: 28px;
   padding: 0 8px;
+  overflow: hidden;
   border: 1px solid var(--app-border);
   border-radius: 6px;
   background: var(--app-surface);
   color: var(--app-text);
   font-size: 12px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .toolbar-button {


### PR DESCRIPTION
## Summary
- Toolbar / path-bar / menu / status / home cards: ellipsis + `min-width: 0` so labels stay inside their boxes
- Path inputs get ellipsis (+ titles where missing)
- PathPairBar Browse column grid fixed (4 columns)

## Test plan
- [x] Related vitest subset
- [ ] CI green
- [ ] Spot-check Home / Folder / Text / Hex / Settings at narrow width