### PR TITLE
Harden Folder Compare real file ops

### DIFF
--- a/docs/Beyond Compare 5 当前项目实现对照审计.md
+++ b/docs/Beyond Compare 5 当前项目实现对照审计.md
@@ -102,10 +102,10 @@
 
 ### Folder Compare 偏差
 
-- 初始列表包含 180 条硬编码 `generatedRows` 演示数据，未运行真实比较前会显示假文件树。
-- Copy、Delete、Rename、属性修改、Touch、Quick Compare、Compare To、Open、Open With、报告、同步预览等很多按钮只更新本地状态文本或打开面板，没有调用真实文件操作。
-- 后端 `folder-core` 虽有复制、移动、删除、重命名等函数，但没有通过 Tauri command 和前端 API 暴露给 Folder Compare UI。
-- 目标截图中的路径栏、列布局、工具栏按钮、文件/文件夹操作菜单和 Beyond Compare 操作语义没有完整复刻。
+- （2026-09-06）初始演示树已移除，未比较前显示空态。
+- Copy / Move / Rename / Delete / Attributes / Touch 已接 Tauri 与前端 API，并在失败时显示错误；目录项也可 Rename / Delete / Move。
+- Open / Compare To / Quick Compare 打开子比较会话；Open With / Associated App 调用外部程序；报告导出与同步预览已接真实命令。
+- Align With / Break Alignment 仍未实现（按钮禁用，无「未实现」文案）。远程/归档一侧、对齐覆盖持久化、完整工具栏语义仍缺。
 
 ### Folder Sync 偏差
 
@@ -132,12 +132,12 @@
 
 ### Hex Compare 偏差
 
-- 默认初始字节是硬编码 A-Z 示例。
+- （2026-09-06）初始不再显示 A–Z 演示字节；未比较前为空态。仍缺完整浏览/跳转与部分工具栏语义。
 - 前端每次只请求 `offset: 0, length: 256`，没有实现完整文件浏览、跳转 offset、差异导航、复制、规则、Reload、Swap 等目标功能。
 
 ### Picture Compare 偏差
 
-- 初始元数据和统计是硬编码示例。
+- （2026-09-06）初始元数据/统计为空，需运行比较后填充。
 - overlay 是前端视觉层，未看到目标软件的 `Tol / Range / Blend / Meta` 规则与容差模型完整实现。
 - 没有目标截图中的专属工具栏语义、差异范围控制、容差规则编辑和报告/保存能力。
 
@@ -145,19 +145,19 @@
 
 - 当前只能比较 `.reg` 文本导出，不支持直接连接/浏览 Windows 注册表 hive 并编辑。
 - 没有 Copy、Next Diff、Prev Diff、Swap、Reload、Expand、Collapse 的完整命令实现。
-- 初始 registry tree 是硬编码示例。
+- （2026-09-06）初始 registry tree 为空，需加载导出后填充。
 
 ### Media Compare 偏差
 
 - 当前聚焦元数据字段比较，没有媒体播放、双侧播放控制、前滚/后滚、流选择、规则/重要性设置等。
 - 目标截图记录 `Play2`、前滚/后滚等工具栏按钮，当前未实现对应行为。
-- 初始媒体信息是硬编码示例。
+- （2026-09-06）初始媒体信息为空，需运行比较后填充。
 
 ### Version Compare 偏差
 
 - 当前仅 Windows 支持版本资源读取，非 Windows 返回 unsupported。
 - 没有目标工具栏的 All/Diffs/Same/Minor/Rules/Next/Prev/Swap/Reload，也没有重要性规则配置。
-- 初始版本字段是硬编码示例。
+- （2026-09-06）初始版本字段为空，需运行比较后填充。
 
 ### Text Edit 偏差
 
@@ -216,9 +216,8 @@
 
 ### Folder Compare
 
-- 未实现真实 Copy / Move / Rename / Delete / Attributes / Touch 等 UI 操作调用。
-- 未实现 Quick Compare、Compare To、Open With、文件比较报告的真实工作流。
-- 未实现 Filters、Peek、Select、Files 菜单、Stop/cancel 作业等目标命令。
+- Copy / Move / Rename / Delete / Attributes / Touch 的 UI→Tauri 调用已接通；Align With / Break Alignment 仍未实现。
+- Quick Compare、Compare To、Open / Open With、文件夹报告导出已有真实工作流；Filters / Peek / Select / Files 菜单仍不完整。
 - 未实现高级对齐覆盖持久化和真正影响后续比较。
 - 未实现名称过滤、其他过滤、处理规则、比较规则、符号链接/权限/时间戳策略等完整设置。
 

