### PR TITLE
Fix Folder Compare narrow toolbar overlap

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1794,12 +1794,12 @@ pub fn register_unix_shell_integration(
     {
         let script = shell_core::LinuxDesktopIntegrationBuilder::new(config).install_script();
         apply_unix_shell_script(&script, "open-diff-register-unix-shell.sh")?;
-        return Ok(ShellRegistrationResult {
+        Ok(ShellRegistrationResult {
             windows: false,
             applied: true,
             script,
             message: "Linux Open With / shell-compare desktop entry installed".to_owned(),
-        });
+        })
     }
 
     #[cfg(target_os = "macos")]
@@ -1837,12 +1837,12 @@ pub fn unregister_unix_shell_integration(
     {
         let script = shell_core::LinuxDesktopIntegrationBuilder::new(config).uninstall_script();
         apply_unix_shell_script(&script, "open-diff-unregister-unix-shell.sh")?;
-        return Ok(ShellRegistrationResult {
+        Ok(ShellRegistrationResult {
             windows: false,
             applied: true,
             script,
             message: "Linux Open With / shell-compare desktop entry removed".to_owned(),
-        });
+        })
     }
 
     #[cfg(target_os = "macos")]

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -597,8 +597,8 @@ select {
 }
 
 .folder-toolbar .folder-actions {
-  display: flex !important;
   position: static !important;
+  display: flex !important;
   grid-column: 1 !important;
   grid-row: auto !important;
   flex-wrap: wrap !important;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -559,14 +559,25 @@ select {
   overflow: visible !important;
 }
 
+.folder-toolbar .path-pair,
+.folder-toolbar .archive-path-hint,
+.folder-toolbar .folder-criteria,
+.folder-toolbar .folder-actions {
+  position: static !important;
+  grid-column: 1 !important;
+  grid-row: auto !important;
+  width: 100% !important;
+  min-width: 0 !important;
+  margin: 0 !important;
+  overflow: visible !important;
+}
+
 .folder-toolbar .path-pair {
   display: grid !important;
   grid-template-columns: minmax(140px, 1fr) minmax(140px, 1fr) !important;
   grid-auto-rows: auto !important;
   gap: 8px !important;
-  min-width: 0 !important;
   min-height: 0 !important;
-  overflow: visible !important;
 }
 
 .folder-toolbar .path-pair > label {
@@ -584,29 +595,47 @@ select {
   line-height: 1.2 !important;
 }
 
-.folder-toolbar .path-pair > label > input {
+.folder-toolbar .path-pair .path-field-row {
+  display: flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  width: 100% !important;
+  min-width: 0 !important;
+}
+
+.folder-toolbar .path-pair .path-field-row > input,
+.folder-toolbar .path-pair .path-field-row > .path-input {
   display: block !important;
   box-sizing: border-box !important;
-  width: 100% !important;
+  flex: 1 1 auto !important;
+  width: auto !important;
   min-width: 0 !important;
   height: 30px !important;
   min-height: 30px !important;
   padding: 0 8px !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
   pointer-events: auto !important;
   opacity: 1 !important;
 }
 
+.folder-toolbar .path-pair .path-field-row > button {
+  flex: 0 0 auto !important;
+  white-space: nowrap !important;
+}
+
+.folder-toolbar .archive-path-hint {
+  display: block !important;
+  color: #555555 !important;
+  font-size: 11px !important;
+  line-height: 1.35 !important;
+}
+
 .folder-toolbar .folder-actions {
-  position: static !important;
   display: flex !important;
-  grid-column: 1 !important;
-  grid-row: auto !important;
   flex-wrap: wrap !important;
   gap: 6px !important;
-  width: 100% !important;
-  min-width: 0 !important;
-  margin: 0 !important;
-  overflow: visible !important;
 }
 
 .folder-toolbar .folder-criteria {
@@ -614,8 +643,16 @@ select {
   flex-wrap: wrap !important;
   align-items: center !important;
   gap: 8px 14px !important;
-  min-width: 0 !important;
-  overflow: visible !important;
+}
+
+.folder-toolbar .folder-criteria legend {
+  display: block !important;
+  float: none !important;
+  width: 100% !important;
+  margin: 0 0 6px !important;
+  padding: 0 !important;
+  color: #111111 !important;
+  font-weight: 600 !important;
 }
 
 .folder-toolbar .folder-criteria label {
@@ -632,6 +669,12 @@ select {
   min-width: 0 !important;
   overflow-wrap: anywhere !important;
   white-space: normal !important;
+}
+
+@media (width <= 1100px) {
+  .folder-toolbar .path-pair {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
 }
 
 .folder-root-summary,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -550,9 +550,10 @@ select {
 .folder-toolbar {
   display: grid !important;
   grid-template-columns: minmax(0, 1fr) !important;
-  grid-template-rows: auto auto !important;
+  grid-auto-flow: row !important;
+  grid-auto-rows: auto !important;
   align-items: stretch !important;
-  gap: 8px !important;
+  gap: 10px !important;
   min-height: 0 !important;
   padding: 8px 10px !important;
   overflow: visible !important;
@@ -597,10 +598,14 @@ select {
 
 .folder-toolbar .folder-actions {
   display: flex !important;
+  position: static !important;
+  grid-column: 1 !important;
   grid-row: auto !important;
   flex-wrap: wrap !important;
   gap: 6px !important;
+  width: 100% !important;
   min-width: 0 !important;
+  margin: 0 !important;
   overflow: visible !important;
 }
 

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -1206,13 +1206,13 @@ onUnmounted(() => {
               </button>
             </div>
           </label>
-          <p
-            class="archive-path-hint"
-            data-testid="folder-path-hint"
-          >
-            {{ $t('ui.archivePathHint') }}
-          </p>
         </div>
+        <p
+          class="archive-path-hint"
+          data-testid="folder-path-hint"
+        >
+          {{ $t('ui.archivePathHint') }}
+        </p>
         <fieldset
           class="folder-criteria"
           data-testid="folder-criteria"
@@ -2058,6 +2058,18 @@ onUnmounted(() => {
   grid-template-columns: minmax(0, 1fr);
   align-items: stretch;
   gap: 10px;
+  overflow: visible;
+}
+
+.path-pair,
+.archive-path-hint,
+.folder-criteria,
+.folder-actions {
+  position: static;
+  grid-column: 1;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
 }
 
 .path-pair {
@@ -2078,10 +2090,9 @@ onUnmounted(() => {
 }
 
 .archive-path-hint {
-  grid-column: 1 / -1;
-  margin: 0;
   color: var(--app-text-muted);
   font-size: 12px;
+  line-height: 1.35;
 }
 
 .folder-criteria {
@@ -2089,7 +2100,6 @@ onUnmounted(() => {
   flex-wrap: wrap;
   align-items: center;
   gap: 8px 14px;
-  margin: 0;
   padding: 0;
   border: 0;
   color: var(--app-text-muted);
@@ -2097,6 +2107,10 @@ onUnmounted(() => {
 }
 
 .folder-criteria legend {
+  display: block;
+  float: none;
+  width: 100%;
+  margin: 0 0 6px;
   padding: 0;
   color: var(--app-text);
   font-weight: 600;
@@ -2126,7 +2140,6 @@ onUnmounted(() => {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  min-width: 0;
 }
 
 .folder-root-summary {
@@ -2500,6 +2513,12 @@ onUnmounted(() => {
 .status-left-only strong,
 .status-right-only strong {
   color: var(--diff-deleted-fg);
+}
+
+@media (width <= 1100px) {
+  .path-pair {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 @media (width <= 760px) {

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -1212,45 +1212,45 @@ onUnmounted(() => {
           >
             {{ $t('ui.archivePathHint') }}
           </p>
-          <fieldset
-            class="folder-criteria"
-            data-testid="folder-criteria"
-          >
-            <legend>{{ $t('ui.folderCriteria') }}</legend>
-            <label>
-              <input
-                v-model="folderCriteria.compareSize"
-                data-testid="folder-criteria-size"
-                type="checkbox"
-              />
-              <span>{{ $t('ui.compareBySize') }}</span>
-            </label>
-            <label>
-              <input
-                v-model="folderCriteria.compareModifiedTime"
-                data-testid="folder-criteria-timestamp"
-                type="checkbox"
-              />
-              <span>{{ $t('ui.compareByTimestamp') }}</span>
-            </label>
-            <label>
-              <input
-                v-model="folderCriteria.compareContents"
-                data-testid="folder-criteria-contents"
-                type="checkbox"
-              />
-              <span>{{ $t('ui.compareBinaryContents') }}</span>
-            </label>
-            <label>
-              <input
-                v-model="folderCriteria.compareCrc"
-                data-testid="folder-criteria-crc"
-                type="checkbox"
-              />
-              <span>{{ $t('ui.compareCrc') }}</span>
-            </label>
-          </fieldset>
         </div>
+        <fieldset
+          class="folder-criteria"
+          data-testid="folder-criteria"
+        >
+          <legend>{{ $t('ui.folderCriteria') }}</legend>
+          <label>
+            <input
+              v-model="folderCriteria.compareSize"
+              data-testid="folder-criteria-size"
+              type="checkbox"
+            />
+            <span>{{ $t('ui.compareBySize') }}</span>
+          </label>
+          <label>
+            <input
+              v-model="folderCriteria.compareModifiedTime"
+              data-testid="folder-criteria-timestamp"
+              type="checkbox"
+            />
+            <span>{{ $t('ui.compareByTimestamp') }}</span>
+          </label>
+          <label>
+            <input
+              v-model="folderCriteria.compareContents"
+              data-testid="folder-criteria-contents"
+              type="checkbox"
+            />
+            <span>{{ $t('ui.compareBinaryContents') }}</span>
+          </label>
+          <label>
+            <input
+              v-model="folderCriteria.compareCrc"
+              data-testid="folder-criteria-crc"
+              type="checkbox"
+            />
+            <span>{{ $t('ui.compareCrc') }}</span>
+          </label>
+        </fieldset>
         <div class="folder-actions">
           <NButton
             size="small"
@@ -2055,9 +2055,9 @@ onUnmounted(() => {
 
 .folder-toolbar {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: end;
-  gap: 12px;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: stretch;
+  gap: 10px;
 }
 
 .path-pair {
@@ -2086,7 +2086,6 @@ onUnmounted(() => {
 
 .folder-criteria {
   display: flex;
-  grid-column: 1 / -1;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px 14px;
@@ -2125,7 +2124,9 @@ onUnmounted(() => {
 
 .folder-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+  min-width: 0;
 }
 
 .folder-root-summary {


### PR DESCRIPTION
## Summary
Smoke at ~990px showed folder criteria labels overlapping action buttons. Criteria is now a sibling above actions; toolbar stacks in one column with wrapping buttons.

## Test plan
- [x] FolderCompareView vitest
- [ ] CI green
- [ ] Local narrow-window smoke after install