### PR TITLE
Make Folder Sync, Folder Merge, and Text Merge execute for real

### DIFF
--- a/docs/Beyond Compare 5 当前项目实现对照审计.md
+++ b/docs/Beyond Compare 5 当前项目实现对照审计.md
@@ -15,9 +15,9 @@
 当前项目不是 Beyond Compare 5 UI 的高保真复刻，而是一个自有 Workbench 风格的差异比较应用。路由和会话目录几乎把所有会话类型都标为已实现，但真实完成度分层明显：
 
 - Text Compare、Folder Compare、Table Compare、Hex Compare、Picture Compare、Registry Compare、Media Compare、Version Compare 有真实后端比较调用。
-- Folder Sync 只有预览，没有执行同步。
-- Folder Merge 只有生成合并计划，没有执行输出合并。
-- Text Merge 不是实际三方合并，只是硬编码冲突示例加保存输出。
+- Folder Sync：预览 + 执行已接线（复制/删除按计划落盘；支持逐项覆盖）。
+- Folder Merge：计划 + 输出执行已接线；文件内容冲突可带路径打开 Text Merge。
+- Text Merge：可从路径加载三路文件并做行级自动合并；接受冲突后可保存输出。
 - Home、菜单栏、工具栏、会话树和大量操作按钮与 Beyond Compare 5 截图不一致。
 - 多处 UI 使用硬编码演示数据、状态提示或假操作，容易被误认为已完成。
 
@@ -115,12 +115,12 @@
 ### Folder Merge 偏差
 
 - 当前只调用 `build_folder_merge_plan` 生成计划，没有 `Merge` 或 `To Output` 的真实输出执行。
-- 点击冲突只路由到 `/merge/text`，没有传递真实冲突文件、base/left/right/output 路径，也不会打开对应三方文本合并。
+- 文件内容冲突可打开 `/merge/text` 并传递 left/base/right/output 路径；类型不兼容冲突需手工处理。
 - 目标工具栏中的 `Merge / To Output / Same OK / Rules / Filters / Peek` 等没有对应真实行为。
 
 ### Text Merge 偏差
 
-- 当前冲突、base/left/right/output 内容全部是硬编码示例。
+- 空态启动；通过 Load / 会话启动调用 `merge_text_files` 读取真实文件并做行级三路合并。
 - `acceptConflict` 只是把输出改成固定三行，没有真实 diff3 或三方合并算法。
 - 只实现了保存 output 文本，没有读取三路输入、自动识别冲突、跳转冲突、Favor Left/Favor Right、Left/Center/Right 视图同步等目标功能。
 
@@ -232,7 +232,7 @@
 
 - 未实现真实三方文件夹合并输出。
 - 未实现 Merge、To Output、Same OK 等操作。
-- 未实现冲突文件打开到真实 Text Merge。
+- 文件内容冲突可打开真实 Text Merge（含路径）；类型冲突仍需手工处理。
 - 未实现文件夹合并规则、过滤、输出目录写入、冲突标记持久化。
 
 ### Text Merge
@@ -241,7 +241,7 @@
 - 未实现真实三方 merge 算法和自动冲突检测。
 - 未实现 Favor Left、Favor Right、Conflict、Left、Center、Right、Next Conflict、Prev Conflict。
 - 未实现手动对齐多行选择。
-- 未实现从 Text Compare 或 Folder Merge 传入上下文。
+- 已支持从 Folder Merge 传入路径上下文；Text Compare 联动仍可加强。
 
 ### Table Compare
 

--- a/docs/项目完成度报表.md
+++ b/docs/项目完成度报表.md
@@ -104,7 +104,7 @@ Dependabot 五条分支相对**当前** master 为 ahead 1 / behind 8（diverged
 | Folder Compare 文件操作未暴露到 Tauri       | **过时**。Copy / Move / Rename / Delete / Attributes / Touch 已接；Open / Quick Compare / Compare To 打开子会话    |
 | Home 快捷入口只有 4 个                      | **过时**。`HomeView` 现有约 12 种 `quickStartTypes`                                                                |
 | 会话目录全部 `implemented: true`            | **仍准确**。`src/app/sessionCatalog.ts` 15 项全 true                                                               |
-| Text Merge 硬编码冲突                       | **仍准确**                                                                                                         |
+| Text Merge 硬编码冲突                       | **过时**。`TextMergeView` → `mergeTextFiles` / `saveTextFile`；接受左右/base 后可保存到输出路径                    |
 | Remote / Archive / Reports / Git 未真实实现 | **仍准确**                                                                                                         |
 | 大量初始演示数据                            | **部分过时**。Folder / Hex / Picture / Registry / Media / Version / Table / Text 初始空态；Home 与部分会话仍有示例 |
 
@@ -151,18 +151,20 @@ Dependabot 五条分支相对**当前** master 为 ahead 1 / behind 8（diverged
 **Folder Sync**
 
 - 路由：`/sync/folder`