--- a/docs/项目完成度报表.md
+++ b/docs/项目完成度报表.md
@@ -101,12 +101,12 @@ Dependabot 五条分支相对**当前** master 为 ahead 1 / behind 8（diverged
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Folder Sync 只有预览，没有执行              | **过时**。`FolderSyncView` → `executeFolderSync` → Tauri `execute_folder_sync`                                |
 | Folder Merge 只有计划，没有输出             | **过时**。`execute_folder_merge_plan` 已注册并写入输出目录                                                    |
-| Folder Compare 文件操作未暴露到 Tauri       | **部分过时**。Copy / Rename / Delete / Attributes / Touch 已接；Move / Quick Compare / Compare To / Open 仍假 |
+| Folder Compare 文件操作未暴露到 Tauri       | **过时**。Copy / Move / Rename / Delete / Attributes / Touch 已接；Open / Quick Compare / Compare To 打开子会话 |
 | Home 快捷入口只有 4 个                      | **过时**。`HomeView` 现有约 12 种 `quickStartTypes`                                                           |
 | 会话目录全部 `implemented: true`            | **仍准确**。`src/app/sessionCatalog.ts` 15 项全 true                                                          |
 | Text Merge 硬编码冲突                       | **仍准确**                                                                                                    |
 | Remote / Archive / Reports / Git 未真实实现 | **仍准确**                                                                                                    |
-| 大量初始演示数据                            | **仍准确**                                                                                                    |
+| 大量初始演示数据                            | **部分过时**。Folder / Hex / Picture / Registry / Media / Version / Table / Text 初始空态；Home 与部分会话仍有示例 |
 
 **建议（产品）：** 以当前已含 `ui` 的 `master` 继续开发；把 BC5 审计里过时的 Sync/Merge/入口段落更新，避免下一次审计再被旧结论误导。
 
@@ -146,7 +146,7 @@ Dependabot 五条分支相对**当前** master 为 ahead 1 / behind 8（diverged
 - `folder-core` 体量大（约 1700+ 行），含 CRC/二进制比较、过滤模型、报告 HTML/XML/文本渲染。
 - `ui` 合入后：Copy / Rename / Delete / Attributes / Touch 有确认并调 Tauri。
 
-缺口：初始 `generatedRows`（约 180 条演示树）在未比较前就会显示；Move / Quick Compare / Compare To / Open 只改状态文案，**不打开 Text Compare、不调外部程序**；对齐覆盖只在前端；无远程/归档一侧。
+缺口（2026-09-06 复核）：初始演示树与假路径已清除，未比较前为空态；Copy / Move / Rename / Delete / Attributes / Touch 经 Tauri 真实落盘，失败会显示错误；Open / Compare To / Quick Compare 会打开子比较会话；Open With 调外部程序。仍缺：Align With / Break Alignment（按钮已禁用）、远程/归档一侧、对齐覆盖持久化。
 
 **Folder Sync**
 
@@ -191,7 +191,7 @@ Dependabot 五条分支相对**当前** master 为 ahead 1 / behind 8（diverged
 - 前端固定 `offset: 0, length: 256`，无全文件浏览/跳转。
 - Tauri 用 `fs::read` **整文件载入**，与 crate「按块读」能力不一致。
 - 查找/替换/保存未接到 UI。
-- 初始 A–Z 硬编码示例。
+- （2026-09-06）初始空态，不再显示 A–Z 演示字节。
 
 ### 3.5 Image — 部分完成
 
@@ -408,8 +408,8 @@ README Core Features 写 “designed to support” — 对 UI 而言就是未完
 
 1. **分支：** 保留 `ui` 与全部 Dependabot；不要再删未合并或用户点名保留的分支。当前 master 已含 `ui`，后续功能 PR 请基于 `73e8801`。
 2. **诚实标注：** 把 `sessionCatalog.implemented` 改成真实状态（至少 Text Merge、Reports、Remote 不能再标完成）。
