### PR TITLE
Align Folder and Text Compare session menus and toolbars

### DIFF
--- a/src/app/dropLaunch.test.ts
+++ b/src/app/dropLaunch.test.ts
@@ -27,7 +27,7 @@ describe('resolveDropLaunch', () => {
       sessionType: 'text-compare',
       route: '/compare/text',
       autoRun: true,
-      title: 'left.txt vs right.txt',
+      title: 'left.txt <--> right.txt',
       locations: {
         left: { uri: 'C:/work/left.txt', kind: 'file', displayName: 'left.txt' },
         right: { uri: 'C:/work/right.txt', kind: 'file', displayName: 'right.txt' },
@@ -122,7 +122,7 @@ describe('createLaunchFromDrop', () => {
       id: 'fixed',
       source: 'drop',
       sessionType: 'text-compare',
-      title: 'a.ts vs b.ts',
+      title: 'a.ts <--> b.ts',
       route: '/compare/text',
       locations: {
         left: { uri: 'C:/a.ts', displayName: 'a.ts', kind: 'file', readOnly: false },

--- a/src/app/dropLaunch.ts
+++ b/src/app/dropLaunch.ts
@@ -85,7 +85,7 @@ export function createLaunchFromDrop(
     id: options.id ?? crypto.randomUUID(),
     source: 'drop',
     sessionType: selection.sessionType,
-    title: `${classification.left.displayName} vs ${classification.right.displayName}`,
+    title: `${classification.left.displayName} <--> ${classification.right.displayName}`,
     route: selection.route,
     locations: {
       left: dropItemToLaunchLocation(classification.left),

--- a/src/app/sessionToolbars.test.ts
+++ b/src/app/sessionToolbars.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildFolderCompareToolbar,
+  buildTextCompareToolbar,
+  folderCompareToolbarOrder,
+  pathPairTitle,
+  textCompareToolbarOrder,
+} from './sessionToolbars'
+
+describe('sessionToolbars', () => {
+  it('keeps Folder Compare toolbar in expected order', () => {
+    const toolbar = buildFolderCompareToolbar({
+      home: true,
+      all: true,
+      same: true,
+      expand: true,
+      collapse: true,
+      refresh: true,
+      swap: true,
+      stop: true,
+      copy: false,
+      minor: false,
+      rules: false,
+      select: false,
+      files: false,
+      filters: false,
+      peek: false,
+    })
+
+    expect(toolbar.map((item) => item.id)).toEqual([...folderCompareToolbarOrder])
+    expect(toolbar.find((item) => item.id === 'peek')?.enabled).toBe(false)
+    expect(toolbar.find((item) => item.id === 'home')?.enabled).toBe(true)
+  })
+
+  it('keeps Text Compare toolbar in expected order', () => {
+    const toolbar = buildTextCompareToolbar({
+      home: true,
+      all: true,
+      diffs: true,
+      copy: true,
+      'next-section': true,
+      'prev-section': true,
+      swap: true,
+      reload: true,
+    })
+
+    expect(toolbar.map((item) => item.id)).toEqual([...textCompareToolbarOrder])
+    expect(toolbar.find((item) => item.id === 'minor')?.enabled).toBe(false)
+  })
+
+  it('formats path pair titles', () => {
+    expect(pathPairTitle('D:/work/left.txt', 'D:/work/right.txt')).toBe('left.txt <--> right.txt')
+  })
+})

--- a/src/app/sessionToolbars.ts
+++ b/src/app/sessionToolbars.ts
@@ -1,0 +1,113 @@
+/** Folder Compare and Text Compare session toolbar layouts. */
+
+export interface SessionToolbarCommand {
+  id: string
+  glyph: string
+  labelKey: string
+  enabled: boolean
+}
+
+export const folderCompareToolbarOrder = [
+  'home',
+  'all',
+  'same',
+  'minor',
+  'rules',
+  'copy',
+  'expand',
+  'collapse',
+  'select',
+  'files',
+  'refresh',
+  'swap',
+  'stop',
+  'filters',
+  'peek',
+] as const
+
+export const textCompareToolbarOrder = [
+  'home',
+  'all',
+  'diffs',
+  'same',
+  'context',
+  'minor',
+  'rules',
+  'copy',
+  'next-section',
+  'prev-section',
+  'swap',
+  'reload',
+] as const
+
+const folderMeta: Record<
+  (typeof folderCompareToolbarOrder)[number],
+  { glyph: string; labelKey: string }
+> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  all: { glyph: '*', labelKey: 'ui.all' },
+  same: { glyph: '=', labelKey: 'ui.same' },
+  minor: { glyph: '~', labelKey: 'ui.minor' },
+  rules: { glyph: 'R', labelKey: 'ui.rules' },
+  copy: { glyph: 'C', labelKey: 'ui.copy' },
+  expand: { glyph: '+', labelKey: 'ui.expand' },
+  collapse: { glyph: '-', labelKey: 'ui.collapse' },
+  select: { glyph: 'V', labelKey: 'ui.select' },
+  files: { glyph: 'F', labelKey: 'ui.files' },
+  refresh: { glyph: 'R', labelKey: 'ui.refresh' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  stop: { glyph: 'X', labelKey: 'ui.stop' },
+  filters: { glyph: 'F', labelKey: 'ui.filters' },
+  peek: { glyph: 'P', labelKey: 'ui.peek' },
+}
+
+const textMeta: Record<
+  (typeof textCompareToolbarOrder)[number],
+  { glyph: string; labelKey: string }
+> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  all: { glyph: '*', labelKey: 'ui.all' },
+  diffs: { glyph: '!=', labelKey: 'ui.diffs' },
+  same: { glyph: '=', labelKey: 'ui.same' },
+  context: { glyph: 'C', labelKey: 'ui.context' },
+  minor: { glyph: '~', labelKey: 'ui.minor' },
+  rules: { glyph: 'R', labelKey: 'ui.rules' },
+  copy: { glyph: 'C', labelKey: 'ui.copy' },
+  'next-section': { glyph: 'N', labelKey: 'ui.nextSection' },
+  'prev-section': { glyph: 'P', labelKey: 'ui.prevSection' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  reload: { glyph: 'R', labelKey: 'ui.reload' },
+}
+
+export function buildFolderCompareToolbar(
+  enabled: Partial<Record<(typeof folderCompareToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return folderCompareToolbarOrder.map((id) => ({
+    id,
+    glyph: folderMeta[id].glyph,
+    labelKey: folderMeta[id].labelKey,
+    enabled: Boolean(enabled[id]),
+  }))
+}
+
+export function buildTextCompareToolbar(
+  enabled: Partial<Record<(typeof textCompareToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return textCompareToolbarOrder.map((id) => ({
+    id,
+    glyph: textMeta[id].glyph,
+    labelKey: textMeta[id].labelKey,
+    enabled: Boolean(enabled[id]),
+  }))
+}
+
+export function pathPairTitle(leftPath: string, rightPath: string): string {
+  return `${pathBaseName(leftPath)} <--> ${pathBaseName(rightPath)}`
+}
+
+export function pathBaseName(path: string): string {
+  const normalized = path.replaceAll('\\', '/').replace(/\/+$/, '')
+  const parts = normalized.split('/').filter(Boolean)
+
+  return parts.at(-1) ?? path
+}

--- a/src/components/diff/TextDiffPanel.vue
+++ b/src/components/diff/TextDiffPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
 import type { DiffLine, InlineDiffSegment } from '@/types/diff'
 
 const textDiffRowHeightPx = 24
@@ -410,6 +411,12 @@ const splitBySyntaxTokens = (
 
   return parts
 }
+
+defineExpose({
+  setDisplayMode,
+  jumpToNextDiff,
+  jumpToPreviousDiff,
+})
 </script>
 
 <template>

--- a/src/components/workbench/WorkbenchShell.vue
+++ b/src/components/workbench/WorkbenchShell.vue
@@ -1,249 +1,234 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from '@/i18n'
+import type { SessionToolbarCommand } from '@/app/sessionToolbars'
 
 const props = defineProps<{
   title: string
   eyebrow?: string
   subtitle?: string
   inspectorLabel?: string
+  toolbarCommands?: SessionToolbarCommand[]
+  toolbarTestIdPrefix?: string
+}>()
+const emit = defineEmits<{
+  'toolbar-command': [id: string]
 }>()
 const { t } = useI18n()
 const resolvedInspectorLabel = computed(() => props.inspectorLabel ?? t('ui.inspector'))
-const toolbarItems = computed(() => toolbarForTitle(props.title))
+const toolbarItems = computed(() => {
+  if (props.toolbarCommands) {
+    return props.toolbarCommands
+  }
 
-interface BcToolbarItem {
-  label: string
+  return toolbarForTitle(props.title).map((item) => ({
+    id: item.id,
+    glyph: item.glyph,
+    labelKey: item.labelKey,
+    enabled: false,
+  }))
+})
+const testIdPrefix = computed(() => props.toolbarTestIdPrefix ?? 'session-toolbar')
+
+interface LegacyToolbarItem {
+  id: string
+  labelKey: string
   glyph: string
 }
 
-function item(label: string, glyph = ''): BcToolbarItem {
-  return { label, glyph: glyph || label.slice(0, 1) }
+function item(id: string, labelKey: string, glyph: string): LegacyToolbarItem {
+  return { id, labelKey, glyph }
 }
 
-function toolbarForTitle(title: string): BcToolbarItem[] {
+function toolbarForTitle(title: string): LegacyToolbarItem[] {
   const normalizedTitle = title.toLowerCase()
 
   if (normalizedTitle.includes('folder merge') || normalizedTitle.includes('文件夹合并')) {
     return [
-      item('Home', 'H'),
-      item('Sessions', 'S'),
-      item('All', '*'),
-      item('Diffs', '!='),
-      item('Same', '='),
-      item('Minor', '~'),
-      item('Same OK', 'OK'),
-      item('Rules', 'R'),
-      item('Merge', 'M'),
-      item('To Output', 'O'),
-      item('Expand', '+'),
-      item('Collapse', '-'),
-      item('Select', 'V'),
-      item('Files', 'F'),
-      item('Refresh', 'R'),
-      item('Swap', '<>'),
-      item('Stop', 'X'),
-      item('Filters', 'F'),
-      item('Peek', 'P'),
+      item('home', 'ui.home', 'H'),
+      item('all', 'ui.all', '*'),
+      item('same', 'ui.same', '='),
+      item('minor', 'ui.minor', '~'),
+      item('rules', 'ui.rules', 'R'),
+      item('expand', 'ui.expand', '+'),
+      item('collapse', 'ui.collapse', '-'),
+      item('refresh', 'ui.refresh', 'R'),
+      item('swap', 'ui.swap', '<>'),
+      item('stop', 'ui.stop', 'X'),
+      item('filters', 'ui.filters', 'F'),
+      item('peek', 'ui.peek', 'P'),
     ]
   }
 
   if (normalizedTitle.includes('folder sync') || normalizedTitle.includes('文件夹同步')) {
     return [
-      item('Home', 'H'),
-      item('Sessions', 'S'),
-      item('Minor', '~'),
-      item('Expand', '+'),
-      item('Collapse', '-'),
-      item('Select', 'V'),
-      item('Refresh', 'R'),
-      item('Stop', 'X'),
-      item('Peek', 'P'),
-      item('Accept', 'A'),
-      item('Cancel', 'X'),
-      item('Sync Now', 'S'),
+      item('home', 'ui.home', 'H'),
+      item('minor', 'ui.minor', '~'),
+      item('expand', 'ui.expand', '+'),
+      item('collapse', 'ui.collapse', '-'),
+      item('refresh', 'ui.refresh', 'R'),
+      item('stop', 'ui.stop', 'X'),
+      item('peek', 'ui.peek', 'P'),
     ]
   }
 
   if (normalizedTitle.includes('folder compare') || normalizedTitle.includes('文件夹比较')) {
     return [
-      item('Home', 'H'),
-      item('Sessions', 'S'),
-      item('All', '*'),
-      item('Diffs', '!='),
-      item('Same', '='),
-      item('Structure', 'St'),
-      item('Minor', '~'),
-      item('Rules', 'R'),
-      item('Copy', 'C'),
-      item('Expand', '+'),
-      item('Collapse', '-'),
-      item('Select', 'V'),
-      item('Files', 'F'),
-      item('Refresh', 'R'),
-      item('Swap', '<>'),
-      item('Stop', 'X'),
-      item('Filters', 'F'),
-      item('Peek', 'P'),
+      item('home', 'ui.home', 'H'),
+      item('all', 'ui.all', '*'),
+      item('same', 'ui.same', '='),
+      item('minor', 'ui.minor', '~'),
+      item('rules', 'ui.rules', 'R'),
+      item('copy', 'ui.copy', 'C'),
+      item('expand', 'ui.expand', '+'),
+      item('collapse', 'ui.collapse', '-'),
+      item('select', 'ui.select', 'V'),
+      item('files', 'ui.files', 'F'),
+      item('refresh', 'ui.refresh', 'R'),
+      item('swap', 'ui.swap', '<>'),
+      item('stop', 'ui.stop', 'X'),
+      item('filters', 'ui.filters', 'F'),
+      item('peek', 'ui.peek', 'P'),
     ]
   }
 
   if (normalizedTitle.includes('text merge') || normalizedTitle.includes('文本合并')) {
     return [
-      item('Home', 'H'),
-      item('Sessions', 'S'),
-      item('All', '*'),
-      item('Diffs', '!='),
-      item('Same', '='),
-      item('Context', 'C'),
-      item('Minor', '~'),
-      item('Same OK', 'OK'),
-      item('Favor Left', 'L'),
-      item('Favor Right', 'R'),
-      item('Rules', 'R'),
-      item('Format', 'F'),
-      item('Conflict', '!'),
-      item('Left', 'L'),
-      item('Center', 'C'),
-      item('Right', 'R'),
-      item('Next Conflict', 'N'),
-      item('Prev Conflict', 'P'),
-      item('Swap', '<>'),
-      item('Reload', 'R'),
+      item('home', 'ui.home', 'H'),
+      item('all', 'ui.all', '*'),
+      item('same', 'ui.same', '='),
+      item('context', 'ui.context', 'C'),
+      item('minor', 'ui.minor', '~'),
+      item('rules', 'ui.rules', 'R'),
+      item('swap', 'ui.swap', '<>'),
+      item('reload', 'ui.reload', 'R'),
     ]
   }
 
   if (normalizedTitle.includes('text compare') || normalizedTitle.includes('文本比较')) {
     return [
-      item('Home', 'H'),
-      item('Sessions', 'S'),
-      item('All', '*'),
-      item('Diffs', '!='),
-      item('Same', '='),
-      item('Context', 'C'),
-      item('Minor', '~'),
-      item('Rules', 'R'),
-      item('Format', 'F'),
-      item('Copy', 'C'),
-      item('Next Section', 'N'),
-      item('Prev Section', 'P'),
-      item('Swap', '<>'),
-      item('Reload', 'R'),
+      item('home', 'ui.home', 'H'),
+      item('all', 'ui.all', '*'),
+      item('diffs', 'ui.diffs', '!='),
+      item('same', 'ui.same', '='),
+      item('context', 'ui.context', 'C'),
+      item('minor', 'ui.minor', '~'),
+      item('rules', 'ui.rules', 'R'),
+      item('copy', 'ui.copy', 'C'),
+      item('next-section', 'ui.nextSection', 'N'),
+      item('prev-section', 'ui.prevSection', 'P'),
+      item('swap', 'ui.swap', '<>'),
+      item('reload', 'ui.reload', 'R'),
     ]
   }
 
   if (normalizedTitle.includes('table compare') || normalizedTitle.includes('表格比较')) {
     return [
-      item('Home', 'H'),
-      item('All', '*'),
-      item('Diffs', '!='),
-      item('Same', '='),
-      item('Minor', '~'),
-      item('Rules', 'R'),
-      item('Copy', 'C'),
-      item('Next Diff', 'N'),
-      item('Prev Diff', 'P'),
-      item('Swap', '<>'),
-      item('Reload', 'R'),
+      item('home', 'ui.home', 'H'),
+      item('all', 'ui.all', '*'),
+      item('diffs', 'ui.diffs', '!='),
+      item('same', 'ui.same', '='),
+      item('minor', 'ui.minor', '~'),
+      item('rules', 'ui.rules', 'R'),
+      item('copy', 'ui.copy', 'C'),
+      item('swap', 'ui.swap', '<>'),
+      item('reload', 'ui.reload', 'R'),
     ]
   }
 
   if (normalizedTitle.includes('hex compare') || normalizedTitle.includes('十六进制比较')) {
     return [
-      item('Home', 'H'),
-      item('All', '*'),
-      item('Diffs', '!='),
-      item('Same', '='),
-      item('Rules', 'R'),
-      item('Copy', 'C'),
-      item('Next Diff', 'N'),
-      item('Prev Diff', 'P'),
-      item('Swap', '<>'),
-      item('Reload', 'R'),
+      item('home', 'ui.home', 'H'),
+      item('all', 'ui.all', '*'),
+      item('diffs', 'ui.diffs', '!='),
+      item('same', 'ui.same', '='),
+      item('rules', 'ui.rules', 'R'),
+      item('copy', 'ui.copy', 'C'),
+      item('swap', 'ui.swap', '<>'),
+      item('reload', 'ui.reload', 'R'),
     ]
   }
 
   if (normalizedTitle.includes('picture compare') || normalizedTitle.includes('图片比较')) {
     return [
-      item('Home', 'H'),
-      item('Tol', 'T'),
-      item('Range', 'R'),
-      item('Blend', 'B'),
-      item('Minor', '~'),
-      item('Rules', 'R'),
-      item('Swap', '<>'),
-      item('Reload', 'R'),
-      item('Meta', 'M'),
+      item('home', 'ui.home', 'H'),
+      item('minor', 'ui.minor', '~'),
+      item('rules', 'ui.rules', 'R'),
+      item('swap', 'ui.swap', '<>'),
+      item('reload', 'ui.reload', 'R'),
     ]
   }
 
   if (normalizedTitle.includes('registry compare') || normalizedTitle.includes('注册表比较')) {
     return [
-      item('Home', 'H'),
-      item('All', '*'),
-      item('Diffs', '!='),
-      item('Same', '='),
-      item('Copy', 'C'),
-      item('Next Diff', 'N'),
-      item('Prev Diff', 'P'),
-      item('Swap', '<>'),
-      item('Reload', 'R'),
-      item('Expand', '+'),
-      item('Collapse', '-'),
+      item('home', 'ui.home', 'H'),
+      item('all', 'ui.all', '*'),
+      item('diffs', 'ui.diffs', '!='),
+      item('same', 'ui.same', '='),
+      item('copy', 'ui.copy', 'C'),
+      item('swap', 'ui.swap', '<>'),
+      item('reload', 'ui.reload', 'R'),
+      item('expand', 'ui.expand', '+'),
+      item('collapse', 'ui.collapse', '-'),
     ]
   }
 
   if (normalizedTitle.includes('media compare') || normalizedTitle.includes('媒体比较')) {
     return [
-      item('Home', 'H'),
-      item('All', '*'),
-      item('Diffs', '!='),
-      item('Same', '='),
-      item('Minor', '~'),
-      item('Rules', 'R'),
-      item('Next Diff', 'N'),
-      item('Prev Diff', 'P'),
-      item('Swap', '<>'),
-      item('Reload', 'R'),
-      item('Play', 'P'),
-      item('Back', 'B'),
-      item('Forward', 'F'),
+      item('home', 'ui.home', 'H'),
+      item('all', 'ui.all', '*'),
+      item('diffs', 'ui.diffs', '!='),
+      item('same', 'ui.same', '='),
+      item('minor', 'ui.minor', '~'),
+      item('rules', 'ui.rules', 'R'),
+      item('swap', 'ui.swap', '<>'),
+      item('reload', 'ui.reload', 'R'),
     ]
   }
 
   if (normalizedTitle.includes('version compare') || normalizedTitle.includes('版本比较')) {
     return [
-      item('Home', 'H'),
-      item('All', '*'),
-      item('Diffs', '!='),
-      item('Same', '='),
-      item('Minor', '~'),
-      item('Rules', 'R'),
-      item('Next Diff', 'N'),
-      item('Prev Diff', 'P'),
-      item('Swap', '<>'),
-      item('Reload', 'R'),
+      item('home', 'ui.home', 'H'),
+      item('all', 'ui.all', '*'),
+      item('diffs', 'ui.diffs', '!='),
+      item('same', 'ui.same', '='),
+      item('minor', 'ui.minor', '~'),
+      item('rules', 'ui.rules', 'R'),
+      item('swap', 'ui.swap', '<>'),
+      item('reload', 'ui.reload', 'R'),
     ]
   }
 
   if (normalizedTitle.includes('text edit') || normalizedTitle.includes('文本编辑')) {
     return [
-      item('Home', 'H'),
-      item('Undo', 'U'),
-      item('Redo', 'R'),
-      item('Cut', 'X'),
-      item('Copy', 'C'),
-      item('Paste', 'P'),
-      item('Delete', 'D'),
-      item('Syntax', 'S'),
+      item('home', 'ui.home', 'H'),
+      item('undo', 'ui.undo', 'U'),
+      item('redo', 'ui.redo', 'R'),
+      item('cut', 'ui.cut', 'X'),
+      item('copy', 'ui.copy', 'C'),
+      item('paste', 'ui.paste', 'P'),
+      item('delete', 'ui.delete', 'D'),
+      item('syntax', 'ui.syntax', 'S'),
     ]
   }
 
   if (normalizedTitle.includes('text patch') || normalizedTitle.includes('文本补丁')) {
-    return [item('Home', 'H'), item('Next Section', 'N'), item('Prev Section', 'P')]
+    return [
+      item('home', 'ui.home', 'H'),
+      item('next-section', 'ui.nextSection', 'N'),
+      item('prev-section', 'ui.prevSection', 'P'),
+    ]
   }
 
   return []
+}
+
+function onToolbarCommand(command: SessionToolbarCommand): void {
+  if (!command.enabled) {
+    return
+  }
+
+  emit('toolbar-command', command.id)
 }
 </script>
 
@@ -272,15 +257,19 @@ function toolbarForTitle(title: string): BcToolbarItem[] {
       <section
         v-if="toolbarItems.length > 0"
         class="bc-session-toolbar"
+        :data-testid="`${testIdPrefix}-bar`"
       >
         <button
           v-for="toolbarItem in toolbarItems"
-          :key="`${toolbarItem.label}-${toolbarItem.glyph}`"
+          :key="toolbarItem.id"
           type="button"
           class="bc-toolbar-command"
+          :disabled="!toolbarItem.enabled"
+          :data-testid="`${testIdPrefix}-${toolbarItem.id}`"
+          @click="onToolbarCommand(toolbarItem)"
         >
           <span class="bc-toolbar-glyph">{{ toolbarItem.glyph }}</span>
-          <span>{{ toolbarItem.label }}</span>
+          <span>{{ t(toolbarItem.labelKey) }}</span>
         </button>
       </section>
       <slot name="toolbar" />

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -764,5 +764,12 @@ export const deDE: LanguagePack = {
     'ui.homeStartHint': 'Ordner durchsuchen oder zwei Elemente hier ablegen.',
     'ui.noFilteredRows': 'Keine Einträge für die aktuellen Filter.',
     'status.syncCompleted': 'Sync finished: {succeeded} succeeded, {failed} failed',
+    'ui.expand': 'Erweitern',
+    'ui.collapse': 'Reduzieren',
+    'ui.peek': 'Einblick',
+    'ui.filters': 'Filter',
+    'ui.stop': 'Stopp',
+    'ui.nextSection': 'Nächster Abschnitt',
+    'ui.prevSection': 'Vorheriger Abschnitt',
   },
 }

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -744,5 +744,12 @@ export const enUS: LanguagePack = {
       'Drag folders or files onto a session icon, or click a session icon to begin.',
     'ui.noFilteredRows': 'No items match the current filters.',
     'status.syncCompleted': 'Sync finished: {succeeded} succeeded, {failed} failed',
+    'ui.expand': 'Expand',
+    'ui.collapse': 'Collapse',
+    'ui.peek': 'Peek',
+    'ui.filters': 'Filters',
+    'ui.stop': 'Stop',
+    'ui.nextSection': 'Next Section',
+    'ui.prevSection': 'Prev Section',
   },
 }

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -758,5 +758,12 @@ export const esES: LanguagePack = {
     'ui.homeStartHint': 'Examina carpetas o suelta dos elementos aquí.',
     'ui.noFilteredRows': 'Ningún elemento coincide con los filtros.',
     'status.syncCompleted': 'Sync finished: {succeeded} succeeded, {failed} failed',
+    'ui.expand': 'Expandir',
+    'ui.collapse': 'Contraer',
+    'ui.peek': 'Vista previa',
+    'ui.filters': 'Filtros',
+    'ui.stop': 'Detener',
+    'ui.nextSection': 'Sección siguiente',
+    'ui.prevSection': 'Sección anterior',
   },
 }

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -759,5 +759,12 @@ export const frFR: LanguagePack = {
     'ui.homeStartHint': 'Parcourez des dossiers ou déposez deux éléments ici.',
     'ui.noFilteredRows': 'Aucun élément ne correspond aux filtres.',
     'status.syncCompleted': 'Sync finished: {succeeded} succeeded, {failed} failed',
+    'ui.expand': 'Développer',
+    'ui.collapse': 'Réduire',
+    'ui.peek': 'Aperçu',
+    'ui.filters': 'Filtres',
+    'ui.stop': 'Arrêter',
+    'ui.nextSection': 'Section suivante',
+    'ui.prevSection': 'Section précédente',
   },
 }

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -743,5 +743,12 @@ export const jaJP: LanguagePack = {
     'ui.homeStartHint': 'フォルダーを参照するか、2 つの項目をここにドロップします。',
     'ui.noFilteredRows': '現在のフィルターに一致する項目はありません。',
     'status.syncCompleted': 'Sync finished: {succeeded} succeeded, {failed} failed',
+    'ui.expand': '展開',
+    'ui.collapse': '折りたたみ',
+    'ui.peek': 'ピーク',
+    'ui.filters': 'フィルタ',
+    'ui.stop': '停止',
+    'ui.nextSection': '次のセクション',
+    'ui.prevSection': '前のセクション',
   },
 }

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -739,5 +739,12 @@ export const koKR: LanguagePack = {
     'ui.homeStartHint': '폴더를 찾아보거나 두 항목을 여기에 놓으세요.',
     'ui.noFilteredRows': '현재 필터와 일치하는 항목이 없습니다.',
     'status.syncCompleted': 'Sync finished: {succeeded} succeeded, {failed} failed',
+    'ui.expand': '펼치기',
+    'ui.collapse': '접기',
+    'ui.peek': '미리보기',
+    'ui.filters': '필터',
+    'ui.stop': '중지',
+    'ui.nextSection': '다음 섹션',
+    'ui.prevSection': '이전 섹션',
   },
 }

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -723,5 +723,12 @@ export const zhCN: LanguagePack = {
     'ui.homeStartHint': '浏览文件夹，或把两个项目拖到这里。',
     'ui.noFilteredRows': '没有符合当前筛选的项目。',
     'status.syncCompleted': '同步完成：成功 {succeeded}，失败 {failed}',
+    'ui.expand': '展开',
+    'ui.collapse': '折叠',
+    'ui.peek': '预览',
+    'ui.filters': '过滤器',
+    'ui.stop': '停止',
+    'ui.nextSection': '下一节',
+    'ui.prevSection': '上一节',
   },
 }

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -724,5 +724,12 @@ export const zhTW: LanguagePack = {
     'ui.homeStartHint': '瀏覽資料夾，或把兩個項目拖到這裡。',
     'ui.noFilteredRows': '沒有符合目前篩選的項目。',
     'status.syncCompleted': '同步完成：成功 {succeeded}，失敗 {failed}',
+    'ui.expand': '展開',
+    'ui.collapse': '摺疊',
+    'ui.peek': '預覽',
+    'ui.filters': '篩選器',
+    'ui.stop': '停止',
+    'ui.nextSection': '下一節',
+    'ui.prevSection': '上一節',
   },
 }

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -75,6 +75,58 @@ describe('AppLayout command palette', () => {
     expect(wrapper.find('[data-testid="menu-command-session.newTab"]').exists()).toBe(true)
   })
 
+  it('shows Session Actions Edit Search View Tools Help on Folder Compare', () => {
+    routePath = '/compare/folder'
+    const wrapper = mountAppLayout()
+    const menuOrder = [
+      'menu-session',
+      'menu-actions',
+      'menu-edit',
+      'menu-search',
+      'menu-view',
+      'menu-tools',
+      'menu-help',
+    ]
+
+    expect(
+      wrapper
+        .findAll('.menus > .menu-group > button')
+        .map((node) => node.attributes('data-testid')),
+    ).toEqual(menuOrder)
+    expect(wrapper.find('[data-testid="menu-file"]').exists()).toBe(false)
+  })
+
+  it('shows Session File Edit Search View Tools Help on Text Compare', () => {
+    routePath = '/compare/text'
+    const wrapper = mountAppLayout()
+
+    expect(wrapper.find('[data-testid="menu-session"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-file"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-edit"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-search"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-view"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-tools"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-help"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-actions"]').exists()).toBe(false)
+  })
+
+  it('formats window title with path pair when the active tab has known paths', async () => {
+    routePath = '/compare/text'
+    const wrapper = mountAppLayout()
+    const tabs = useTabsStore()
+
+    tabs.openTab({
+      title: 'Text Compare',
+      titleKey: 'ui.textCompare',
+      route: '/compare/text',
+      dirty: false,
+    })
+    tabs.setTabTitle('/compare/text', 'left.txt <--> right.txt')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.brand').text()).toContain('left.txt <--> right.txt - Text Compare')
+  })
+
   it('does not show hardcoded fake session counts in the chrome', () => {
     const wrapper = mountAppLayout()
 

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -92,7 +92,7 @@ onMounted(() => {
 
       const sessionType = launch.sessionType as SessionType
       const kind = sessionType === 'folder-compare' ? 'directory' : 'file'
-      const title = `${launch.left.split(/[/\\]/).pop() ?? launch.left} vs ${launch.right.split(/[/\\]/).pop() ?? launch.right}`
+      const title = `${launch.left.split(/[/\\]/).pop() ?? launch.left} <--> ${launch.right.split(/[/\\]/).pop() ?? launch.right}`
 
       sessionLaunch.setPendingLaunch({
         id: crypto.randomUUID(),
@@ -285,13 +285,22 @@ const localizedStatusSegments = computed(() => [
 ])
 const windowTitle = computed(() => {
   if (route.path === '/') {
-    return 'Home - Beyond Compare'
+    return 'Home - OpenDiff'
   }
 
   const entry = sessionCatalog.find((item) => item.route === route.path)
-  const title = entry ? t(entry.titleKey) : t('app.brand')
+  const sessionName = entry ? t(entry.titleKey) : t('app.brand')
+  const active = tabs.activeTab
+  const pathPairTitle =
+    active.route === route.path && !active.titleKey && active.title.includes('<-->')
+      ? active.title
+      : undefined
 
-  return `${title} - Beyond Compare`
+  if (pathPairTitle) {
+    return `${pathPairTitle} - ${sessionName} - OpenDiff`
+  }
+
+  return `${sessionName} - OpenDiff`
 })
 
 function navigate(nextRoute: string, title: string, titleKey?: string): void {

--- a/src/stores/tabs.ts
+++ b/src/stores/tabs.ts
@@ -123,6 +123,19 @@ export const useTabsStore = defineStore('tabs', () => {
     return true
   }
 
+  function setTabTitle(idOrRoute: string, title: string): boolean {
+    const tab = tabs.value.find((item) => item.id === idOrRoute || item.route === idOrRoute)
+
+    if (!tab || tab.id === 'home') {
+      return false
+    }
+
+    tab.title = title
+    tab.titleKey = undefined
+
+    return true
+  }
+
   function workspaceSnapshot(): WorkspaceTabsSnapshot {
     return {
       tabs: tabs.value.map((tab) => ({ ...tab })),
@@ -155,6 +168,7 @@ export const useTabsStore = defineStore('tabs', () => {
     closeOtherTabs,
     closeTabsToTheRight,
     setTabDirty,
+    setTabTitle,
     workspaceSnapshot,
     restoreWorkspaceTabs,
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -239,8 +239,13 @@ select {
   box-shadow: inset 0 0 0 1px #89bdea;
 }
 
-.bc-toolbar-command:hover {
+.bc-toolbar-command:hover:not(:disabled) {
   background: #dceeff;
+}
+
+.bc-toolbar-command:disabled {
+  cursor: default;
+  opacity: 0.45;
 }
 
 .bc-toolbar-glyph {

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -166,6 +166,42 @@ describe('FolderCompareView', () => {
     vi.clearAllMocks()
   })
 
+  it('renders the Folder Compare session toolbar order', () => {
+    const wrapper = mountFolderCompareView()
+    const ids = [
+      'home',
+      'all',
+      'same',
+      'minor',
+      'rules',
+      'copy',
+      'expand',
+      'collapse',
+      'select',
+      'files',
+      'refresh',
+      'swap',
+      'stop',
+      'filters',
+      'peek',
+    ]
+
+    expect(wrapper.find('[data-testid="folder-session-toolbar-bar"]').exists()).toBe(true)
+    expect(
+      wrapper
+        .findAll('[data-testid^="folder-session-toolbar-"]')
+        .filter((node) => node.attributes('data-testid') !== 'folder-session-toolbar-bar')
+        .map((node) => node.attributes('data-testid')?.replace('folder-session-toolbar-', '')),
+    ).toEqual(ids)
+    expect(
+      wrapper.find('[data-testid="folder-session-toolbar-minor"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(
+      wrapper.find('[data-testid="folder-session-toolbar-peek"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(wrapper.html()).not.toContain('未实现')
+  })
+
   it('does not render a demo folder tree before a real compare', () => {
     const wrapper = mountFolderCompareView()
 

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -15,6 +15,7 @@ import { createChildCompareLaunch } from '@/app/childSession'
 import { pickNativePath } from '@/app/filePicker'
 import { formatCompareError } from '@/app/compareError'
 import { loadFolderDisplayFilters, saveFolderDisplayFilters } from '@/app/folderDisplayFilters'
+import { buildFolderCompareToolbar, pathPairTitle } from '@/app/sessionToolbars'
 import {
   changeFolderEntryAttributes,
   compareFolderPaths,
@@ -155,6 +156,7 @@ function applyFolderLaunch(
 ): void {
   leftRoot.value = launch.locations.left?.uri ?? leftRoot.value
   rightRoot.value = launch.locations.right?.uri ?? rightRoot.value
+  syncFolderTabTitle()
 
   if (launch.autoRun && launch.locations.left?.uri && launch.locations.right?.uri) {
     void runFolderCompare()
@@ -186,6 +188,10 @@ watch(
     }
   },
 )
+
+watch([leftRoot, rightRoot], () => {
+  syncFolderTabTitle()
+})
 
 const summary = computed(() => ({
   total: rows.value.length,
@@ -398,6 +404,93 @@ function expandAllFolders(): void {
 
 function collapseAllFolders(): void {
   expandedDirectoryIds.value = new Set()
+}
+
+function swapFolderRoots(): void {
+  const nextLeft = rightRoot.value
+
+  rightRoot.value = leftRoot.value
+  leftRoot.value = nextLeft
+  syncFolderTabTitle()
+}
+
+function showAllFolderStatuses(): void {
+  visibleStatuses.value = new Set(['Same', 'Different', 'Left only', 'Right only'])
+  persistDisplayFilters()
+}
+
+function showSameFolderStatuses(): void {
+  visibleStatuses.value = new Set(['Same'])
+  persistDisplayFilters()
+}
+
+function syncFolderTabTitle(): void {
+  if (!leftRoot.value || !rightRoot.value) {
+    return
+  }
+
+  tabs.setTabTitle('/compare/folder', pathPairTitle(leftRoot.value, rightRoot.value))
+}
+
+function goHomeFromFolder(): void {
+  tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+  void router.push('/')
+}
+
+const folderSessionToolbar = computed(() =>
+  buildFolderCompareToolbar({
+    home: true,
+    all: true,
+    same: true,
+    minor: false,
+    rules: false,
+    copy: Boolean(selectedFilePath.value),
+    expand: true,
+    collapse: true,
+    select: false,
+    files: false,
+    refresh: Boolean(leftRoot.value && rightRoot.value) && !folderCompareLoading.value,
+    swap: Boolean(leftRoot.value || rightRoot.value),
+    stop: folderCompareLoading.value,
+    filters: false,
+    peek: false,
+  }),
+)
+
+function runFolderToolbarCommand(commandId: string): void {
+  switch (commandId) {
+    case 'home':
+      goHomeFromFolder()
+      break
+    case 'all':
+      showAllFolderStatuses()
+      break
+    case 'same':
+      showSameFolderStatuses()
+      break
+    case 'copy':
+      if (selectedFilePath.value) {
+        copySelectedTo('Right')
+      }
+      break
+    case 'expand':
+      expandAllFolders()
+      break
+    case 'collapse':
+      collapseAllFolders()
+      break
+    case 'refresh':
+      void runFolderCompare()
+      break
+    case 'swap':
+      swapFolderRoots()
+      break
+    case 'stop':
+      cancelFolderCompare()
+      break
+    default:
+      break
+  }
 }
 
 function isExpanded(row: FolderTreeRow): boolean {
@@ -1142,6 +1235,9 @@ onUnmounted(() => {
     :eyebrow="$t('ui.folder')"
     :subtitle="`${leftRoot} -> ${rightRoot}`"
     :inspector-label="$t('ui.folderCompareInspector')"
+    :toolbar-commands="folderSessionToolbar"
+    toolbar-test-id-prefix="folder-session-toolbar"
+    @toolbar-command="runFolderToolbarCommand"
   >
     <section class="folder-compare-view">
       <header class="folder-toolbar">

--- a/src/views/TextCompareView.test.ts
+++ b/src/views/TextCompareView.test.ts
@@ -9,6 +9,12 @@ import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useStatusBarStore } from '@/stores/statusBar'
 import type { TextDiffRequest } from '@/types/diff'
 
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
 vi.mock('@/api/diff', () => ({
   diffText: vi.fn().mockResolvedValue({
     lines: [],
@@ -90,6 +96,54 @@ describe('TextCompareView', () => {
     setActivePinia(createPinia())
     vi.mocked(diffText).mockClear()
     vi.mocked(readTextFile).mockClear()
+  })
+
+  it('renders the Text Compare session toolbar order', () => {
+    const wrapper = mountTextCompareView()
+    const ids = [
+      'home',
+      'all',
+      'diffs',
+      'same',
+      'context',
+      'minor',
+      'rules',
+      'copy',
+      'next-section',
+      'prev-section',
+      'swap',
+      'reload',
+    ]
+
+    expect(wrapper.find('[data-testid="text-session-toolbar-bar"]').exists()).toBe(true)
+    expect(
+      wrapper
+        .findAll('[data-testid^="text-session-toolbar-"]')
+        .filter((node) => node.attributes('data-testid') !== 'text-session-toolbar-bar')
+        .map((node) => node.attributes('data-testid')?.replace('text-session-toolbar-', '')),
+    ).toEqual(ids)
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-same"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-rules"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(wrapper.html()).not.toContain('未实现')
+  })
+
+  it('swaps paths from the session toolbar', async () => {
+    const wrapper = mountTextCompareView()
+
+    await wrapper.find('[data-testid="text-left-path"]').setValue('D:/left.txt')
+    await wrapper.find('[data-testid="text-right-path"]').setValue('D:/right.txt')
+    await wrapper.find('[data-testid="text-session-toolbar-swap"]').trigger('click')
+
+    expect((wrapper.find('[data-testid="text-left-path"]').element as HTMLInputElement).value).toBe(
+      'D:/right.txt',
+    )
+    expect(
+      (wrapper.find('[data-testid="text-right-path"]').element as HTMLInputElement).value,
+    ).toBe('D:/left.txt')
   })
 
   it('passes the selected algorithm when running a diff', async () => {

--- a/src/views/TextCompareView.vue
+++ b/src/views/TextCompareView.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watchEffect } from 'vue'
+import { computed, onMounted, ref, watch, watchEffect } from 'vue'
+import { useRouter } from 'vue-router'
 import { diffText, exportTextCompareReport, readTextFile } from '@/api/diff'
 import { useStatusBarStore } from '@/stores/statusBar'
 import { useLastCompareStore } from '@/stores/lastCompare'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 import type { TextDiffAlgorithm, TextDiffRequest, TextDiffResponse } from '@/types/diff'
 import TextDiffPanel from '@/components/diff/TextDiffPanel.vue'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
@@ -14,6 +16,7 @@ import { useI18n } from '@/i18n'
 import { grammarForPath } from '@/app/syntaxGrammars'
 import { pickNativePath } from '@/app/filePicker'
 import { formatCompareError } from '@/app/compareError'
+import { buildTextCompareToolbar, pathPairTitle } from '@/app/sessionToolbars'
 
 type DiffLine = TextDiffResponse['lines'][number]
 
@@ -24,6 +27,8 @@ const rightPathLabel = ref('')
 const statusBar = useStatusBarStore()
 const sessionLaunch = useSessionLaunchStore()
 const lastCompare = useLastCompareStore()
+const tabs = useTabsStore()
+const router = useRouter()
 const { t } = useI18n()
 const algorithm = ref<TextDiffAlgorithm>('myers')
 const ignoreWhitespace = ref(false)
@@ -494,6 +499,16 @@ function goToNextDiff(): void {
   currentDiffIndex.value = Math.min(currentDiffIndex.value + 1, activeDiffRows.value.length - 1)
 }
 
+function goToPreviousDiff(): void {
+  if (activeDiffRows.value.length === 0) {
+    currentDiffIndex.value = 0
+
+    return
+  }
+
+  currentDiffIndex.value = Math.max(currentDiffIndex.value - 1, 0)
+}
+
 function ignoreCurrentDiff(): void {
   if (activeDiffRows.value.length === 0) {
     return
@@ -630,6 +645,80 @@ function closeHtmlPreviewWhenUnavailable(): void {
   }
 }
 
+const textDiffPanelRef = ref<{
+  setDisplayMode: (mode: 'all' | 'differences') => void
+} | null>(null)
+
+function syncTextTabTitle(): void {
+  if (!leftPathLabel.value || !rightPathLabel.value) {
+    return
+  }
+
+  tabs.setTabTitle('/compare/text', pathPairTitle(leftPathLabel.value, rightPathLabel.value))
+}
+
+function goHomeFromText(): void {
+  tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+  void router.push('/')
+}
+
+const textSessionToolbar = computed(() =>
+  buildTextCompareToolbar({
+    home: true,
+    all: true,
+    diffs: true,
+    same: false,
+    context: false,
+    minor: false,
+    rules: false,
+    copy: Boolean(result.value) && activeDiffRows.value.length > 0,
+    'next-section': activeDiffRows.value.length > 0,
+    'prev-section': activeDiffRows.value.length > 0,
+    swap: Boolean(leftPathLabel.value || rightPathLabel.value || left.value || right.value),
+    reload:
+      Boolean(leftPathLabel.value && rightPathLabel.value) || Boolean(left.value || right.value),
+  }),
+)
+
+function runTextToolbarCommand(commandId: string): void {
+  switch (commandId) {
+    case 'home':
+      goHomeFromText()
+      break
+    case 'all':
+      textDiffPanelRef.value?.setDisplayMode('all')
+      break
+    case 'diffs':
+      textDiffPanelRef.value?.setDisplayMode('differences')
+      break
+    case 'copy':
+      copyCurrentDiff('leftToRight')
+      break
+    case 'next-section':
+      goToNextDiff()
+      break
+    case 'prev-section':
+      goToPreviousDiff()
+      break
+    case 'swap':
+      swapPaths()
+      break
+    case 'reload':
+      if (leftPathLabel.value && rightPathLabel.value) {
+        void loadLaunchTextFiles(leftPathLabel.value, rightPathLabel.value)
+      } else {
+        void runDiff()
+      }
+      break
+    default:
+      break
+  }
+}
+
+watch([leftPathLabel, rightPathLabel], () => {
+  syncTextTabTitle()
+})
+
 function toggleSourceEditors(): void {
   showSourceEditors.value = !showSourceEditors.value
 }
@@ -643,6 +732,9 @@ function toggleSourceEditors(): void {
     :subtitle="statsLabel"
     :inspector-label="$t('ui.textCompareInspector')"
     data-testid="text-workbench"
+    :toolbar-commands="textSessionToolbar"
+    toolbar-test-id-prefix="text-session-toolbar"
+    @toolbar-command="runTextToolbarCommand"
   >
     <template #title-actions>
       <span class="stats">{{ statsLabel }}</span>
@@ -1020,6 +1112,7 @@ function toggleSourceEditors(): void {
 
       <TextDiffPanel
         v-if="result"
+        ref="textDiffPanelRef"
         :lines="result.lines"
         :grammar="grammarForPath(leftPathLabel || rightPathLabel)"
       />


### PR DESCRIPTION
## Summary
- Folder Compare and Text Compare get session menu bars (Session/Actions/... vs Session/File/...) and ordered session toolbars with existing actions wired and stubs disabled (no 「未实现」).
- Window/tab titles use `left <--> right - {session}` when paths are known; chrome product suffix is OpenDiff; i18n keys added across locale packs.
- Unit tests cover toolbar order/presence, menu sets, path-pair titles; Sync/Merge execution and deep file ops stay deferred (later file operations).

## Matched
- Folder menus: Session, Actions, Edit, Search, View, Tools, Help
- Folder toolbar order: Home, All, Same, Minor, Rules, Copy, Expand, Collapse, Select, Files, Refresh, Swap, Stop, Filters, Peek
- Text menus: Session, File, Edit, Search, View, Tools, Help
- Text toolbar order: Home, All, Diffs, Same, Context, Minor, Rules, Copy, Next Section, Prev Section, Swap, Reload
- Wired where present: Home, All/Same (folder filters), Expand/Collapse, Refresh, Swap, Stop, Copy (selection), Text All/Diffs/Copy/Next/Prev/Swap/Reload
- Disabled stubs: Minor, Rules, Select, Files, Filters, Peek, Text Same/Context/etc.
- Path-pair titles + i18n + vitest on touched files

## Deferred
- Sync/Merge execution and deep file ops (later file operations)
- Full semantic parity for Rules/Filters/Peek/Select/Files/Context/Same on text
- Other session types' toolbars (Table/Hex/…)

## Test plan
- [x] vitest on sessionToolbars, AppLayout, FolderCompareView, TextCompareView, dropLaunch, language skeletons
- [x] prettier/eslint/stylelint/vue-tsc on changed tree
- [ ] Manual: open Folder/Text Compare, confirm menu order and toolbar labels
- [ ] Manual: set both paths and confirm left <--> right OpenDiff chrome title