-- `preview_folder_sync` + `execute_folder_sync` 真实存在。
+- `preview_folder_sync` + `execute_folder_sync` 真实存在（复制/删除按预览计划落盘；冲突项默认跳过）。
 - 策略：updateRight / updateLeft / updateBoth / mirrorRight / mirrorLeft。
+- UI 支持逐项 Leave / 双向复制 / 删除覆盖并随 `execute_folder_sync` 提交。
 
-缺口：无逐项 Leave/反向复制/删除覆盖；无 Accept/Cancel 工作流；默认路径是占位符。BC5 审计「无执行」对 **当前 master 已不成立**。
+缺口：无完整 Accept/Cancel 会话工作流；无远程/归档一侧。
 
 **Folder Merge**
 
 - 路由：`/merge/folder`
-- `build_folder_merge_plan` + `execute_folder_merge_plan`。
-- `folder-merge-core` 做结构计划（Keep / CopyLeft / CopyRight / Delete / MarkConflict）。
+- `build_folder_merge_plan` + `execute_folder_merge_plan` 会把安全的自动动作写到输出目录。
+- `folder-merge-core`：结构计划 + **文件内容指纹**（同路径双方改写则 MarkConflict）。
+- 文件内容冲突可打开 `/merge/text`，并传入 left/base/right/output 真实路径。
 
-缺口：冲突点进 `/merge/text` **不传路径**；合并是路径级复制/删除，不是文件内容三方合并。
+缺口：目录/类型不兼容冲突需手工处理；不是 Myers/diff3 块级文件夹内容合并；无远程一侧。
 
 ### 3.3 Table — 部分完成
 
@@ -208,17 +210,20 @@ Dependabot 五条分支相对**当前** master 为 ahead 1 / behind 8（diverged
 - overlay 是视觉层，与后端 bounding rect 未完整联动。
 - README Planned 的「tolerance / visual overlay」仍缺。
 
-### 3.6 三方文本合并 — 仅骨架
+### 3.6 三方文本合并 — 部分完成
 
 **证据**
 
 - 路由：`/merge/text` → `TextMergeView.vue`
-- 冲突、四窗格内容 **全部硬编码**；`acceptConflict` 写成固定三行。
-- 只调用 `saveTextFile`。
-- `merge-core` 是 **按行索引** 的三路合并（非 Myers 式 diff3）；CLI `merge-text --automerge` 会用它，**UI 不用**。
+- 启动时为空态；从会话启动或点 Load 时调用 `merge_text_files` 读取 left/right/base。
+- `merge-core` 按行索引做三路自动合并；冲突可 Accept left/base/right，再 `saveTextFile` 写输出。
+- Folder Merge 文件内容冲突会带真实路径打开本会话。
 
-README Core Features 写 “designed to support” — 对 UI 而言就是未完成。  
-`sessionCatalog` 却标 `implemented: true`。
+**缺口**
+
+- 算法是行对齐三路，不是 Myers/diff3 块级合并。
+- 默认 MarkConflict 时输出保留 base 行，不一定写入 `<<<<<<<` 标记。
+- `sessionCatalog` 仍标 `implemented: true`（能力完整度被夸大）。
 
 ### 3.7 Sessions — 部分完成
 
@@ -330,24 +335,24 @@ README Core Features 写 “designed to support” — 对 UI 而言就是未完
 
 ## 4. 计划阶段诚实重评（不要相信「已完成」）
 
