### PR TITLE
Fix Linux Thunar drops missed by wry drag handler

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2622,6 +2622,7 @@ dependencies = [
  "file-core",
  "folder-core",
  "folder-merge-core",
+ "gtk",
  "hex-core",
  "image",
  "image-core",
@@ -2646,6 +2647,7 @@ dependencies = [
  "tokio",
  "version-core",
  "vfs-core",
+ "webkit2gtk",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ license = "Apache-2.0"
 [workspace.dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
-tauri = { version = "2.11.3", features = [] }
+tauri = { version = "2.11.3", features = ["wry"] }
 tauri-build = "2.6.3"
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros"] }
 encoding_rs = "0.8.35"
@@ -106,3 +106,7 @@ rfd = "0.15"
 
 [dev-dependencies]
 rust_xlsxwriter = "0.96.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18"
+webkit2gtk = { version = "=2.0.2", features = ["v2_38"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,12 +8,12 @@ mod sources;
 
 pub fn run() {
     tauri::Builder::default()
-        .setup(|app| {
+        .setup(|_app| {
             #[cfg(target_os = "linux")]
             {
                 use tauri::Manager;
 
-                if let Some(main) = app.get_webview_window("main") {
+                if let Some(main) = _app.get_webview_window("main") {
                     if let Err(error) = linux_dnd::install_linux_desktop_drop_bridge(&main) {
                         eprintln!("[OpenDiff] Linux desktop drop bridge unavailable: {error}");
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,27 @@
 pub use shell_startup::{prepare_shell_startup, ShellStartupDecision};
 
 mod commands;
+#[cfg(target_os = "linux")]
+mod linux_dnd;
 mod shell_startup;
 mod sources;
 
 pub fn run() {
     tauri::Builder::default()
+        .setup(|app| {
+            #[cfg(target_os = "linux")]
+            {
+                use tauri::Manager;
+
+                if let Some(main) = app.get_webview_window("main") {
+                    if let Err(error) = linux_dnd::install_linux_desktop_drop_bridge(&main) {
+                        eprintln!("[OpenDiff] Linux desktop drop bridge unavailable: {error}");
+                    }
+                }
+            }
+
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::apply_text_patch,
             commands::apply_text_patch_to_file,

--- a/src-tauri/src/linux_dnd.rs
+++ b/src-tauri/src/linux_dnd.rs
@@ -21,7 +21,9 @@ pub const DESKTOP_DROP_EVENT: &str = "open-diff://desktop-drop";
 pub const DESKTOP_DRAG_ENTER_EVENT: &str = "open-diff://desktop-drag-enter";
 pub const DESKTOP_DRAG_LEAVE_EVENT: &str = "open-diff://desktop-drag-leave";
 
-pub fn install_linux_desktop_drop_bridge<R: Runtime>(window: &WebviewWindow<R>) -> tauri::Result<()> {
+pub fn install_linux_desktop_drop_bridge<R: Runtime>(
+    window: &WebviewWindow<R>,
+) -> tauri::Result<()> {
     let app = window.app_handle().clone();
     let window_label = window.label().to_string();
 

--- a/src-tauri/src/linux_dnd.rs
+++ b/src-tauri/src/linux_dnd.rs
@@ -1,0 +1,175 @@
+//! Linux/WebKitGTK desktop file-drop bridge.
+//!
+//! wry's built-in handler only emits `DragDropEvent::Drop` when its controller is already in
+//! `Leaving` state and when `drag_data_received` used target info `== 2`. Thunar (and some other
+//! file managers) often deliver URI lists with a different info index, or deliver the drop while
+//! the controller is still `Entered`, so the JS `onDragDropEvent` listener never sees a `drop`.
+//!
+//! This bridge attaches after wry and accepts URI-list drops more permissively, then emits
+//! `open-diff://desktop-drop` with absolute paths for the frontend.
+
+#![cfg(target_os = "linux")]
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use gtk::gdk;
+use gtk::prelude::*;
+use tauri::{Emitter, Manager, Runtime, WebviewWindow};
+
+pub const DESKTOP_DROP_EVENT: &str = "open-diff://desktop-drop";
+pub const DESKTOP_DRAG_ENTER_EVENT: &str = "open-diff://desktop-drag-enter";
+pub const DESKTOP_DRAG_LEAVE_EVENT: &str = "open-diff://desktop-drag-leave";
+
+pub fn install_linux_desktop_drop_bridge<R: Runtime>(window: &WebviewWindow<R>) -> tauri::Result<()> {
+    let app = window.app_handle().clone();
+    let window_label = window.label().to_string();
+
+    window.with_webview(move |platform| {
+        let webview = platform.inner();
+        let pending_paths: Rc<RefCell<Option<Vec<String>>>> = Rc::new(RefCell::new(None));
+        let drop_requested = Rc::new(Cell::new(false));
+        let entered = Rc::new(Cell::new(false));
+
+        {
+            let pending_paths = pending_paths.clone();
+            let drop_requested = drop_requested.clone();
+            let entered = entered.clone();
+            let app = app.clone();
+            let window_label = window_label.clone();
+
+            webview.connect_drag_data_received(move |_, ctx, _, _, data, _info, time| {
+                let uris = data.uris();
+                if uris.is_empty() {
+                    return;
+                }
+
+                let paths = uris
+                    .iter()
+                    .map(|uri| uri_to_abs_path(uri.as_str()))
+                    .filter(|path| !path.is_empty())
+                    .collect::<Vec<_>>();
+
+                if paths.is_empty() {
+                    return;
+                }
+
+                if drop_requested.get() {
+                    drop_requested.set(false);
+                    entered.set(false);
+                    pending_paths.borrow_mut().take();
+                    ctx.drop_finish(true, time);
+                    let _ = app.emit_to(window_label.as_str(), DESKTOP_DROP_EVENT, paths);
+                    return;
+                }
+
+                if !entered.get() {
+                    entered.set(true);
+                    let _ = app.emit_to(
+                        window_label.as_str(),
+                        DESKTOP_DRAG_ENTER_EVENT,
+                        paths.clone(),
+                    );
+                }
+
+                *pending_paths.borrow_mut() = Some(paths);
+            });
+        }
+
+        {
+            let pending_paths = pending_paths.clone();
+            let drop_requested = drop_requested.clone();
+            let entered = entered.clone();
+            let app = app.clone();
+            let window_label = window_label.clone();
+
+            webview.connect_drag_drop(move |widget, ctx, _x, _y, time| {
+                if let Some(paths) = pending_paths.borrow_mut().take() {
+                    entered.set(false);
+                    drop_requested.set(false);
+                    ctx.drop_finish(true, time);
+                    let _ = app.emit_to(window_label.as_str(), DESKTOP_DROP_EVENT, paths);
+                    return true;
+                }
+
+                // Data may arrive only after we accept the drop — request uri-list now.
+                let target = widget
+                    .drag_dest_find_target(ctx, None)
+                    .unwrap_or_else(|| gdk::Atom::intern("text/uri-list"));
+
+                drop_requested.set(true);
+                widget.drag_get_data(ctx, &target, time);
+                true
+            });
+        }
+
+        {
+            let pending_paths = pending_paths.clone();
+            let drop_requested = drop_requested.clone();
+            let entered = entered.clone();
+            let app = app.clone();
+            let window_label = window_label.clone();
+
+            webview.connect_drag_leave(move |_, _, _| {
+                if drop_requested.get() {
+                    return;
+                }
+
+                // Defer leave so a following drop signal (common GTK ordering) still sees paths.
+                let pending_paths = pending_paths.clone();
+                let drop_requested = drop_requested.clone();
+                let entered = entered.clone();
+                let app = app.clone();
+                let window_label = window_label.clone();
+                gtk::glib::idle_add_local_once(move || {
+                    if drop_requested.get() {
+                        return;
+                    }
+
+                    if entered.get() {
+                        entered.set(false);
+                        pending_paths.borrow_mut().take();
+                        let _ = app.emit_to(window_label.as_str(), DESKTOP_DRAG_LEAVE_EVENT, ());
+                    }
+                });
+            });
+        }
+    })?;
+
+    Ok(())
+}
+
+fn uri_to_abs_path(uri: &str) -> String {
+    let stripped = uri.strip_prefix("file://").unwrap_or(uri);
+    percent_decode(stripped)
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (from_hex(bytes[i + 1]), from_hex(bytes[i + 2])) {
+                out.push((hi << 4) | lo);
+                i += 3;
+                continue;
+            }
+        }
+
+        out.push(bytes[i]);
+        i += 1;
+    }
+
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn from_hex(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}

--- a/src/app/desktopDrop.test.ts
+++ b/src/app/desktopDrop.test.ts
@@ -13,11 +13,13 @@ describe('desktopDrop', () => {
 
   it('returns a no-op unlisten outside Tauri', async () => {
     const onPaths = vi.fn()
-    const stop = await listenDesktopPathDrop(onPaths)
+    const onPhase = vi.fn()
+    const stop = await listenDesktopPathDrop(onPaths, onPhase)
 
     expect(typeof stop).toBe('function')
     stop()
     expect(onPaths).not.toHaveBeenCalled()
+    expect(onPhase).toHaveBeenCalledWith('unavailable', 'not-tauri')
   })
 
   it('falls back to path heuristics when classify_paths is unavailable', async () => {

--- a/src/app/desktopDrop.ts
+++ b/src/app/desktopDrop.ts
@@ -10,6 +10,8 @@ export interface ClassifiedPathEntry {
   kind: string
 }
 
+export type DesktopDragPhase = 'listening' | 'enter' | 'over' | 'drop' | 'leave' | 'unavailable'
+
 export function isTauriRuntime(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 }
@@ -39,28 +41,99 @@ export async function resolveDropInputsFromPaths(paths: string[]): Promise<DropI
  * Listen for OS file/folder drops with absolute paths (Tauri native drag-drop).
  * Requires `dragDropEnabled: true` on the window and `core:default` capability
  * so `onDragDropEvent` can register event listeners.
+ *
+ * On Linux, also listens for `open-diff://desktop-drop` from the Rust WebKitGTK bridge,
+ * which recovers Thunar/Nautilus drops that wry's Leaving-state handler can miss.
  */
 export async function listenDesktopPathDrop(
   onPaths: (paths: string[]) => void | Promise<void>,
+  onPhase?: (phase: DesktopDragPhase, detail?: string) => void,
 ): Promise<() => void> {
   if (!isTauriRuntime()) {
+    onPhase?.('unavailable', 'not-tauri')
+
     return () => undefined
+  }
+
+  const stoppers: Array<() => void> = []
+  let lastDropKey = ''
+  let lastDropAt = 0
+
+  const deliverPaths = (paths: string[]): void => {
+    const cleaned = paths.map((path) => path.trim()).filter(Boolean)
+
+    if (cleaned.length === 0) {
+      return
+    }
+
+    const key = cleaned.join('\0')
+    const now = Date.now()
+
+    if (key === lastDropKey && now - lastDropAt < 600) {
+      return
+    }
+
+    lastDropKey = key
+    lastDropAt = now
+    onPhase?.('drop', `${cleaned.length} path(s)`)
+    void onPaths(cleaned)
   }
 
   try {
     const { getCurrentWebview } = await import('@tauri-apps/api/webview')
     const unlisten = await getCurrentWebview().onDragDropEvent((event) => {
+      if (event.payload.type === 'enter') {
+        onPhase?.('enter', `${event.payload.paths.length} path(s)`)
+
+        return
+      }
+
+      if (event.payload.type === 'over') {
+        onPhase?.('over')
+
+        return
+      }
+
+      if (event.payload.type === 'leave') {
+        onPhase?.('leave')
+
+        return
+      }
+
       if (event.payload.type !== 'drop') {
         return
       }
 
-      void onPaths(event.payload.paths)
+      deliverPaths(event.payload.paths)
     })
 
-    return unlisten
+    stoppers.push(unlisten)
+    onPhase?.('listening', 'webview')
   } catch (error) {
     console.warn('[OpenDiff] desktop path drop listener unavailable', error)
+    onPhase?.('unavailable', 'webview-listen-failed')
+  }
 
-    return () => undefined
+  try {
+    const { listen } = await import('@tauri-apps/api/event')
+    const unlistenDrop = await listen<string[]>('open-diff://desktop-drop', (event) => {
+      deliverPaths(event.payload ?? [])
+    })
+    const unlistenEnter = await listen<string[]>('open-diff://desktop-drag-enter', (event) => {
+      onPhase?.('enter', `${(event.payload ?? []).length} path(s)`)
+    })
+    const unlistenLeave = await listen('open-diff://desktop-drag-leave', () => {
+      onPhase?.('leave')
+    })
+
+    stoppers.push(unlistenDrop, unlistenEnter, unlistenLeave)
+  } catch (error) {
+    console.warn('[OpenDiff] Linux desktop drop bridge listener unavailable', error)
+  }
+
+  return () => {
+    for (const stop of stoppers) {
+      stop()
+    }
   }
 }

--- a/src/app/desktopDrop.ts
+++ b/src/app/desktopDrop.ts
@@ -55,7 +55,7 @@ export async function listenDesktopPathDrop(
     return () => undefined
   }
 
-  const stoppers: Array<() => void> = []
+  const stoppers: (() => void)[] = []
   let lastDropKey = ''
   let lastDropAt = 0
 
@@ -75,36 +75,29 @@ export async function listenDesktopPathDrop(
 
     lastDropKey = key
     lastDropAt = now
-    onPhase?.('drop', `${cleaned.length} path(s)`)
+    onPhase?.('drop', `${String(cleaned.length)} path(s)`)
     void onPaths(cleaned)
   }
 
   try {
     const { getCurrentWebview } = await import('@tauri-apps/api/webview')
     const unlisten = await getCurrentWebview().onDragDropEvent((event) => {
-      if (event.payload.type === 'enter') {
-        onPhase?.('enter', `${event.payload.paths.length} path(s)`)
+      switch (event.payload.type) {
+        case 'enter':
+          onPhase?.('enter', `${String(event.payload.paths.length)} path(s)`)
 
-        return
+          return
+        case 'over':
+          onPhase?.('over')
+
+          return
+        case 'leave':
+          onPhase?.('leave')
+
+          return
+        case 'drop':
+          deliverPaths(event.payload.paths)
       }
-
-      if (event.payload.type === 'over') {
-        onPhase?.('over')
-
-        return
-      }
-
-      if (event.payload.type === 'leave') {
-        onPhase?.('leave')
-
-        return
-      }
-
-      if (event.payload.type !== 'drop') {
-        return
-      }
-
-      deliverPaths(event.payload.paths)
     })
 
     stoppers.push(unlisten)
@@ -117,10 +110,10 @@ export async function listenDesktopPathDrop(
   try {
     const { listen } = await import('@tauri-apps/api/event')
     const unlistenDrop = await listen<string[]>('open-diff://desktop-drop', (event) => {
-      deliverPaths(event.payload ?? [])
+      deliverPaths(event.payload)
     })
     const unlistenEnter = await listen<string[]>('open-diff://desktop-drag-enter', (event) => {
-      onPhase?.('enter', `${(event.payload ?? []).length} path(s)`)
+      onPhase?.('enter', `${String(event.payload.length)} path(s)`)
     })
     const unlistenLeave = await listen('open-diff://desktop-drag-leave', () => {
       onPhase?.('leave')

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -24,11 +24,13 @@ vi.mock('vue-router', () => ({
 const desktopDropHandlers: ((paths: string[]) => void | Promise<void>)[] = []
 
 vi.mock('@/app/desktopDrop', () => ({
-  listenDesktopPathDrop: vi.fn((onPaths: (paths: string[]) => void | Promise<void>, _onPhase?: unknown) => {
-    desktopDropHandlers.push(onPaths)
+  listenDesktopPathDrop: vi.fn(
+    (onPaths: (paths: string[]) => void | Promise<void>, _onPhase?: unknown) => {
+      desktopDropHandlers.push(onPaths)
 
-    return Promise.resolve(() => undefined)
-  }),
+      return Promise.resolve(() => undefined)
+    },
+  ),
   resolveDropInputsFromPaths: vi.fn((paths: string[]) =>
     Promise.resolve(
       paths.map((path) => ({

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -24,7 +24,7 @@ vi.mock('vue-router', () => ({
 const desktopDropHandlers: ((paths: string[]) => void | Promise<void>)[] = []
 
 vi.mock('@/app/desktopDrop', () => ({
-  listenDesktopPathDrop: vi.fn((onPaths: (paths: string[]) => void | Promise<void>) => {
+  listenDesktopPathDrop: vi.fn((onPaths: (paths: string[]) => void | Promise<void>, _onPhase?: unknown) => {
     desktopDropHandlers.push(onPaths)
 
     return Promise.resolve(() => undefined)

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -113,27 +113,50 @@ onMounted(() => {
     }
   })()
 
-  void listenDesktopPathDrop(async (paths) => {
-    const result = await resolveDropLaunchFromPaths(paths, { autoRun: true })
+  void listenDesktopPathDrop(
+    async (paths) => {
+      const result = await resolveDropLaunchFromPaths(paths, { autoRun: true })
 
-    if (!result.ok) {
-      statusBar.reportStatus({
-        comparisonStatus: result.reason,
-        source: 'drop',
+      if (!result.ok) {
+        statusBar.reportStatus({
+          comparisonStatus: result.reason,
+          source: 'drop',
+        })
+
+        return
+      }
+
+      sessionLaunch.setPendingLaunch(result.payload)
+      tabs.openTab({
+        title: result.selection.title,
+        titleKey: result.selection.titleKey,
+        route: result.selection.route,
+        dirty: false,
       })
-
-      return
-    }
-
-    sessionLaunch.setPendingLaunch(result.payload)
-    tabs.openTab({
-      title: result.selection.title,
-      titleKey: result.selection.titleKey,
-      route: result.selection.route,
-      dirty: false,
-    })
-    void router.push(result.selection.route)
-  }).then((stop) => {
+      void router.push(result.selection.route)
+    },
+    (phase) => {
+      // Subtle status only for real drag activity (not a permanent "Listening" banner).
+      if (phase === 'enter') {
+        statusBar.reportStatus({
+          comparisonStatus: 'Drop to open compare',
+          source: 'drop',
+        })
+      } else if (phase === 'leave') {
+        statusBar.reportStatus({
+          comparisonStatus: 'Ready',
+          source: 'drop',
+        })
+      } else if (phase === 'drop') {
+        statusBar.reportStatus({
+          comparisonStatus: 'Opening dropped files…',
+          source: 'drop',
+        })
+      } else if (phase === 'unavailable') {
+        console.warn('[OpenDiff] desktop drop listener phase unavailable')
+      }
+    },
+  ).then((stop) => {
     stopDesktopDrop = stop
   })
 })


### PR DESCRIPTION
## Summary

- Installed 1.1.2 from #54 already embedded `core:default` (expanded ACL present), but Thunar → Home drops still did nothing.
- Root cause: wry's WebKitGTK handler only emits `Drop` when its controller is already `Leaving` and when `drag_data_received` used target `info == 2`. Thunar often misses that path.
- Add a Linux `with_webview` URI-list bridge that emits `open-diff://desktop-drop`, keep Tauri `onDragDropEvent`, and show subtle status-bar enter/drop feedback.

## Type of change

- [x] Bug fix

## Validation

- [x] `vitest run src/app/desktopDrop.test.ts src/app/packagingConfig.test.ts src/layouts/AppLayout.test.ts` (26 passed)
- [x] `tauri build --bundles deb` + `dpkg -i` — binary embeds `open-diff://desktop-drop` and core ACL
- [ ] Parent: re-smoke Thunar drop of two text files onto Home

## Checklist

- [x] Focused follow-up to #54; not merged
- [x] No AI attribution in commits