### PR TITLE
Fix Linux desktop drag-and-drop auto-open compare

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default capability for the main OpenDiff window (core events needed for desktop drag-drop).",
+  "windows": ["main"],
+  "permissions": ["core:default"]
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,12 +12,14 @@
   "app": {
     "windows": [
       {
+        "label": "main",
         "title": "OpenDiff",
         "width": 1280,
         "height": 820,
         "minWidth": 980,
         "minHeight": 640,
-        "resizable": true
+        "resizable": true,
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/src/app/desktopDrop.test.ts
+++ b/src/app/desktopDrop.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { isTauriRuntime, listenDesktopPathDrop, resolveDropInputsFromPaths } from './desktopDrop'
+
+describe('desktopDrop', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    Reflect.deleteProperty(window, '__TAURI_INTERNALS__')
+  })
+
+  it('detects non-Tauri runtimes', () => {
+    expect(isTauriRuntime()).toBe(false)
+  })
+
+  it('returns a no-op unlisten outside Tauri', async () => {
+    const onPaths = vi.fn()
+    const stop = await listenDesktopPathDrop(onPaths)
+
+    expect(typeof stop).toBe('function')
+    stop()
+    expect(onPaths).not.toHaveBeenCalled()
+  })
+
+  it('falls back to path heuristics when classify_paths is unavailable', async () => {
+    const inputs = await resolveDropInputsFromPaths(['/tmp/left.txt', '/tmp/right.txt'])
+
+    expect(inputs).toEqual([
+      { path: '/tmp/left.txt', kind: 'file' },
+      { path: '/tmp/right.txt', kind: 'file' },
+    ])
+  })
+})

--- a/src/app/desktopDrop.ts
+++ b/src/app/desktopDrop.ts
@@ -35,6 +35,11 @@ export async function resolveDropInputsFromPaths(paths: string[]): Promise<DropI
   return dropInputsFromAbsolutePaths(cleaned)
 }
 
+/**
+ * Listen for OS file/folder drops with absolute paths (Tauri native drag-drop).
+ * Requires `dragDropEnabled: true` on the window and `core:default` capability
+ * so `onDragDropEvent` can register event listeners.
+ */
 export async function listenDesktopPathDrop(
   onPaths: (paths: string[]) => void | Promise<void>,
 ): Promise<() => void> {
@@ -53,7 +58,9 @@ export async function listenDesktopPathDrop(
     })
 
     return unlisten
-  } catch {
+  } catch (error) {
+    console.warn('[OpenDiff] desktop path drop listener unavailable', error)
+
     return () => undefined
   }
 }