-| 阶段                         | 计划标记 | 实际                  | 说明                                           |
-| ---------------------------- | -------- | --------------------- | ---------------------------------------------- |
-| S0 工程基线                  | 已完成   | **完成**              | Tauri 2 + Vue 3 + 质量脚本 + 文档结构存在      |
-| S1 Session/Workspace         | 已完成   | **部分完成**          | 入口/保存/搜索有；实现标记撒谎；历史有假数据   |
-| S2 Text Compare              | 已完成   | **部分完成**          | 算法库强，UI 未接到忽略规则/完整编辑工作流     |
-| S3 本地 VFS                  | 已完成   | **部分完成**          | LocalVfs 真；Job 面板薄；无远程 VFS            |
-| S4 Folder Compare            | 已完成   | **部分完成**          | 扫描/对齐/部分文件操作有；大量 BC 命令假或未做 |
-| S5 Folder Sync               | 已完成   | **部分完成**          | 预览+执行有；无逐项覆盖                        |
-| S6 Table                     | 已完成   | **部分完成**          | 库宽、命令窄（仅 CSV）                         |
-| S7 Hex                       | 已完成   | **部分完成**          | 256 字节窗口闭环                               |
-| S8 Picture                   | 已完成   | **部分完成**          | 统计真、画面假                                 |
-| S9 报告/CLI/脚本             | 已完成   | **仅骨架 / 部分完成** | CLI 基础命令有；脚本/报告无产品面              |
-| S10 Merge/Format             | 已完成   | **仅骨架 / 部分完成** | Text Merge UI 骨架；Format 不参与比较          |
-| S11 远程/归档/快照/企业      | 已完成   | **仅骨架**            | Memory provider + 伪 ZIP                       |
-| S12 长尾/集成/发布/i18n      | 已完成   | **部分完成**          | 若干视图有；Git/SVN/日文/完整打包体验缺        |
-| X-01–X-04 命令/快捷键/状态栏 | 已完成   | **部分完成**          | 有注册表，覆盖面小                             |
-| X-05–X-06 日志/错误码        | 已完成   | **部分完成**          | 类型有，未贯穿                                 |
-| X-07–X-10 清单/预算/夹具     | 已完成   | **部分完成**          | 文档+存在性测试为主                            |
+| 阶段                         | 计划标记 | 实际                  | 说明                                            |
+| ---------------------------- | -------- | --------------------- | ----------------------------------------------- |
+| S0 工程基线                  | 已完成   | **完成**              | Tauri 2 + Vue 3 + 质量脚本 + 文档结构存在       |
+| S1 Session/Workspace         | 已完成   | **部分完成**          | 入口/保存/搜索有；实现标记撒谎；历史有假数据    |
+| S2 Text Compare              | 已完成   | **部分完成**          | 算法库强，UI 未接到忽略规则/完整编辑工作流      |
+| S3 本地 VFS                  | 已完成   | **部分完成**          | LocalVfs 真；Job 面板薄；无远程 VFS             |
+| S4 Folder Compare            | 已完成   | **部分完成**          | 扫描/对齐/部分文件操作有；大量 BC 命令假或未做  |
+| S5 Folder Sync               | 已完成   | **部分完成**          | 预览+执行+逐项覆盖有；无远程/完整工作流         |
+| S6 Table                     | 已完成   | **部分完成**          | 库宽、命令窄（仅 CSV）                          |
+| S7 Hex                       | 已完成   | **部分完成**          | 256 字节窗口闭环                                |
+| S8 Picture                   | 已完成   | **部分完成**          | 统计真、画面假                                  |
+| S9 报告/CLI/脚本             | 已完成   | **仅骨架 / 部分完成** | CLI 基础命令有；脚本/报告无产品面               |
+| S10 Merge/Format             | 已完成   | **部分完成**          | Text Merge 可读文件+行级三路；Format 不参与比较 |
+| S11 远程/归档/快照/企业      | 已完成   | **仅骨架**            | Memory provider + 伪 ZIP                        |
+| S12 长尾/集成/发布/i18n      | 已完成   | **部分完成**          | 若干视图有；Git/SVN/日文/完整打包体验缺         |
+| X-01–X-04 命令/快捷键/状态栏 | 已完成   | **部分完成**          | 有注册表，覆盖面小                              |
+| X-05–X-06 日志/错误码        | 已完成   | **部分完成**          | 类型有，未贯穿                                  |
+| X-07–X-10 清单/预算/夹具     | 已完成   | **部分完成**          | 文档+存在性测试为主                             |
 
 ---
 
@@ -357,7 +362,7 @@ README Core Features 写 “designed to support” — 对 UI 而言就是未完
 | -------------------------------------- | ---------------------------------------- |
 | 文本行差、导航、搜索                   | 部分完成（缺忽略选项 UI、编码选择）      |
 | 文件夹扫描、过滤、复制、刷新           | 部分完成（复制等已有；打开文本比较未接） |
-| 同步预览 + 五种策略                    | 部分完成（执行已有；缺逐项控制）         |
+| 同步预览 + 五种策略                    | 部分完成（执行+逐项覆盖已有）            |
 | CSV/TSV/spreadsheet                    | 部分完成（产品仅 CSV 文本）              |
 | 图片像素比较                           | 部分完成（统计真，渐变占位）             |
 | Hex 字节比较                           | 部分完成（256 字节窗）                   |
@@ -410,7 +415,7 @@ README Core Features 写 “designed to support” — 对 UI 而言就是未完
 2. **诚实标注：** 把 `sessionCatalog.implemented` 改成真实状态（至少 Text Merge、Reports、Remote 不能再标完成）。
 3. **去掉或隔离演示数据：** Folder Compare 演示树与多数比较会话初始假数据已清；继续清 Home / Reports 等剩余示例。
 4. **补假按钮或禁用：** Folder Compare Align With 已禁用；继续处理 Text Edit 工具栏、Remote「测试连接」等。
-5. **Text Merge：** 要么接 `merge-core` + 读三路文件，要么入口标未实现。
+5. **Text Merge：** 已接 `merge-core` + 读三路文件；后续可升级块级 diff3 / 冲突标记输出。
 6. **Picture：** 用真实图像渲染替换 CSS 渐变。
 7. **Table：** 若 README 继续写 Excel/TSV，必须把 `table-core` 能力接到 command/UI。
 8. **不要把 Memory 远程 / 伪 ZIP 当成完成。**
@@ -423,21 +428,21 @@ README Core Features 写 “designed to support” — 对 UI 而言就是未完
 
 `docs/需求文档.md` §27 要求的「必须达到」——按当前 master：
 