-3. **去掉或隔离演示数据：** Folder Compare `generatedRows`、各视图硬编码左右内容，避免「打开即完成」的错觉。
-4. **补假按钮或禁用：** Folder Compare 的 Quick Compare / Compare To / Move / Open；Text Edit 工具栏；Remote「测试连接」。
+3. **去掉或隔离演示数据：** Folder Compare 演示树与多数比较会话初始假数据已清；继续清 Home / Reports 等剩余示例。
+4. **补假按钮或禁用：** Folder Compare Align With 已禁用；继续处理 Text Edit 工具栏、Remote「测试连接」等。
 5. **Text Merge：** 要么接 `merge-core` + 读三路文件，要么入口标未实现。
 6. **Picture：** 用真实图像渲染替换 CSS 渐变。
 7. **Table：** 若 README 继续写 Excel/TSV，必须把 `table-core` 能力接到 command/UI。

--- a/docs/项目完成度报表.md
+++ b/docs/项目完成度报表.md
@@ -97,15 +97,15 @@ Dependabot 五条分支相对**当前** master 为 ahead 1 / behind 8（diverged
 
 ### 2.1 BC5 审计文档 vs 当前 `master`（含 `ui`）
 
-| BC5 审计原文                                | 当前源码核实                                                                                                  |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Folder Sync 只有预览，没有执行              | **过时**。`FolderSyncView` → `executeFolderSync` → Tauri `execute_folder_sync`                                |
-| Folder Merge 只有计划，没有输出             | **过时**。`execute_folder_merge_plan` 已注册并写入输出目录                                                    |
-| Folder Compare 文件操作未暴露到 Tauri       | **过时**。Copy / Move / Rename / Delete / Attributes / Touch 已接；Open / Quick Compare / Compare To 打开子会话 |
-| Home 快捷入口只有 4 个                      | **过时**。`HomeView` 现有约 12 种 `quickStartTypes`                                                           |
-| 会话目录全部 `implemented: true`            | **仍准确**。`src/app/sessionCatalog.ts` 15 项全 true                                                          |
-| Text Merge 硬编码冲突                       | **仍准确**                                                                                                    |
-| Remote / Archive / Reports / Git 未真实实现 | **仍准确**                                                                                                    |
+| BC5 审计原文                                | 当前源码核实                                                                                                       |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Folder Sync 只有预览，没有执行              | **过时**。`FolderSyncView` → `executeFolderSync` → Tauri `execute_folder_sync`                                     |
+| Folder Merge 只有计划，没有输出             | **过时**。`execute_folder_merge_plan` 已注册并写入输出目录                                                         |
+| Folder Compare 文件操作未暴露到 Tauri       | **过时**。Copy / Move / Rename / Delete / Attributes / Touch 已接；Open / Quick Compare / Compare To 打开子会话    |
+| Home 快捷入口只有 4 个                      | **过时**。`HomeView` 现有约 12 种 `quickStartTypes`                                                                |
+| 会话目录全部 `implemented: true`            | **仍准确**。`src/app/sessionCatalog.ts` 15 项全 true                                                               |
+| Text Merge 硬编码冲突                       | **仍准确**                                                                                                         |
+| Remote / Archive / Reports / Git 未真实实现 | **仍准确**                                                                                                         |
 | 大量初始演示数据                            | **部分过时**。Folder / Hex / Picture / Registry / Media / Version / Table / Text 初始空态；Home 与部分会话仍有示例 |
 
 **建议（产品）：** 以当前已含 `ui` 的 `master` 继续开发；把 BC5 审计里过时的 Sync/Merge/入口段落更新，避免下一次审计再被旧结论误导。

--- a/src/api/diff.test.ts
+++ b/src/api/diff.test.ts
@@ -17,6 +17,7 @@ import {
   exportTextCompareReport,
   findHexInFile,
   mergeTextFiles,
+  createFolderSnapshot,
   moveFolderEntry,
   renameFolderEntry,
   saveHexEdits,
@@ -530,6 +531,22 @@ describe('diff api', () => {
       sourcePath: 'C:/work/main.ts',
       patch: 'diff',
       outputPath: 'C:/work/main.patched.ts',
+    })
+  })
+
+  it('creates a folder snapshot through the Tauri command contract', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce('/tmp/snap.json')
+
+    await createFolderSnapshot({
+      sourceRoot: 'D:/left',
+      outputPath: '/tmp/snap.json',
+      name: 'left-snap',
+    })
+
+    expect(invoke).toHaveBeenCalledWith('create_folder_snapshot', {
+      sourceRoot: 'D:/left',
+      outputPath: '/tmp/snap.json',
+      name: 'left-snap',
     })
   })
 })