--- a/src/app/packagingConfig.test.ts
+++ b/src/app/packagingConfig.test.ts
@@ -5,6 +5,13 @@ import { describe, expect, it } from 'vitest'
 interface TauriConfig {
   productName: string
   identifier: string
+  app?: {
+    windows?: {
+      label?: string
+      title?: string
+      dragDropEnabled?: boolean
+    }[]
+  }
   bundle: {
     targets: string[] | string
     category?: string
@@ -110,6 +117,25 @@ describe('packagingConfig', () => {
     })
     expect(config.bundle.windows?.wix?.upgradeCode).toBe('90ffd755-2be3-5b35-8809-0f6022d8f999')
     expect(config.bundle.windows?.wix?.language).toBe('en-US')
+  })
+
+  it('enables native desktop drag-drop and grants core event capability', () => {
+    const config = JSON.parse(
+      readFileSync(resolve(process.cwd(), 'src-tauri/tauri.conf.json'), 'utf8'),
+    ) as TauriConfig
+    const capabilityPath = resolve(process.cwd(), 'src-tauri/capabilities/default.json')
+    const capability = JSON.parse(readFileSync(capabilityPath, 'utf8')) as {
+      identifier: string
+      windows: string[]
+      permissions: string[]
+    }
+
+    expect(config.app?.windows?.[0]?.label).toBe('main')
+    expect(config.app?.windows?.[0]?.dragDropEnabled).toBe(true)
+    expect(existsSync(capabilityPath)).toBe(true)
+    expect(capability.identifier).toBe('default')
+    expect(capability.windows).toContain('main')
+    expect(capability.permissions).toContain('core:default')
   })
 
   it('defines macOS app and DMG bundle metadata for macOS builders', () => {

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -390,6 +390,33 @@ describe('FolderCompareView', () => {
     )
   })
 
+  it('applies a pending folder drop launch while already mounted', async () => {
+    mountFolderCompareView()
+    const launchStore = useSessionLaunchStore()
+
+    launchStore.setPendingLaunch({
+      id: 'drop-folder-1',
+      source: 'drop',
+      sessionType: 'folder-compare',
+      title: 'folder-a vs folder-b',
+      route: '/compare/folder',
+      autoRun: true,
+      locations: {
+        left: { uri: 'D:/drops/folder-a', kind: 'directory', readOnly: false },
+        right: { uri: 'D:/drops/folder-b', kind: 'directory', readOnly: false },
+      },
+    })
+    await flushPromises()
+
+    expect(compareFolderPaths).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leftRoot: 'D:/drops/folder-a',
+        rightRoot: 'D:/drops/folder-b',
+      }),
+    )
+    expect(launchStore.pendingLaunch).toBeUndefined()
+  })
+
   it('exposes full path tooltips on path inputs', async () => {
     const wrapper = mountFolderCompareView()
     const longPath = 'D:/very/long/path/to/project/left-root-directory'

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -12,7 +12,6 @@ import {
   type FileOperationConfirmation,
 } from '@/app/fileOperationConfirmation'
 import { createChildCompareLaunch } from '@/app/childSession'
-import { listenDesktopPathDrop, resolveDropInputsFromPaths } from '@/app/desktopDrop'
 import { pickNativePath } from '@/app/filePicker'
 import { formatCompareError } from '@/app/compareError'
 import { loadFolderDisplayFilters, saveFolderDisplayFilters } from '@/app/folderDisplayFilters'
@@ -151,27 +150,42 @@ const syncPreviewItems = ref<SyncPreviewItem[]>([])
 const pendingSyncSafetyItems = ref<SyncPreviewItem[]>([])
 const lastSyncAction = ref<string>()
 
-onMounted(() => {
-  window.addEventListener('click', closeContextMenus)
-  void listenDesktopPathDrop(async (paths) => {
-    await applyDroppedPaths(paths)
-  }).then((stop) => {
-    stopDesktopDrop = stop
-  })
-
-  const launch = sessionLaunch.consumeLaunch('/compare/folder')
-
-  if (!launch) {
-    return
-  }
-
+function applyFolderLaunch(
+  launch: NonNullable<ReturnType<typeof sessionLaunch.consumeLaunch>>,
+): void {
   leftRoot.value = launch.locations.left?.uri ?? leftRoot.value
   rightRoot.value = launch.locations.right?.uri ?? rightRoot.value
 
   if (launch.autoRun && launch.locations.left?.uri && launch.locations.right?.uri) {
     void runFolderCompare()
   }
+}
+
+onMounted(() => {
+  window.addEventListener('click', closeContextMenus)
+
+  const launch = sessionLaunch.consumeLaunch('/compare/folder')
+
+  if (launch) {
+    applyFolderLaunch(launch)
+  }
 })
+
+// AppLayout owns the single Tauri drop listener; apply fresh launches while this view stays mounted.
+watch(
+  () => sessionLaunch.pendingLaunch,
+  (pending) => {
+    if (pending?.route !== '/compare/folder') {
+      return
+    }
+
+    const launch = sessionLaunch.consumeLaunch('/compare/folder')
+
+    if (launch) {
+      applyFolderLaunch(launch)
+    }
+  },
+)
 
 const summary = computed(() => ({
   total: rows.value.length,
@@ -996,7 +1010,6 @@ function archivePath(path: string): string {
 
 const rowContextMenu = ref<{ x: number; y: number; rowId: string }>()
 const pathContextMenu = ref<{ x: number; y: number; side: 'left' | 'right' }>()
-let stopDesktopDrop: (() => void) | undefined
 
 async function browseFolder(side: 'left' | 'right'): Promise<void> {
   const selected = await pickNativePath({ directory: true })
@@ -1009,30 +1022,6 @@ async function browseFolder(side: 'left' | 'right'): Promise<void> {
     leftRoot.value = selected
   } else {
     rightRoot.value = selected
-  }
-}
-
-async function applyDroppedPaths(paths: string[]): Promise<void> {
-  const inputs = await resolveDropInputsFromPaths(paths)
-  const first = inputs.at(0)
-  const second = inputs.at(1)
-
-  if (first && second) {
-    leftRoot.value = first.path
-    rightRoot.value = second.path
-
-    return
-  }
-
-  if (first) {
-    // ponytail: single drop fills empty side first, else left
-    if (!leftRoot.value) {
-      leftRoot.value = first.path
-    } else if (!rightRoot.value) {
-      rightRoot.value = first.path
-    } else {
-      leftRoot.value = first.path
-    }
   }
 }
 
@@ -1143,7 +1132,6 @@ function handleTreeScroll(event: Event): void {
 }
 
 onUnmounted(() => {
-  stopDesktopDrop?.()
   window.removeEventListener('click', closeContextMenus)
 })
 </script>


### PR DESCRIPTION
## Summary
- Add a default Tauri capability (`core:default`) so the webview can register `onDragDropEvent` listeners; without it, native file drops were swallowed and Home never launched a compare.
- Explicitly enable `dragDropEnabled` on the main window and keep a single app-level drop listener in `AppLayout` (Folder Compare now consumes pending launches while mounted instead of attaching a second listener).
- Keep HTML5 drop on Home as a browser/dev fallback; native absolute paths come from the Tauri event path.

## Test plan
- [x] `vitest` for desktopDrop, dropLaunch, packagingConfig, AppLayout, FolderCompareView
- [ ] Rebuild/install Linux deb and retest Thunar drop of two text files and two folders onto Home
- [ ] Confirm dropping while already on Folder Compare still fills left/right paths