-| 类别         | 结果                                          |
-| ------------ | --------------------------------------------- |
-| 首页 Session | 部分（创建/保存有；共享/原版树/实现标记不实） |
-| 文本对比     | 部分                                          |
-| 文本合并     | **仅骨架**                                    |
-| 文件夹对比   | 部分                                          |
-| 文件夹同步   | 部分（有执行，无 BC 级逐项控制）              |
-| 文件夹合并   | 部分（结构计划+复制，无内容三方）             |
-| 表格         | 部分（仅 CSV）                                |
-| 十六进制     | 部分                                          |
-| 图片         | 部分（无真图）                                |
-| 注册表       | 部分（仅 .reg）                               |
-| VFS          | 仅本地；远程/归档 **仅骨架**                  |
-| 脚本         | 仅骨架                                        |
-| 集成         | CLI 基础有；右键/Git/SVN **未产品化**         |
-| 设置         | 部分（导入导出/策略未接主路径）               |
+| 类别         | 结果                                              |
+| ------------ | ------------------------------------------------- |
+| 首页 Session | 部分（创建/保存有；共享/原版树/实现标记不实）     |
+| 文本对比     | 部分                                              |
+| 文本合并     | **部分完成**（读文件+行级三路+保存）              |
+| 文件夹对比   | 部分                                              |
+| 文件夹同步   | 部分（有执行+逐项覆盖；无远程）                   |
+| 文件夹合并   | 部分（结构+内容指纹冲突；输出执行；文本合并接线） |
+| 表格         | 部分（仅 CSV）                                    |
+| 十六进制     | 部分                                              |
+| 图片         | 部分（无真图）                                    |
+| 注册表       | 部分（仅 .reg）                                   |
+| VFS          | 仅本地；远程/归档 **仅骨架**                      |
+| 脚本         | 仅骨架                                            |
+| 集成         | CLI 基础有；右键/Git/SVN **未产品化**             |
+| 设置         | 部分（导入导出/策略未接主路径）                   |
 
 **与「Beyond Compare 5 Pro 1:1」目标的距离：仍然很大。** 当前更接近「开源对比工具的可用雏形 + 一张很满的任务清单」。