--- a/src/api/diff.ts
+++ b/src/api/diff.ts
@@ -244,6 +244,18 @@ export function moveFolderEntry(
   })
 }
 
+export function createFolderSnapshot(request: {
+  sourceRoot: string
+  outputPath: string
+  name?: string
+}): Promise<string> {
+  return invoke<string>('create_folder_snapshot', {
+    sourceRoot: request.sourceRoot,
+    outputPath: request.outputPath,
+    name: request.name,
+  })
+}
+
 export function applyTextPatch(request: ApplyTextPatchRequest): Promise<ApplyTextPatchResponse> {
   return invoke<ApplyTextPatchResponse>('apply_text_patch', {
     source: request.source,

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -453,6 +453,64 @@ describe('FolderCompareView', () => {
     expect(launchStore.pendingLaunch).toBeUndefined()
   })
 
+  it('disables export and sync preview until both roots are set', () => {
+    const wrapper = mountFolderCompareView()
+
+    expect(
+      wrapper.find('[data-testid="export-folder-html-report"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(wrapper.find('[data-testid="preview-sync-plan"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('surfaces copy failures instead of leaving a hanging confirmation', async () => {
+    vi.mocked(copyFolderCompareEntry).mockRejectedValueOnce(new Error('disk full'))
+    const wrapper = mountFolderCompareView()
+
+    await runCompare(wrapper)
+    await wrapper.find('[data-row-id="src-main-ts"]').trigger('click')
+    await wrapper.find('[data-testid="copy-selected-to-right"]').trigger('click')
+    await wrapper.find('[data-testid="confirm-folder-copy"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="folder-compare-error"]').text()).toContain('disk full')
+    expect(wrapper.find('[data-testid="folder-copy-confirmation"]').exists()).toBe(true)
+  })
+
+  it('refreshes the tree after touch and enables directory rename/delete/move', async () => {
+    const wrapper = mountFolderCompareView()
+
+    await runCompare(wrapper)
+    vi.mocked(compareFolderPaths).mockClear()
+
+    await wrapper.find('[data-row-id="readme-md"]').trigger('click')
+    await wrapper.find('[data-testid="touch-selected-file"]').trigger('click')
+    await flushPromises()
+
+    expect(touchFolderEntry).toHaveBeenCalled()
+    expect(compareFolderPaths).toHaveBeenCalled()
+
+    await wrapper.find('[data-row-id="src"]').trigger('click')
+    expect(
+      wrapper.find('[data-testid="rename-selected-file"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="delete-selected-file"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="move-selected-file"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="copy-selected-to-right"]').attributes('disabled'),
+    ).toBeDefined()
+
+    await wrapper.find('[data-testid="move-selected-file"]').trigger('click')
+    await flushPromises()
+    expect(moveFolderEntry).toHaveBeenCalledWith({
+      sourcePath: 'D:/left/src',
+      targetPath: 'D:/left/archive/src',
+    })
+  })
+
   it('exposes full path tooltips on path inputs', async () => {
     const wrapper = mountFolderCompareView()
     const longPath = 'D:/very/long/path/to/project/left-root-directory'

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -210,6 +210,15 @@ const selectedFilePath = computed(() => {
 
   return row.leftPath ?? row.rightPath
 })
+const selectedEntryPath = computed(() => {
+  const row = selectedRow.value
+
+  if (!row) {
+    return undefined
+  }
+
+  return row.leftPath ?? row.rightPath
+})
 const alignWithCandidates = computed(() =>
   rows.value.filter(
     (row) =>
@@ -791,36 +800,44 @@ async function confirmFolderCopy(): Promise<void> {
     return
   }
 
-  await copyFolderCompareEntry({
-    leftRoot: leftRoot.value,
-    rightRoot: rightRoot.value,
-    relativePath: row.relativePath,
-    direction: direction === 'Left' ? 'toLeft' : 'toRight',
-  })
-  lastCopyAction.value = t('status.copiedToSide', {
-    side: direction === 'Left' ? t('ui.left') : t('ui.right'),
-    path: confirmation.paths[0],
-  })
-  pendingCopyConfirmation.value = undefined
-  pendingCopyDirection.value = undefined
-  await runFolderCompare()
+  try {
+    await copyFolderCompareEntry({
+      leftRoot: leftRoot.value,
+      rightRoot: rightRoot.value,
+      relativePath: row.relativePath,
+      direction: direction === 'Left' ? 'toLeft' : 'toRight',
+    })
+    lastCopyAction.value = t('status.copiedToSide', {
+      side: direction === 'Left' ? t('ui.left') : t('ui.right'),
+      path: confirmation.paths[0],
+    })
+    pendingCopyConfirmation.value = undefined
+    pendingCopyDirection.value = undefined
+    await runFolderCompare()
+  } catch (error) {
+    folderCompareError.value = formatCompareError(error, t)
+  }
 }
 
 async function confirmRenameFile(): Promise<void> {
-  const path = selectedFilePath.value
+  const path = selectedEntryPath.value
 
   if (!path || !renameTargetName.value) {
     return
   }
 
-  await renameFolderEntry({ path, newName: renameTargetName.value })
-  lastFileOperationAction.value = t('status.renamedPath', { path: renameTargetName.value })
-  renamePanelOpen.value = false
-  await runFolderCompare()
+  try {
+    await renameFolderEntry({ path, newName: renameTargetName.value })
+    lastFileOperationAction.value = t('status.renamedPath', { path: renameTargetName.value })
+    renamePanelOpen.value = false
+    await runFolderCompare()
+  } catch (error) {
+    folderCompareError.value = formatCompareError(error, t)
+  }
 }
 
 async function moveSelectedFile(): Promise<void> {
-  const path = selectedFilePath.value
+  const path = selectedEntryPath.value
 
   if (!path) {
     return
@@ -828,13 +845,17 @@ async function moveSelectedFile(): Promise<void> {
 
   const targetPath = archivePath(path)
 
-  await moveFolderEntry({ sourcePath: path, targetPath })
-  lastFileOperationAction.value = `${t('ui.move')} -> ${targetPath}`
-  await runFolderCompare()
+  try {
+    await moveFolderEntry({ sourcePath: path, targetPath })
+    lastFileOperationAction.value = `${t('ui.move')} -> ${targetPath}`
+    await runFolderCompare()
+  } catch (error) {
+    folderCompareError.value = formatCompareError(error, t)
+  }
 }
 
 function deleteSelectedFile(): void {
-  const path = selectedFilePath.value
+  const path = selectedEntryPath.value
 
   if (!path) {
     return
@@ -852,38 +873,52 @@ async function confirmDangerousFileOperation(): Promise<void> {
     return
   }
 
-  await Promise.all(
-    pendingDangerousOperation.value.paths.map((path) => deleteFolderEntry({ path })),
-  )
-  lastFileOperationAction.value = pendingDangerousOperationLabel.value
-  pendingDangerousOperation.value = undefined
-  pendingDangerousOperationLabel.value = ''
-  await runFolderCompare()
+  try {
+    await Promise.all(
+      pendingDangerousOperation.value.paths.map((path) => deleteFolderEntry({ path })),
+    )
+    lastFileOperationAction.value = pendingDangerousOperationLabel.value
+    pendingDangerousOperation.value = undefined
+    pendingDangerousOperationLabel.value = ''
+    await runFolderCompare()
+  } catch (error) {
+    folderCompareError.value = formatCompareError(error, t)
+  }
 }
 
 async function toggleSelectedReadonly(selected: boolean): Promise<void> {
-  const path = selectedFilePath.value
+  const path = selectedEntryPath.value
 
   if (!path) {
     return
   }
 
-  await changeFolderEntryAttributes({ path, readonly: selected })
-  selectedReadonly.value = selected
-  lastMetadataAction.value = t('status.attributesChanged', {
-    state: selected ? 'readonly' : 'writable',
-  })
+  try {
+    await changeFolderEntryAttributes({ path, readonly: selected })
+    selectedReadonly.value = selected
+    lastMetadataAction.value = t('status.attributesChanged', {
+      state: selected ? 'readonly' : 'writable',
+    })
+    await runFolderCompare()
+  } catch (error) {
+    folderCompareError.value = formatCompareError(error, t)
+  }
 }
 
 async function touchSelectedFile(): Promise<void> {
-  const path = selectedFilePath.value
+  const path = selectedEntryPath.value
 
   if (!path) {
     return
   }
 
-  await touchFolderEntry({ path, modifiedAtMs: Date.now() })
-  lastMetadataAction.value = t('status.touchedPath', { path })
+  try {
+    await touchFolderEntry({ path, modifiedAtMs: Date.now() })
+    lastMetadataAction.value = t('status.touchedPath', { path })
+    await runFolderCompare()
+  } catch (error) {
+    folderCompareError.value = formatCompareError(error, t)
+  }
 }
 
 function excludeSelectedRow(): void {
@@ -1365,6 +1400,7 @@ onUnmounted(() => {
             size="small"
             secondary
             data-testid="export-folder-html-report"
+            :disabled="!leftRoot || !rightRoot"
             @click="exportFolderReport('html')"
             >{{ $t('ui.export') }} {{ $t('ui.html') }}</NButton
           >
@@ -1372,6 +1408,7 @@ onUnmounted(() => {
             size="small"
             secondary
             data-testid="preview-sync-plan"
+            :disabled="!leftRoot || !rightRoot"
             @click="previewSyncPlan"
             >{{ $t('ui.previewSync') }}</NButton
           >
@@ -1446,7 +1483,7 @@ onUnmounted(() => {
             size="small"
             secondary
             data-testid="move-selected-file"
-            :disabled="!selectedFilePath"
+            :disabled="!selectedEntryPath"
             @click="moveSelectedFile"
             >{{ $t('ui.move') }}</NButton
           >
@@ -1454,7 +1491,7 @@ onUnmounted(() => {
             size="small"
             secondary
             data-testid="delete-selected-file"
-            :disabled="!selectedFilePath"
+            :disabled="!selectedEntryPath"
             @click="deleteSelectedFile"
             >{{ $t('ui.delete') }}</NButton
           >
@@ -1462,7 +1499,7 @@ onUnmounted(() => {
             size="small"
             secondary
             data-testid="rename-selected-file"
-            :disabled="!selectedFilePath"
+            :disabled="!selectedEntryPath"
             @click="renameSelectedFile"
             >{{ $t('ui.rename') }}</NButton
           >
@@ -1739,7 +1776,7 @@ onUnmounted(() => {
             data-testid="toggle-selected-readonly"
             type="checkbox"
             :checked="selectedReadonly"
-            :disabled="!selectedFilePath"
+            :disabled="!selectedEntryPath"
             @change="toggleSelectedReadonly(($event.target as HTMLInputElement).checked)"
           />
           <span>{{ $t('ui.readonly') }}</span>
@@ -1748,7 +1785,7 @@ onUnmounted(() => {
           size="small"
           secondary
           data-testid="touch-selected-file"
-          :disabled="!selectedFilePath"
+          :disabled="!selectedEntryPath"
           @click="touchSelectedFile"
           >{{ $t('ui.touch') }}</NButton
         >


### PR DESCRIPTION
## Summary
- Folder Compare file ops (copy / move / rename / delete / attributes / touch) now surface failures, refresh after metadata changes, and support directory rename/delete/move while keeping copy/open file-only.
- Export report and sync preview stay disabled until both roots are set; Align With / Break Alignment remain disabled without unfinished labels.
- Exposes `create_folder_snapshot` through the frontend API; refreshes stale Folder Compare gap notes in the completion docs.

## Ops now real vs still stubbed
**Real (UI → Tauri → disk):**
- Copy Left / Copy Right
- Move (to sibling `archive/`)
- Rename
- Delete (with confirmation)
- Attributes (readonly)
- Touch
- Open / Open With / Associated App
- Quick Compare / Compare To (child session)
- Folder report export / sync preview+run

**Still stubbed / disabled:**
- Align With
- Break Alignment
- Session toolbar Minor / Rules / Filters / Peek / Select / Files
- Remote / archive folder sides
- Persistent alignment overrides

## Test plan
- [x] `vitest` FolderCompareView + diff API (29 passed)
- [x] `cargo test -p open-diff-app --lib` folder file-op / move / snapshot tests
- [x] `cargo test -p folder-core --lib` move/delete/rename + touch/attributes tests
- [ ] Manual: compare two local folders, copy/rename/delete/move a file, rename/move a directory, confirm errors show when a path is missing