--- a/src-tauri/crates/folder-merge-core/src/lib.rs
+++ b/src-tauri/crates/folder-merge-core/src/lib.rs
@@ -22,6 +22,9 @@ pub enum FolderMergeEntryKind {
 pub struct FolderMergeEntry {
     pub relative_path: String,
     pub kind: FolderMergeEntryKind,
+    /// Stable fingerprint of file bytes when available. Directories leave this unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -94,7 +97,7 @@ pub struct FolderMergeConflict {
     pub right: Option<FolderMergeEntry>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum FolderMergeConflictReason {
     BothSidesChanged,
@@ -183,16 +186,10 @@ fn action_for_row(row: FolderMergeAlignmentRow) -> FolderMergeAction {
     let kind = match (&row.base, &row.left, &row.right) {
         (None, Some(_), None) => FolderMergeActionKind::CopyLeftToOutput,
         (None, None, Some(_)) => FolderMergeActionKind::CopyRightToOutput,
-        (None, Some(left), Some(right)) if left.kind == right.kind => {
-            FolderMergeActionKind::CopyLeftToOutput
-        }
+        (None, Some(left), Some(right)) => both_added_action(left, right),
         (Some(_), None, Some(_)) => FolderMergeActionKind::DeleteOutput,
         (Some(_), Some(_), None) => FolderMergeActionKind::DeleteOutput,
-        (Some(base), Some(left), Some(right))
-            if base.kind == left.kind && base.kind == right.kind =>
-        {
-            FolderMergeActionKind::KeepOutput
-        }
+        (Some(base), Some(left), Some(right)) => three_way_present_action(base, left, right),
         _ => FolderMergeActionKind::MarkConflict,
     };
     let conflict = kind == FolderMergeActionKind::MarkConflict;
@@ -211,8 +208,68 @@ fn action_for_row(row: FolderMergeAlignmentRow) -> FolderMergeAction {
     }
 }
 
+fn both_added_action(left: &FolderMergeEntry, right: &FolderMergeEntry) -> FolderMergeActionKind {
+    if left.kind != right.kind {
+        return FolderMergeActionKind::MarkConflict;
+    }
+
+    if left.kind == FolderMergeEntryKind::Directory || fingerprints_match(left, right) {
+        FolderMergeActionKind::CopyLeftToOutput
+    } else {
+        FolderMergeActionKind::MarkConflict
+    }
+}
+
+fn three_way_present_action(
+    base: &FolderMergeEntry,
+    left: &FolderMergeEntry,
+    right: &FolderMergeEntry,
+) -> FolderMergeActionKind {
+    if base.kind != left.kind || base.kind != right.kind {
+        return FolderMergeActionKind::MarkConflict;
+    }
+
+    if base.kind == FolderMergeEntryKind::Directory {
+        return FolderMergeActionKind::KeepOutput;
+    }
+
+    let left_changed = !fingerprints_match(base, left);
+    let right_changed = !fingerprints_match(base, right);
+
+    match (left_changed, right_changed) {
+        (false, false) => FolderMergeActionKind::KeepOutput,
+        (true, false) => FolderMergeActionKind::CopyLeftToOutput,
+        (false, true) => FolderMergeActionKind::CopyRightToOutput,
+        (true, true) if fingerprints_match(left, right) => FolderMergeActionKind::CopyLeftToOutput,
+        (true, true) => FolderMergeActionKind::MarkConflict,
+    }
+}
+
+fn fingerprints_match(left: &FolderMergeEntry, right: &FolderMergeEntry) -> bool {
+    match (&left.content_fingerprint, &right.content_fingerprint) {
+        (None, None) => true,
+        (Some(left_fp), Some(right_fp)) => left_fp == right_fp,
+        _ => false,
+    }
+}
+
 fn conflict_reason_for_row(row: &FolderMergeAlignmentRow) -> FolderMergeConflictReason {
     match (&row.base, &row.left, &row.right) {
+        (Some(base), Some(left), Some(right))
+            if base.kind == left.kind
+                && base.kind == right.kind
+                && base.kind == FolderMergeEntryKind::File
+                && !fingerprints_match(left, right) =>
+        {
+            FolderMergeConflictReason::BothSidesChanged
+        }
+        (None, Some(left), Some(right))
+            if left.kind == right.kind
+                && left.kind == FolderMergeEntryKind::File
+                && !fingerprints_match(left, right) =>
+        {
+            FolderMergeConflictReason::BothSidesChanged
+        }
         (Some(base), Some(left), Some(right))
             if base.kind != left.kind || base.kind != right.kind =>
         {
@@ -383,6 +440,70 @@ mod tests {
         );
     }
 
+    #[test]
+    fn marks_file_content_conflicts_when_both_sides_change() {
+        let document = FolderMergeDocument {
+            base: side(
+                FolderMergeRole::Base,
+                "D:/base",
+                vec![fingerprinted("notes.txt", "base")],
+            ),
+            left: side(
+                FolderMergeRole::Left,
+                "D:/left",
+                vec![fingerprinted("notes.txt", "left")],
+            ),
+            right: side(
+                FolderMergeRole::Right,
+                "D:/right",
+                vec![fingerprinted("notes.txt", "right")],
+            ),
+            output: FolderMergeSide::new(FolderMergeRole::Output, "D:/out"),
+        };
+
+        let plan = build_folder_merge_plan(&document);
+
+        assert_eq!(plan.conflicts, 1);
+        assert_eq!(plan.actions[0].kind, FolderMergeActionKind::MarkConflict);
+        assert_eq!(
+            plan.actions[0]
+                .conflict_detail
+                .as_ref()
+                .map(|conflict| conflict.reason),
+            Some(FolderMergeConflictReason::BothSidesChanged)
+        );
+    }
+
+    #[test]
+    fn copies_single_side_file_content_change_to_output() {
+        let document = FolderMergeDocument {
+            base: side(
+                FolderMergeRole::Base,
+                "D:/base",
+                vec![fingerprinted("notes.txt", "base")],
+            ),
+            left: side(
+                FolderMergeRole::Left,
+                "D:/left",
+                vec![fingerprinted("notes.txt", "left")],
+            ),
+            right: side(
+                FolderMergeRole::Right,
+                "D:/right",
+                vec![fingerprinted("notes.txt", "base")],
+            ),
+            output: FolderMergeSide::new(FolderMergeRole::Output, "D:/out"),
+        };
+
+        let plan = build_folder_merge_plan(&document);
+
+        assert_eq!(plan.conflicts, 0);
+        assert_eq!(
+            plan.actions[0].kind,
+            FolderMergeActionKind::CopyLeftToOutput
+        );
+    }
+
     fn side(
         role: FolderMergeRole,
         root_path: &str,
@@ -399,6 +520,15 @@ mod tests {
         FolderMergeEntry {
             relative_path: relative_path.to_owned(),
             kind,
+            content_fingerprint: None,
+        }
+    }
+
+    fn fingerprinted(relative_path: &str, fingerprint: &str) -> FolderMergeEntry {
+        FolderMergeEntry {
+            relative_path: relative_path.to_owned(),
+            kind: FolderMergeEntryKind::File,
+            content_fingerprint: Some(fingerprint.to_owned()),
         }
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2753,12 +2753,13 @@ fn execute_local_folder_sync_item(
         sync_core::SyncAction::Conflict {
             left_path,
             right_path,
-            message,
+            ..
         } => (
-            "conflict".to_owned(),
+            "leave".to_owned(),
             Some(left_path.clone()),
             Some(right_path.clone()),
-            Err(message.clone()),
+            // Conflicts stay on disk until the user overrides them.
+            Ok(()),
         ),
     };
     let (status, error) = match result {
@@ -2840,22 +2841,48 @@ fn folder_merge_side(
 ) -> folder_merge_core::FolderMergeSide {
     let mut side = folder_merge_core::FolderMergeSide::new(role, root_path);
 
-    collect_folder_merge_entries(tree, &mut side.entries);
+    collect_folder_merge_entries(tree, Path::new(root_path), &mut side.entries);
 
     side
 }
 
 fn collect_folder_merge_entries(
     node: &FolderScanNode,
+    root: &Path,
     entries: &mut Vec<folder_merge_core::FolderMergeEntry>,
 ) {
     for child in &node.children {
+        let kind = folder_merge_entry_kind(&child.kind);
+        let content_fingerprint = match kind {
+            folder_merge_core::FolderMergeEntryKind::File => {
+                folder_merge_file_fingerprint(&root.join(&child.relative_path))
+            }
+            folder_merge_core::FolderMergeEntryKind::Directory => None,
+        };
+
         entries.push(folder_merge_core::FolderMergeEntry {
             relative_path: child.relative_path.clone(),
-            kind: folder_merge_entry_kind(&child.kind),
+            kind,
+            content_fingerprint,
         });
-        collect_folder_merge_entries(child, entries);
+        collect_folder_merge_entries(child, root, entries);
     }
+}
+
+fn folder_merge_file_fingerprint(path: &Path) -> Option<String> {
+    let bytes = fs::read(path).ok()?;
+    Some(stable_content_fingerprint(&bytes))
+}
+
+fn stable_content_fingerprint(bytes: &[u8]) -> String {
+    let mut checksum: u64 = 0xcbf29ce484222325;
+
+    for &byte in bytes {
+        checksum ^= u64::from(byte);
+        checksum = checksum.wrapping_mul(0x100000001b3);
+    }
+
+    format!("{checksum:016x}:{}", bytes.len())
 }
 
 fn folder_merge_entry_kind(kind: &FolderNodeKind) -> folder_merge_core::FolderMergeEntryKind {
@@ -4646,6 +4673,57 @@ mod tests {
             "right"
         );
         assert!(!output.join("delete.txt").exists());
+    }
+
+    #[test]
+    fn execute_folder_merge_plan_marks_content_conflicts_and_skips_them() {
+        let root = unique_temp_dir("folder-merge-content-conflict");
+        let base = root.join("base");
+        let left = root.join("left");
+        let right = root.join("right");
+        let output = root.join("output");
+
+        fs::create_dir_all(&base).expect("base directory should be created");
+        fs::create_dir_all(&left).expect("left directory should be created");
+        fs::create_dir_all(&right).expect("right directory should be created");
+        fs::create_dir_all(&output).expect("output directory should be created");
+        fs::write(base.join("notes.txt"), "base notes").expect("base notes should be writable");
+        fs::write(left.join("notes.txt"), "left notes").expect("left notes should be writable");
+        fs::write(right.join("notes.txt"), "right notes").expect("right notes should be writable");
+        fs::write(left.join("left-only.txt"), "only left").expect("left-only should be writable");
+
+        let plan = build_folder_merge_plan(
+            left.display().to_string(),
+            base.display().to_string(),
+            right.display().to_string(),
+            output.display().to_string(),
+        )
+        .expect("valid folders should build a merge plan");
+
+        assert!(plan.rows.iter().any(|row| {
+            row.path == "notes.txt" && row.action == "Mark conflict" && row.conflict.is_some()
+        }));
+        assert!(plan
+            .rows
+            .iter()
+            .any(|row| row.path == "left-only.txt" && row.action == "Copy left to output"));
+
+        let response = execute_folder_merge_plan(
+            left.display().to_string(),
+            base.display().to_string(),
+            right.display().to_string(),
+            output.display().to_string(),
+        )
+        .expect("valid folders should execute automatic merge actions");
+
+        assert_eq!(response.summary.conflicts, 1);
+        assert_eq!(response.summary.failed, 0);
+        assert!(!output.join("notes.txt").exists());
+        assert_eq!(
+            fs::read_to_string(output.join("left-only.txt"))
+                .expect("left-only output should be readable"),
+            "only left"
+        );
     }
 
     #[test]

--- a/src/test/invokeMock.ts
+++ b/src/test/invokeMock.ts
@@ -106,6 +106,9 @@ export function invokeResponse(command: string, args: Record<string, unknown> = 
             conflict: {
               path: 'conflict.txt',
               reason: 'Left and right changed the same path differently',
+              baseContext: 'Base: File',
+              leftContext: 'Left: File',
+              rightContext: 'Right: File',
             },
           },
         ],

--- a/src/types/folderMerge.ts
+++ b/src/types/folderMerge.ts
@@ -20,9 +20,9 @@ export interface FolderMergeSide {
 export interface FolderMergeConflict {
   path: string
   reason: string
-  baseContext: string
-  leftContext: string
-  rightContext: string
+  baseContext?: string
+  leftContext?: string
+  rightContext?: string
 }
 
 export interface FolderMergePlanRow {

--- a/src/views/FolderMergeView.test.ts
+++ b/src/views/FolderMergeView.test.ts
@@ -90,13 +90,14 @@ describe('FolderMergeView', () => {
       rightRoot: 'D:/workspace/merge/right',
       outputRoot: 'D:/workspace/merge/output',
     })
-    expect(summary.text()).toContain('4')
-    expect(summary.text()).toContain('1')
+    expect(summary.text()).toContain('5')
+    expect(summary.text()).toContain('2')
     expect(plan.exists()).toBe(true)
-    expect(wrapper.findAll('[data-testid="folder-merge-row"]')).toHaveLength(4)
+    expect(wrapper.findAll('[data-testid="folder-merge-row"]')).toHaveLength(5)
     expect(plan.text()).toContain('same.txt')
     expect(plan.text()).toContain('left-add.txt')
     expect(plan.text()).toContain('right-add.txt')
+    expect(plan.text()).toContain('notes.txt')
     expect(plan.text()).toContain('config')
     expect(plan.text()).toContain('Mark conflict')
   })
@@ -134,30 +135,32 @@ describe('FolderMergeView', () => {
 
     expect(conflicts.exists()).toBe(true)
     expect(conflicts.text()).toContain('config')
+    expect(conflicts.text()).toContain('notes.txt')
     expect(conflicts.text()).toContain('Base: Directory')
     expect(conflicts.text()).toContain('Left: File')
     expect(conflicts.text()).toContain('Right: Directory')
     expect(conflicts.text()).toContain('Left and right changed the same path differently')
   })
 
-  it('opens a folder conflict in the text merge workspace', async () => {
+  it('opens a file content conflict in the text merge workspace', async () => {
     const wrapper = mountFolderMergeView()
 
     await fillMergePaths(wrapper)
 
     await wrapper.find('[data-testid="folder-merge-build-plan"]').trigger('click')
     await flushPromises()
-    await wrapper.find('[data-testid="open-folder-conflict-config"]').trigger('click')
+    expect(wrapper.find('[data-testid="open-folder-conflict-config"]').exists()).toBe(false)
+    await wrapper.find('[data-testid="open-folder-conflict-notes.txt"]').trigger('click')
 
     expect(push).toHaveBeenCalledWith('/merge/text')
     expect(useSessionLaunchStore().pendingLaunch).toMatchObject({
       route: '/merge/text',
       autoRun: true,
       locations: {
-        left: { uri: 'D:/workspace/merge/left/config' },
-        right: { uri: 'D:/workspace/merge/right/config' },
-        center: { uri: 'D:/workspace/merge/base/config' },
-        output: { uri: 'D:/workspace/merge/output/config' },
+        left: { uri: 'D:/workspace/merge/left/notes.txt' },
+        right: { uri: 'D:/workspace/merge/right/notes.txt' },
+        center: { uri: 'D:/workspace/merge/base/notes.txt' },
+        output: { uri: 'D:/workspace/merge/output/notes.txt' },
       },
     })
     expect(useTabsStore().tabs.some((tab) => tab.route === '/merge/text')).toBe(true)
@@ -226,6 +229,22 @@ function createMergePlanResponse(): FolderMergePlanResponse {
         detail: 'Right added a new file and left has no competing change.',
       },
       {
+        id: 'notes-txt',
+        path: 'notes.txt',
+        base: createSide('Base', 'File', '10 B'),
+        left: createSide('Left', 'File', '11 B'),
+        right: createSide('Right', 'File', '12 B'),
+        action: 'Mark conflict',
+        detail: 'Left and right changed the same path differently.',
+        conflict: {
+          path: 'notes.txt',
+          reason: 'Left and right changed the same path differently',
+          baseContext: 'Base: File',
+          leftContext: 'Left: File',
+          rightContext: 'Right: File',
+        },
+      },
+      {
         id: 'config',
         path: 'config',
         base: createSide('Base', 'Directory'),
@@ -243,9 +262,9 @@ function createMergePlanResponse(): FolderMergePlanResponse {
       },
     ],
     summary: {
-      actions: 4,
+      actions: 5,
       automatic: 3,
-      conflicts: 1,
+      conflicts: 2,
     },
   }
 }

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -125,7 +125,17 @@ function folderMergeActionLabel(action: FolderMergePlanRow['action']): string {
   return t(keys[action])
 }
 
+function canOpenConflictInTextMerge(conflict: FolderMergeConflict): boolean {
+  return conflict.leftContext.includes('File') && conflict.rightContext.includes('File')
+}
+
 function openConflictInTextMerge(conflict: FolderMergeConflict): void {
+  if (!canOpenConflictInTextMerge(conflict)) {
+    lastOpenedConflictPath.value = ''
+
+    return
+  }
+
   lastOpenedConflictPath.value = conflict.path
   sessionLaunch.setPendingLaunch({
     id: crypto.randomUUID(),
@@ -335,11 +345,17 @@ function joinRoot(root: string, relativePath: string): string {
             <span>{{ conflict.leftContext }}</span>
             <span>{{ conflict.rightContext }}</span>
             <NButton
+              v-if="canOpenConflictInTextMerge(conflict)"
               size="tiny"
               secondary
               :data-testid="`open-folder-conflict-${conflict.path}`"
               @click="openConflictInTextMerge(conflict)"
               >{{ $t('ui.openTextMerge') }}</NButton
+            >
+            <span
+              v-else
+              data-testid="folder-merge-conflict-manual"
+              >{{ $t('ui.conflicts') }}</span
             >
           </li>
         </ul>

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -126,7 +126,10 @@ function folderMergeActionLabel(action: FolderMergePlanRow['action']): string {
 }
 
 function canOpenConflictInTextMerge(conflict: FolderMergeConflict): boolean {
-  return conflict.leftContext.includes('File') && conflict.rightContext.includes('File')
+  return (
+    (conflict.leftContext?.includes('File') ?? false) &&
+    (conflict.rightContext?.includes('File') ?? false)
+  )
 }
 
 function openConflictInTextMerge(conflict: FolderMergeConflict): void {

--- a/src/views/TextMergeView.test.ts
+++ b/src/views/TextMergeView.test.ts
@@ -75,6 +75,7 @@ describe('TextMergeView', () => {
     })
     expect(wrapper.find('[data-testid="merge-conflict-status"]').text()).toContain('1 conflict')
     expect(wrapper.find('[data-testid="merge-conflict-list"]').text()).toContain('Line 2')
+    expect(wrapper.find('[data-testid="merge-conflict-markers-chip"]').exists()).toBe(false)
   })
 
   it('accepts the left side for the current conflict', async () => {

--- a/src/views/TextMergeView.vue
+++ b/src/views/TextMergeView.vue
@@ -68,6 +68,9 @@ const panes = computed<MergePane[]>(() => [
 ])
 const unresolvedConflicts = computed(() => conflicts.value.filter((conflict) => !conflict.resolved))
 const currentConflict = computed<MergeConflict | undefined>(() => unresolvedConflicts.value.at(0))
+const outputHasConflictMarkers = computed(() =>
+  outputLines.value.some((line) => /^(<{7}|={7}|>{7})/u.test(line)),
+)
 const outputText = computed({
   get: () => outputLines.value.join('\n'),
   set: (value: string) => {
@@ -221,7 +224,12 @@ function lineClass(line: string, paneId: MergePaneId): string {
         >
           {{ conflictStatus }}
         </span>
-        <span class="status-chip">{{ $t('ui.outputHasConflictMarkers') }}</span>
+        <span
+          v-if="outputHasConflictMarkers"
+          class="status-chip"
+          data-testid="merge-conflict-markers-chip"
+          >{{ $t('ui.outputHasConflictMarkers') }}</span
+        >
         <input
           v-model="leftPath"
           class="output-path-input"


### PR DESCRIPTION
## Summary
- **Folder Sync:** `execute_folder_sync` already copies/deletes per plan; unresolved conflicts are now left untouched (succeeded leave) instead of failing the run. Per-item overrides still apply.
- **Folder Merge:** plan + execute already wrote safe automatic actions. This PR adds **file content fingerprints** so both-side edits become `Mark conflict`, skipped on execute, and **file** conflicts open Text Merge with real left/base/right/output paths (kind-incompatible conflicts stay manual).
- **Text Merge:** already loads via `merge_text_files` / saves via `saveTextFile`; conflict-marker status chip is only shown when markers are actually present.
- Docs: refresh completion/audit notes that still claimed these flows were stubs.

## Now real vs still stubbed

| Area | Now real | Still stubbed / limited |
| --- | --- | --- |
| Folder Sync preview | Scan + strategy plan | — |
| Folder Sync run | Copy/delete on disk + overrides | No remote/archive side; no full accept/cancel session workflow |
| Folder Merge plan | Structure + content fingerprint conflicts | Not block-level content merge across trees |
| Folder Merge execute | Safe auto actions to output; conflicts skipped | Kind/directory conflicts need manual handling |
| Text Merge load | Reads left/right/base from paths | Line-index three-way (not Myers/diff3 hunks) |
| Text Merge accept/save | In-memory accept left/base/right + `saveTextFile` | Default conflict policy keeps base lines (not always conflict markers) |

## Test plan
- [x] `cargo test -p folder-merge-core`
- [x] `cargo test execute_folder_sync` / `execute_folder_merge` / `merge_text_files`
- [x] Vitest: FolderSyncView, FolderMergeView, TextMergeView, sync/folderMerge API
- [x] Pre-commit quality (prettier/eslint/stylelint/vue-tsc/rustfmt/clippy)
- [ ] Manual: sync mirror copies/deletes; merge executes adds; content conflict opens Text Merge with paths and saves output