### PR TITLE
Align Table, Hex, and Picture session toolbars with real actions

### DIFF
--- a/src/app/sessionToolbars.test.ts
+++ b/src/app/sessionToolbars.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildFolderCompareToolbar,
+  buildHexCompareToolbar,
+  buildMediaCompareToolbar,
+  buildPictureCompareToolbar,
+  buildRegistryCompareToolbar,
+  buildTableCompareToolbar,
   buildTextCompareToolbar,
+  buildVersionCompareToolbar,
   folderCompareToolbarOrder,
+  hexCompareToolbarOrder,
   pathPairTitle,
+  pictureCompareToolbarOrder,
+  tableCompareToolbarOrder,
   textCompareToolbarOrder,
+  versionCompareToolbarOrder,
 } from './sessionToolbars'
 
 describe('sessionToolbars', () => {
@@ -46,6 +56,60 @@ describe('sessionToolbars', () => {
 
     expect(toolbar.map((item) => item.id)).toEqual([...textCompareToolbarOrder])
     expect(toolbar.find((item) => item.id === 'minor')?.enabled).toBe(false)
+  })
+
+  it('keeps Hex Compare toolbar in expected order', () => {
+    const toolbar = buildHexCompareToolbar({
+      home: true,
+      all: true,
+      diffs: true,
+      'next-diff': true,
+      'prev-diff': true,
+      swap: true,
+      reload: true,
+    })
+
+    expect(toolbar.map((item) => item.id)).toEqual([...hexCompareToolbarOrder])
+    expect(toolbar.find((item) => item.id === 'same')?.enabled).toBe(false)
+    expect(toolbar.find((item) => item.id === 'rules')?.enabled).toBe(false)
+  })
+
+  it('keeps Table Compare toolbar in expected order', () => {
+    const toolbar = buildTableCompareToolbar({
+      home: true,
+      'next-diff': true,
+      'prev-diff': true,
+      swap: true,
+      reload: true,
+    })
+
+    expect(toolbar.map((item) => item.id)).toEqual([...tableCompareToolbarOrder])
+    expect(toolbar.find((item) => item.id === 'minor')?.enabled).toBe(false)
+  })
+
+  it('keeps Picture Compare toolbar stubs disabled without fake labels', () => {
+    const toolbar = buildPictureCompareToolbar({
+      home: true,
+      swap: true,
+      reload: true,
+    })
+
+    expect(toolbar.map((item) => item.id)).toEqual([...pictureCompareToolbarOrder])
+    expect(toolbar.find((item) => item.id === 'tol')?.enabled).toBe(false)
+    expect(toolbar.find((item) => item.id === 'range')?.enabled).toBe(false)
+    expect(toolbar.find((item) => item.id === 'blend')?.enabled).toBe(false)
+    expect(toolbar.find((item) => item.id === 'meta')?.enabled).toBe(false)
+    expect(toolbar.every((item) => !item.labelKey.includes('unimplemented'))).toBe(true)
+  })
+
+  it('keeps Registry Media and Version toolbars ordered', () => {
+    expect(buildRegistryCompareToolbar({ home: true }).map((item) => item.id)).toContain('expand')
+    expect(
+      buildMediaCompareToolbar({ home: true, swap: true }).find((i) => i.id === 'swap')?.enabled,
+    ).toBe(true)
+    expect(buildVersionCompareToolbar({ home: true }).map((item) => item.id)).toEqual([
+      ...versionCompareToolbarOrder,
+    ])
   })
 
   it('formats path pair titles', () => {

--- a/src/app/sessionToolbars.ts
+++ b/src/app/sessionToolbars.ts
@@ -1,4 +1,4 @@
-/** Folder Compare and Text Compare session toolbar layouts. */
+/** Session toolbar layouts for compare views. */
 
 export interface SessionToolbarCommand {
   id: string
@@ -40,10 +40,87 @@ export const textCompareToolbarOrder = [
   'reload',
 ] as const
 
-const folderMeta: Record<
-  (typeof folderCompareToolbarOrder)[number],
-  { glyph: string; labelKey: string }
-> = {
+export const hexCompareToolbarOrder = [
+  'home',
+  'all',
+  'diffs',
+  'same',
+  'rules',
+  'copy',
+  'next-diff',
+  'prev-diff',
+  'swap',
+  'reload',
+] as const
+
+export const tableCompareToolbarOrder = [
+  'home',
+  'all',
+  'diffs',
+  'same',
+  'minor',
+  'rules',
+  'copy',
+  'next-diff',
+  'prev-diff',
+  'swap',
+  'reload',
+] as const
+
+export const pictureCompareToolbarOrder = [
+  'home',
+  'tol',
+  'range',
+  'blend',
+  'minor',
+  'rules',
+  'swap',
+  'reload',
+  'meta',
+] as const
+
+export const registryCompareToolbarOrder = [
+  'home',
+  'all',
+  'diffs',
+  'same',
+  'copy',
+  'swap',
+  'reload',
+  'expand',
+  'collapse',
+] as const
+
+export const mediaCompareToolbarOrder = [
+  'home',
+  'all',
+  'diffs',
+  'same',
+  'minor',
+  'rules',
+  'swap',
+  'reload',
+] as const
+
+export const versionCompareToolbarOrder = [
+  'home',
+  'all',
+  'diffs',
+  'same',
+  'minor',
+  'rules',
+  'next-diff',
+  'prev-diff',
+  'swap',
+  'reload',
+] as const
+
+interface ToolbarMeta {
+  glyph: string
+  labelKey: string
+}
+
+const folderMeta: Record<(typeof folderCompareToolbarOrder)[number], ToolbarMeta> = {
   home: { glyph: 'H', labelKey: 'ui.home' },
   all: { glyph: '*', labelKey: 'ui.all' },
   same: { glyph: '=', labelKey: 'ui.same' },
@@ -61,10 +138,7 @@ const folderMeta: Record<
   peek: { glyph: 'P', labelKey: 'ui.peek' },
 }
 
-const textMeta: Record<
-  (typeof textCompareToolbarOrder)[number],
-  { glyph: string; labelKey: string }
-> = {
+const textMeta: Record<(typeof textCompareToolbarOrder)[number], ToolbarMeta> = {
   home: { glyph: 'H', labelKey: 'ui.home' },
   all: { glyph: '*', labelKey: 'ui.all' },
   diffs: { glyph: '!=', labelKey: 'ui.diffs' },
@@ -79,26 +153,140 @@ const textMeta: Record<
   reload: { glyph: 'R', labelKey: 'ui.reload' },
 }
 
+const hexMeta: Record<(typeof hexCompareToolbarOrder)[number], ToolbarMeta> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  all: { glyph: '*', labelKey: 'ui.all' },
+  diffs: { glyph: '!=', labelKey: 'ui.diffs' },
+  same: { glyph: '=', labelKey: 'ui.same' },
+  rules: { glyph: 'R', labelKey: 'ui.rules' },
+  copy: { glyph: 'C', labelKey: 'ui.copy' },
+  'next-diff': { glyph: 'N', labelKey: 'ui.nextDifference' },
+  'prev-diff': { glyph: 'P', labelKey: 'ui.previousDifference' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  reload: { glyph: 'R', labelKey: 'ui.reload' },
+}
+
+const tableMeta: Record<(typeof tableCompareToolbarOrder)[number], ToolbarMeta> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  all: { glyph: '*', labelKey: 'ui.all' },
+  diffs: { glyph: '!=', labelKey: 'ui.diffs' },
+  same: { glyph: '=', labelKey: 'ui.same' },
+  minor: { glyph: '~', labelKey: 'ui.minor' },
+  rules: { glyph: 'R', labelKey: 'ui.rules' },
+  copy: { glyph: 'C', labelKey: 'ui.copy' },
+  'next-diff': { glyph: 'N', labelKey: 'ui.nextDifference' },
+  'prev-diff': { glyph: 'P', labelKey: 'ui.previousDifference' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  reload: { glyph: 'R', labelKey: 'ui.reload' },
+}
+
+const pictureMeta: Record<(typeof pictureCompareToolbarOrder)[number], ToolbarMeta> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  tol: { glyph: 'T', labelKey: 'ui.tol' },
+  range: { glyph: 'G', labelKey: 'ui.range' },
+  blend: { glyph: 'B', labelKey: 'ui.blend' },
+  minor: { glyph: '~', labelKey: 'ui.minor' },
+  rules: { glyph: 'R', labelKey: 'ui.rules' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  reload: { glyph: 'R', labelKey: 'ui.reload' },
+  meta: { glyph: 'M', labelKey: 'ui.meta' },
+}
+
+const registryMeta: Record<(typeof registryCompareToolbarOrder)[number], ToolbarMeta> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  all: { glyph: '*', labelKey: 'ui.all' },
+  diffs: { glyph: '!=', labelKey: 'ui.diffs' },
+  same: { glyph: '=', labelKey: 'ui.same' },
+  copy: { glyph: 'C', labelKey: 'ui.copy' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  reload: { glyph: 'R', labelKey: 'ui.reload' },
+  expand: { glyph: '+', labelKey: 'ui.expand' },
+  collapse: { glyph: '-', labelKey: 'ui.collapse' },
+}
+
+const mediaMeta: Record<(typeof mediaCompareToolbarOrder)[number], ToolbarMeta> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  all: { glyph: '*', labelKey: 'ui.all' },
+  diffs: { glyph: '!=', labelKey: 'ui.diffs' },
+  same: { glyph: '=', labelKey: 'ui.same' },
+  minor: { glyph: '~', labelKey: 'ui.minor' },
+  rules: { glyph: 'R', labelKey: 'ui.rules' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  reload: { glyph: 'R', labelKey: 'ui.reload' },
+}
+
+const versionMeta: Record<(typeof versionCompareToolbarOrder)[number], ToolbarMeta> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  all: { glyph: '*', labelKey: 'ui.all' },
+  diffs: { glyph: '!=', labelKey: 'ui.diffs' },
+  same: { glyph: '=', labelKey: 'ui.same' },
+  minor: { glyph: '~', labelKey: 'ui.minor' },
+  rules: { glyph: 'R', labelKey: 'ui.rules' },
+  'next-diff': { glyph: 'N', labelKey: 'ui.nextDifference' },
+  'prev-diff': { glyph: 'P', labelKey: 'ui.previousDifference' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  reload: { glyph: 'R', labelKey: 'ui.reload' },
+}
+
+function buildToolbar<T extends string>(
+  order: readonly T[],
+  meta: Record<T, ToolbarMeta>,
+  enabled: Partial<Record<T, boolean>>,
+): SessionToolbarCommand[] {
+  return order.map((id) => ({
+    id,
+    glyph: meta[id].glyph,
+    labelKey: meta[id].labelKey,
+    enabled: Boolean(enabled[id]),
+  }))
+}
+
 export function buildFolderCompareToolbar(
   enabled: Partial<Record<(typeof folderCompareToolbarOrder)[number], boolean>>,
 ): SessionToolbarCommand[] {
-  return folderCompareToolbarOrder.map((id) => ({
-    id,
-    glyph: folderMeta[id].glyph,
-    labelKey: folderMeta[id].labelKey,
-    enabled: Boolean(enabled[id]),
-  }))
+  return buildToolbar(folderCompareToolbarOrder, folderMeta, enabled)
 }
 
 export function buildTextCompareToolbar(
   enabled: Partial<Record<(typeof textCompareToolbarOrder)[number], boolean>>,
 ): SessionToolbarCommand[] {
-  return textCompareToolbarOrder.map((id) => ({
-    id,
-    glyph: textMeta[id].glyph,
-    labelKey: textMeta[id].labelKey,
-    enabled: Boolean(enabled[id]),
-  }))
+  return buildToolbar(textCompareToolbarOrder, textMeta, enabled)
+}
+
+export function buildHexCompareToolbar(
+  enabled: Partial<Record<(typeof hexCompareToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return buildToolbar(hexCompareToolbarOrder, hexMeta, enabled)
+}
+
+export function buildTableCompareToolbar(
+  enabled: Partial<Record<(typeof tableCompareToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return buildToolbar(tableCompareToolbarOrder, tableMeta, enabled)
+}
+
+export function buildPictureCompareToolbar(
+  enabled: Partial<Record<(typeof pictureCompareToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return buildToolbar(pictureCompareToolbarOrder, pictureMeta, enabled)
+}
+
+export function buildRegistryCompareToolbar(
+  enabled: Partial<Record<(typeof registryCompareToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return buildToolbar(registryCompareToolbarOrder, registryMeta, enabled)
+}
+
+export function buildMediaCompareToolbar(
+  enabled: Partial<Record<(typeof mediaCompareToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return buildToolbar(mediaCompareToolbarOrder, mediaMeta, enabled)
+}
+
+export function buildVersionCompareToolbar(
+  enabled: Partial<Record<(typeof versionCompareToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return buildToolbar(versionCompareToolbarOrder, versionMeta, enabled)
 }
 
 export function pathPairTitle(leftPath: string, rightPath: string): string {

--- a/src/components/workbench/WorkbenchShell.vue
+++ b/src/components/workbench/WorkbenchShell.vue
@@ -131,6 +131,8 @@ function toolbarForTitle(title: string): LegacyToolbarItem[] {
       item('minor', 'ui.minor', '~'),
       item('rules', 'ui.rules', 'R'),
       item('copy', 'ui.copy', 'C'),
+      item('next-diff', 'ui.nextDifference', 'N'),
+      item('prev-diff', 'ui.previousDifference', 'P'),
       item('swap', 'ui.swap', '<>'),
       item('reload', 'ui.reload', 'R'),
     ]
@@ -144,6 +146,8 @@ function toolbarForTitle(title: string): LegacyToolbarItem[] {
       item('same', 'ui.same', '='),
       item('rules', 'ui.rules', 'R'),
       item('copy', 'ui.copy', 'C'),
+      item('next-diff', 'ui.nextDifference', 'N'),
+      item('prev-diff', 'ui.previousDifference', 'P'),
       item('swap', 'ui.swap', '<>'),
       item('reload', 'ui.reload', 'R'),
     ]
@@ -152,10 +156,14 @@ function toolbarForTitle(title: string): LegacyToolbarItem[] {
   if (normalizedTitle.includes('picture compare') || normalizedTitle.includes('图片比较')) {
     return [
       item('home', 'ui.home', 'H'),
+      item('tol', 'ui.tol', 'T'),
+      item('range', 'ui.range', 'G'),
+      item('blend', 'ui.blend', 'B'),
       item('minor', 'ui.minor', '~'),
       item('rules', 'ui.rules', 'R'),
       item('swap', 'ui.swap', '<>'),
       item('reload', 'ui.reload', 'R'),
+      item('meta', 'ui.meta', 'M'),
     ]
   }
 

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -771,5 +771,9 @@ export const deDE: LanguagePack = {
     'ui.stop': 'Stopp',
     'ui.nextSection': 'Nächster Abschnitt',
     'ui.prevSection': 'Vorheriger Abschnitt',
+    'ui.tol': 'Tol',
+    'ui.range': 'Range',
+    'ui.blend': 'Blend',
+    'ui.meta': 'Meta',
   },
 }

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -751,5 +751,9 @@ export const enUS: LanguagePack = {
     'ui.stop': 'Stop',
     'ui.nextSection': 'Next Section',
     'ui.prevSection': 'Prev Section',
+    'ui.tol': 'Tol',
+    'ui.range': 'Range',
+    'ui.blend': 'Blend',
+    'ui.meta': 'Meta',
   },
 }

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -765,5 +765,9 @@ export const esES: LanguagePack = {
     'ui.stop': 'Detener',
     'ui.nextSection': 'Sección siguiente',
     'ui.prevSection': 'Sección anterior',
+    'ui.tol': 'Tol',
+    'ui.range': 'Range',
+    'ui.blend': 'Blend',
+    'ui.meta': 'Meta',
   },
 }

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -766,5 +766,9 @@ export const frFR: LanguagePack = {
     'ui.stop': 'Arrêter',
     'ui.nextSection': 'Section suivante',
     'ui.prevSection': 'Section précédente',
+    'ui.tol': 'Tol',
+    'ui.range': 'Range',
+    'ui.blend': 'Blend',
+    'ui.meta': 'Meta',
   },
 }

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -750,5 +750,9 @@ export const jaJP: LanguagePack = {
     'ui.stop': '停止',
     'ui.nextSection': '次のセクション',
     'ui.prevSection': '前のセクション',
+    'ui.tol': 'Tol',
+    'ui.range': 'Range',
+    'ui.blend': 'Blend',
+    'ui.meta': 'Meta',
   },
 }

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -746,5 +746,9 @@ export const koKR: LanguagePack = {
     'ui.stop': '중지',
     'ui.nextSection': '다음 섹션',
     'ui.prevSection': '이전 섹션',
+    'ui.tol': 'Tol',
+    'ui.range': 'Range',
+    'ui.blend': 'Blend',
+    'ui.meta': 'Meta',
   },
 }

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -730,5 +730,9 @@ export const zhCN: LanguagePack = {
     'ui.stop': '停止',
     'ui.nextSection': '下一节',
     'ui.prevSection': '上一节',
+    'ui.tol': '容差',
+    'ui.range': '范围',
+    'ui.blend': '混合',
+    'ui.meta': '元数据',
   },
 }

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -731,5 +731,9 @@ export const zhTW: LanguagePack = {
     'ui.stop': '停止',
     'ui.nextSection': '下一節',
     'ui.prevSection': '上一節',
+    'ui.tol': '容差',
+    'ui.range': '範圍',
+    'ui.blend': '混合',
+    'ui.meta': '中繼資料',
   },
 }

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -98,6 +98,19 @@ describe('AppLayout command palette', () => {
     expect(wrapper.find('[data-testid="menu-file"]').exists()).toBe(false)
   })
 
+  it('shows Session File Edit View Tools Help on Picture Compare without Search', () => {
+    routePath = '/compare/picture'
+    const wrapper = mountAppLayout()
+
+    expect(wrapper.find('[data-testid="menu-session"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-file"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-edit"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-search"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="menu-view"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-tools"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-help"]').exists()).toBe(true)
+  })
+
   it('shows Session File Edit Search View Tools Help on Text Compare', () => {
     routePath = '/compare/text'
     const wrapper = mountAppLayout()

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -244,12 +244,15 @@ const visibleAppMenus = computed(() => {
   const homeMenus: AppMenuId[] = ['session', 'view', 'tools', 'help']
   const folderMenus: AppMenuId[] = ['session', 'actions', 'edit', 'search', 'view', 'tools', 'help']
   const fileMenus: AppMenuId[] = ['session', 'file', 'edit', 'search', 'view', 'tools', 'help']
+  const pictureMenus: AppMenuId[] = ['session', 'file', 'edit', 'view', 'tools', 'help']
   let wantedMenus = fileMenus
 
   if (route.path === '/') {
     wantedMenus = homeMenus
   } else if (route.path.includes('/folder')) {
     wantedMenus = folderMenus
+  } else if (route.path.includes('/picture')) {
+    wantedMenus = pictureMenus
   }
 
   const menuById = new Map(appMenus.map((menu) => [menu.id, menu]))

--- a/src/views/HexCompareView.test.ts
+++ b/src/views/HexCompareView.test.ts
@@ -1,9 +1,15 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import HexCompareView from './HexCompareView.vue'
 import { compareHexFiles, findHexInFile, saveHexEdits } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
 
 vi.mock('@/api/diff', () => ({
   compareHexFiles: vi.fn().mockResolvedValue({
@@ -42,7 +48,7 @@ async function runCompare(wrapper: ReturnType<typeof mount>): Promise<void> {
   await wrapper.find('[data-testid="hex-left-path"]').setValue('C:/bin/left.bin')
   await wrapper.find('[data-testid="hex-right-path"]').setValue('C:/bin/right.bin')
   await wrapper.find('[data-testid="run-hex-compare"]').trigger('click')
-  await wrapper.vm.$nextTick()
+  await flushPromises()
 }
 
 describe('HexCompareView', () => {
@@ -61,6 +67,66 @@ describe('HexCompareView', () => {
     expect((wrapper.find('[data-testid="hex-left-path"]').element as HTMLInputElement).value).toBe(
       '',
     )
+  })
+
+  it('renders the Hex Compare session toolbar order', () => {
+    const wrapper = mount(HexCompareView)
+    const ids = [
+      'home',
+      'all',
+      'diffs',
+      'same',
+      'rules',
+      'copy',
+      'next-diff',
+      'prev-diff',
+      'swap',
+      'reload',
+    ]
+
+    expect(wrapper.find('[data-testid="hex-session-toolbar-bar"]').exists()).toBe(true)
+    expect(
+      wrapper
+        .findAll('[data-testid^="hex-session-toolbar-"]')
+        .filter((node) => node.attributes('data-testid') !== 'hex-session-toolbar-bar')
+        .map((node) => node.attributes('data-testid')?.replace('hex-session-toolbar-', '')),
+    ).toEqual(ids)
+    expect(
+      wrapper.find('[data-testid="hex-session-toolbar-same"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(
+      wrapper.find('[data-testid="hex-session-toolbar-rules"]').attributes('disabled'),
+    ).toBeDefined()
+  })
+
+  it('swaps paths and reloads from the session toolbar', async () => {
+    const wrapper = mount(HexCompareView)
+
+    await wrapper.find('[data-testid="hex-left-path"]').setValue('C:/bin/left.bin')
+    await wrapper.find('[data-testid="hex-right-path"]').setValue('C:/bin/right.bin')
+    await wrapper.find('[data-testid="hex-session-toolbar-swap"]').trigger('click')
+
+    expect((wrapper.find('[data-testid="hex-left-path"]').element as HTMLInputElement).value).toBe(
+      'C:/bin/right.bin',
+    )
+    expect((wrapper.find('[data-testid="hex-right-path"]').element as HTMLInputElement).value).toBe(
+      'C:/bin/left.bin',
+    )
+  })
+
+  it('jumps to the next difference range from the session toolbar', async () => {
+    const wrapper = mount(HexCompareView)
+
+    await runCompare(wrapper)
+
+    expect(
+      wrapper.find('[data-testid="hex-session-toolbar-next-diff"]').attributes('disabled'),
+    ).toBeUndefined()
+
+    await wrapper.find('[data-testid="hex-session-toolbar-next-diff"]').trigger('click')
+    await flushPromises()
+
+    expect(compareHexFiles).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 1 }))
   })
 
   it('runs a hex comparison request and renders returned byte windows', async () => {

--- a/src/views/HexCompareView.vue
+++ b/src/views/HexCompareView.vue
@@ -1,11 +1,20 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { compareHexFiles, findHexInFile, saveHexEdits } from '@/api/diff'
-import type { HexByteEdit, HexCompareResponse, HexFindMatch, HexViewCell } from '@/types/diff'
+import type {
+  HexByteEdit,
+  HexCompareResponse,
+  HexDiffRange,
+  HexFindMatch,
+  HexViewCell,
+} from '@/types/diff'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import StatusSummaryGrid from '@/components/workbench/StatusSummaryGrid.vue'
+import { buildHexCompareToolbar, pathPairTitle } from '@/app/sessionToolbars'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 
 interface HexRow {
   offset: string
@@ -29,6 +38,9 @@ const rightCells = ref<HexViewCell[]>([])
 const leftTotalLen = ref(0)
 const rightTotalLen = ref(0)
 const diffRangeCount = ref(0)
+const diffRanges = ref<HexDiffRange[]>([])
+const navigationRanges = ref<HexDiffRange[]>([])
+const activeDiffRangeIndex = ref(0)
 const viewportWidth = ref(640)
 const diffOnly = ref(false)
 const hexOffset = ref(0)
@@ -45,6 +57,8 @@ const saveStatus = ref('')
 const loading = ref(false)
 const error = ref('')
 const sessionLaunch = useSessionLaunchStore()
+const tabs = useTabsStore()
+const router = useRouter()
 const bytesPerRow = computed(() => (viewportWidth.value < 480 ? 8 : 16))
 
 const leftHex = computed<HexSideRows>(() =>
@@ -128,17 +142,116 @@ function syncHexScroll(source: 'left' | 'right', event: Event): void {
   targetElement.scrollTop = sourceElement.scrollTop
 }
 
-function applyHexResult(result: HexCompareResponse): void {
+function applyHexResult(result: HexCompareResponse, preserveNavigationRanges = false): void {
   leftPath.value = result.left.path
   rightPath.value = result.right.path
   leftCells.value = result.left.cells
   rightCells.value = result.right.cells
   leftTotalLen.value = result.summary.leftBytes
   rightTotalLen.value = result.summary.rightBytes
+  diffRanges.value = result.diffRanges
+  if (!preserveNavigationRanges) {
+    navigationRanges.value = result.diffRanges
+    activeDiffRangeIndex.value = 0
+  } else if (activeDiffRangeIndex.value >= navigationRanges.value.length) {
+    activeDiffRangeIndex.value = 0
+  }
   diffRangeCount.value = result.summary.differentRanges
+  syncHexTabTitle()
 }
 
-async function runHexCompare(): Promise<void> {
+function syncHexTabTitle(): void {
+  if (!leftPath.value || !rightPath.value) {
+    return
+  }
+
+  tabs.setTabTitle('/compare/hex', pathPairTitle(leftPath.value, rightPath.value))
+}
+
+function goHomeFromHex(): void {
+  tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+  void router.push('/')
+}
+
+function swapHexPaths(): void {
+  const nextLeftPath = rightPath.value
+
+  rightPath.value = leftPath.value
+  leftPath.value = nextLeftPath
+  const nextLeftCells = rightCells.value
+
+  rightCells.value = leftCells.value
+  leftCells.value = nextLeftCells
+  const nextLeftLen = rightTotalLen.value
+
+  rightTotalLen.value = leftTotalLen.value
+  leftTotalLen.value = nextLeftLen
+  syncHexTabTitle()
+}
+
+function goToHexDiffRange(index: number): void {
+  if (navigationRanges.value.length === 0) {
+    return
+  }
+
+  const nextIndex = (index + navigationRanges.value.length) % navigationRanges.value.length
+
+  activeDiffRangeIndex.value = nextIndex
+  const range = navigationRanges.value[nextIndex]
+
+  hexOffset.value = range.offset
+  jumpOffset.value = range.offset
+  void runHexCompare({ preserveNavigationRanges: true })
+}
+
+const hexSessionToolbar = computed(() =>
+  buildHexCompareToolbar({
+    home: true,
+    all: true,
+    diffs: true,
+    same: false,
+    rules: false,
+    copy: false,
+    'next-diff': navigationRanges.value.length > 0,
+    'prev-diff': navigationRanges.value.length > 0,
+    swap: Boolean(leftPath.value || rightPath.value),
+    reload: Boolean(leftPath.value && rightPath.value),
+  }),
+)
+
+function runHexToolbarCommand(commandId: string): void {
+  switch (commandId) {
+    case 'home':
+      goHomeFromHex()
+      break
+    case 'all':
+      diffOnly.value = false
+      break
+    case 'diffs':
+      diffOnly.value = true
+      break
+    case 'next-diff':
+      goToHexDiffRange(activeDiffRangeIndex.value + 1)
+      break
+    case 'prev-diff':
+      goToHexDiffRange(activeDiffRangeIndex.value - 1)
+      break
+    case 'swap':
+      swapHexPaths()
+      break
+    case 'reload':
+      void runHexCompare()
+      break
+    default:
+      break
+  }
+}
+
+watch([leftPath, rightPath], () => {
+  syncHexTabTitle()
+})
+
+async function runHexCompare(options?: { preserveNavigationRanges?: boolean }): Promise<void> {
   loading.value = true
   error.value = ''
   try {
@@ -149,7 +262,7 @@ async function runHexCompare(): Promise<void> {
       length: hexLength.value,
     })
 
-    applyHexResult(result)
+    applyHexResult(result, options?.preserveNavigationRanges === true)
   } catch (event) {
     error.value = String(event)
   } finally {
@@ -235,6 +348,9 @@ async function runHexSave(): Promise<void> {
     :eyebrow="$t('ui.hex')"
     :subtitle="loadedBytesLabel"
     :inspector-label="$t('ui.hexCompareInspector')"
+    :toolbar-commands="hexSessionToolbar"
+    toolbar-test-id-prefix="hex-session-toolbar"
+    @toolbar-command="runHexToolbarCommand"
   >
     <section class="hex-compare-view">
       <header class="hex-header">
@@ -296,7 +412,7 @@ async function runHexSave(): Promise<void> {
           type="button"
           data-testid="run-hex-compare"
           :disabled="loading"
-          @click="runHexCompare"
+          @click="runHexCompare()"
         >
           {{ $t('ui.runDiff') }}
         </button>

--- a/src/views/MediaCompareView.test.ts
+++ b/src/views/MediaCompareView.test.ts
@@ -5,6 +5,10 @@ import MediaCompareView from './MediaCompareView.vue'
 import { compareMediaFiles } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
 vi.mock('@/api/diff', () => ({
   compareMediaFiles: vi.fn().mockResolvedValue({
     left: {

--- a/src/views/MediaCompareView.vue
+++ b/src/views/MediaCompareView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { compareMediaFiles } from '@/api/diff'
 import type {
   MediaCompareResponse,
@@ -9,7 +10,9 @@ import type {
 } from '@/types/diff'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
+import { buildMediaCompareToolbar } from '@/app/sessionToolbars'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 import { useI18n } from '@/i18n'
 
 const mediaStatuses: MediaFieldStatus[] = ['added', 'removed', 'modified', 'unchanged']
@@ -28,6 +31,8 @@ const emptyMediaSide: MediaSideSummary = {
 const leftPath = ref('')
 const rightPath = ref('')
 const sessionLaunch = useSessionLaunchStore()
+const tabs = useTabsStore()
+const router = useRouter()
 const leftMedia = ref<MediaSideSummary>({ ...emptyMediaSide, stream: { ...emptyMediaSide.stream } })
 const rightMedia = ref<MediaSideSummary>({
   ...emptyMediaSide,
@@ -110,6 +115,48 @@ async function runMediaCompare(): Promise<void> {
     loading.value = false
   }
 }
+
+const mediaSessionToolbar = computed(() =>
+  buildMediaCompareToolbar({
+    home: true,
+    all: false,
+    diffs: false,
+    same: false,
+    minor: false,
+    rules: false,
+    swap: Boolean(leftPath.value || rightPath.value),
+    reload: Boolean(leftPath.value && rightPath.value),
+  }),
+)
+
+function runMediaToolbarCommand(commandId: string): void {
+  if (commandId === 'home') {
+    tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+    void router.push('/')
+
+    return
+  }
+
+  if (commandId === 'swap') {
+    const nextLeftPath = rightPath.value
+
+    rightPath.value = leftPath.value
+    leftPath.value = nextLeftPath
+    const nextLeft = rightMedia.value
+
+    rightMedia.value = leftMedia.value
+    leftMedia.value = nextLeft
+    if (leftPath.value && rightPath.value) {
+      void runMediaCompare()
+    }
+
+    return
+  }
+
+  if (commandId === 'reload') {
+    void runMediaCompare()
+  }
+}
 </script>
 
 <template>
@@ -118,6 +165,9 @@ async function runMediaCompare(): Promise<void> {
     :eyebrow="$t('ui.media')"
     :subtitle="`${leftMedia.name} -> ${rightMedia.name}`"
     :inspector-label="$t('ui.mediaCompareInspector')"
+    :toolbar-commands="mediaSessionToolbar"
+    toolbar-test-id-prefix="media-session-toolbar"
+    @toolbar-command="runMediaToolbarCommand"
   >
     <section class="media-compare-view">
       <header class="media-header">

--- a/src/views/PictureCompareView.test.ts
+++ b/src/views/PictureCompareView.test.ts
@@ -5,6 +5,10 @@ import PictureCompareView from './PictureCompareView.vue'
 import { comparePictureFiles } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
 vi.mock('@/api/diff', () => ({
   comparePictureFiles: vi.fn().mockResolvedValue({
     left: {
@@ -211,5 +215,49 @@ describe('PictureCompareView', () => {
     expect(wrapper.find('[data-testid="picture-metadata-panel"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="picture-metadata-dimensions"]').text()).toContain('2 x 1')
     expect(wrapper.find('[data-testid="picture-metadata-dimensions"]').exists()).toBe(true)
+  })
+
+  it('starts without hardcoded picture statistics before a compare', () => {
+    const wrapper = mount(PictureCompareView)
+
+    expect(wrapper.find('[data-testid="picture-total-pixels"]').text()).toBe('--')
+    expect(wrapper.find('[data-testid="picture-different-pixels"]').text()).toBe('--')
+    expect(wrapper.find('[data-testid="picture-difference-ratio"]').text()).toBe('--')
+    expect(wrapper.find('[data-testid="picture-bounding-rect"]').text()).toBe('--')
+  })
+
+  it('renders Picture session toolbar with Tol and Range stubs disabled', () => {
+    const wrapper = mount(PictureCompareView)
+    const ids = ['home', 'tol', 'range', 'blend', 'minor', 'rules', 'swap', 'reload', 'meta']
+
+    expect(wrapper.find('[data-testid="picture-session-toolbar-bar"]').exists()).toBe(true)
+    expect(
+      wrapper
+        .findAll('[data-testid^="picture-session-toolbar-"]')
+        .filter((node) => node.attributes('data-testid') !== 'picture-session-toolbar-bar')
+        .map((node) => node.attributes('data-testid')?.replace('picture-session-toolbar-', '')),
+    ).toEqual(ids)
+    expect(
+      wrapper.find('[data-testid="picture-session-toolbar-tol"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(
+      wrapper.find('[data-testid="picture-session-toolbar-range"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(wrapper.html()).not.toContain('unimplemented')
+  })
+
+  it('swaps paths from the Picture session toolbar', async () => {
+    const wrapper = mount(PictureCompareView)
+
+    await wrapper.find('[data-testid="picture-left-path"]').setValue('C:/images/left.png')
+    await wrapper.find('[data-testid="picture-right-path"]').setValue('C:/images/right.png')
+    await wrapper.find('[data-testid="picture-session-toolbar-swap"]').trigger('click')
+
+    expect(
+      (wrapper.find('[data-testid="picture-left-path"]').element as HTMLInputElement).value,
+    ).toBe('C:/images/right.png')
+    expect(
+      (wrapper.find('[data-testid="picture-right-path"]').element as HTMLInputElement).value,
+    ).toBe('C:/images/left.png')
   })
 })

--- a/src/views/PictureCompareView.vue
+++ b/src/views/PictureCompareView.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { comparePictureFiles } from '@/api/diff'
 import { localFileSrc } from '@/app/localFileSrc'
 import type { PictureCompareResponse, PictureMetadataRow } from '@/types/diff'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import StatusSummaryGrid from '@/components/workbench/StatusSummaryGrid.vue'
+import { buildPictureCompareToolbar, pathPairTitle } from '@/app/sessionToolbars'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 import { useI18n } from '@/i18n'
 
 const zoom = ref(100)
@@ -28,6 +31,8 @@ const { t } = useI18n()
 const leftPath = ref('')
 const rightPath = ref('')
 const sessionLaunch = useSessionLaunchStore()
+const tabs = useTabsStore()
+const router = useRouter()
 const leftPictureName = ref('')
 const rightPictureName = ref('')
 const loading = ref(false)
@@ -98,11 +103,26 @@ const rightImageStyle = computed<Record<string, string>>(() => ({
   transform: rightImageTransform.value,
 }))
 
-const pictureDifferenceRatioText = computed(
-  () => `${(pictureStatistics.value.differenceRatio * 100).toFixed(2)}%`,
+const pictureDifferenceRatioText = computed(() => {
+  if (!compared.value) {
+    return '--'
+  }
+
+  return `${(pictureStatistics.value.differenceRatio * 100).toFixed(2)}%`
+})
+
+const pictureTotalPixelsText = computed(() =>
+  compared.value ? String(pictureStatistics.value.totalPixels) : '--',
+)
+const pictureDifferentPixelsText = computed(() =>
+  compared.value ? String(pictureStatistics.value.differentPixels) : '--',
 )
 
 const pictureBoundingRectText = computed(() => {
+  if (!compared.value) {
+    return '--'
+  }
+
   const rect = pictureStatistics.value.boundingRect
 
   if (!rect) {
@@ -110,6 +130,68 @@ const pictureBoundingRectText = computed(() => {
   }
 
   return `${String(rect.x)}, ${String(rect.y)}, ${String(rect.width)} x ${String(rect.height)}`
+})
+
+function syncPictureTabTitle(): void {
+  if (!leftPath.value || !rightPath.value) {
+    return
+  }
+
+  tabs.setTabTitle('/compare/picture', pathPairTitle(leftPath.value, rightPath.value))
+}
+
+function goHomeFromPicture(): void {
+  tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+  void router.push('/')
+}
+
+function swapPicturePaths(): void {
+  const nextLeftPath = rightPath.value
+
+  rightPath.value = leftPath.value
+  leftPath.value = nextLeftPath
+  const nextLeftName = rightPictureName.value
+
+  rightPictureName.value = leftPictureName.value
+  leftPictureName.value = nextLeftName
+  syncPictureTabTitle()
+  if (leftPath.value && rightPath.value && compared.value) {
+    void runPictureCompare()
+  }
+}
+
+const pictureSessionToolbar = computed(() =>
+  buildPictureCompareToolbar({
+    home: true,
+    tol: false,
+    range: false,
+    blend: false,
+    minor: false,
+    rules: false,
+    swap: Boolean(leftPath.value || rightPath.value),
+    reload: Boolean(leftPath.value && rightPath.value),
+    meta: false,
+  }),
+)
+
+function runPictureToolbarCommand(commandId: string): void {
+  switch (commandId) {
+    case 'home':
+      goHomeFromPicture()
+      break
+    case 'swap':
+      swapPicturePaths()
+      break
+    case 'reload':
+      void runPictureCompare()
+      break
+    default:
+      break
+  }
+}
+
+watch([leftPath, rightPath], () => {
+  syncPictureTabTitle()
 })
 
 function rotatePicture(delta: number): void {
@@ -137,6 +219,7 @@ function applyPictureResult(result: PictureCompareResponse): void {
   rightPictureName.value = result.right.name
   metadataRows.value = result.metadataRows
   pictureStatistics.value = result.statistics
+  syncPictureTabTitle()
 }
 
 async function runPictureCompare(): Promise<void> {
@@ -166,6 +249,9 @@ async function runPictureCompare(): Promise<void> {
     :eyebrow="$t('ui.picture')"
     :subtitle="pictureDifferenceRatioText"
     :inspector-label="$t('ui.pictureCompareInspector')"
+    :toolbar-commands="pictureSessionToolbar"
+    toolbar-test-id-prefix="picture-session-toolbar"
+    @toolbar-command="runPictureToolbarCommand"
   >
     <section class="picture-compare-view">
       <header class="picture-header">
@@ -223,12 +309,12 @@ async function runPictureCompare(): Promise<void> {
       <section class="picture-stat-grid">
         <article>
           <span>{{ $t('ui.totalPixels') }}</span>
-          <strong data-testid="picture-total-pixels">{{ pictureStatistics.totalPixels }}</strong>
+          <strong data-testid="picture-total-pixels">{{ pictureTotalPixelsText }}</strong>
         </article>
         <article>
           <span>{{ $t('ui.differentPixels') }}</span>
           <strong data-testid="picture-different-pixels">
-            {{ pictureStatistics.differentPixels }}
+            {{ pictureDifferentPixelsText }}
           </strong>
         </article>
         <article>
@@ -474,7 +560,7 @@ async function runPictureCompare(): Promise<void> {
               { label: $t('ui.zoom'), value: `${zoom}%` },
               {
                 label: $t('ui.differentPixels'),
-                value: pictureStatistics.differentPixels,
+                value: pictureDifferentPixelsText,
                 tone: 'modified',
               },
               {

--- a/src/views/RegistryCompareView.test.ts
+++ b/src/views/RegistryCompareView.test.ts
@@ -5,6 +5,10 @@ import RegistryCompareView from './RegistryCompareView.vue'
 import { compareRegistryExports, readTextFile } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
 vi.mock('@/api/diff', () => ({
   compareRegistryExports: vi.fn().mockResolvedValue({
     leftName: 'fixture-left.reg',

--- a/src/views/RegistryCompareView.vue
+++ b/src/views/RegistryCompareView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { compareRegistryExports, readTextFile } from '@/api/diff'
 import type {
   RegistryCompareResponse,
@@ -10,7 +11,9 @@ import type {
 } from '@/types/diff'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
+import { buildRegistryCompareToolbar } from '@/app/sessionToolbars'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 import { useI18n } from '@/i18n'
 
 interface FlatRegistryKeyNode extends RegistryKeyNode {
@@ -21,6 +24,8 @@ const registryStatuses: RegistryDiffStatus[] = ['added', 'removed', 'modified', 
 const leftExport = ref('')
 const rightExport = ref('')
 const sessionLaunch = useSessionLaunchStore()
+const tabs = useTabsStore()
+const router = useRouter()
 const { t } = useI18n()
 const leftName = ref('left.reg')
 const rightName = ref('right.reg')
@@ -149,6 +154,49 @@ async function loadLaunchRegistryExports(leftPath: string, rightPath: string): P
 function fileNameFromPath(path: string): string {
   return path.replaceAll('\\', '/').split('/').filter(Boolean).at(-1) ?? path
 }
+
+const registrySessionToolbar = computed(() =>
+  buildRegistryCompareToolbar({
+    home: true,
+    all: false,
+    diffs: false,
+    same: false,
+    copy: false,
+    swap: Boolean(leftExport.value || rightExport.value),
+    reload: Boolean(leftExport.value && rightExport.value),
+    expand: false,
+    collapse: false,
+  }),
+)
+
+function runRegistryToolbarCommand(commandId: string): void {
+  if (commandId === 'home') {
+    tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+    void router.push('/')
+
+    return
+  }
+
+  if (commandId === 'swap') {
+    const nextLeft = rightExport.value
+
+    rightExport.value = leftExport.value
+    leftExport.value = nextLeft
+    const nextLeftName = rightName.value
+
+    rightName.value = leftName.value
+    leftName.value = nextLeftName
+    if (leftExport.value && rightExport.value) {
+      void runRegistryCompare()
+    }
+
+    return
+  }
+
+  if (commandId === 'reload') {
+    void runRegistryCompare()
+  }
+}
 </script>
 
 <template>
@@ -157,6 +205,9 @@ function fileNameFromPath(path: string): string {
     :eyebrow="$t('ui.registry')"
     :subtitle="`${leftName} -> ${rightName}`"
     :inspector-label="$t('ui.registryCompareInspector')"
+    :toolbar-commands="registrySessionToolbar"
+    toolbar-test-id-prefix="registry-session-toolbar"
+    @toolbar-command="runRegistryToolbarCommand"
   >
     <section class="registry-compare-view">
       <header class="registry-header">

--- a/src/views/TableCompareView.test.ts
+++ b/src/views/TableCompareView.test.ts
@@ -6,6 +6,10 @@ import { compareTable, readTextFile } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import type { TableCompareRequest } from '@/types/diff'
 
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
 vi.mock('@/api/diff', () => ({
   compareTable: vi.fn().mockResolvedValue({
     leftColumns: [
@@ -204,6 +208,44 @@ describe('TableCompareView', () => {
     expect(wrapper.find('[data-testid="active-table-cell"]').text()).toContain('A-1')
 
     await wrapper.find('[data-testid="next-table-difference"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="active-table-cell"]').text()).toContain('12 -> 14')
+  })
+
+  it('renders the Table Compare session toolbar order', () => {
+    const wrapper = mountTableCompareView()
+    const ids = [
+      'home',
+      'all',
+      'diffs',
+      'same',
+      'minor',
+      'rules',
+      'copy',
+      'next-diff',
+      'prev-diff',
+      'swap',
+      'reload',
+    ]
+
+    expect(wrapper.find('[data-testid="table-session-toolbar-bar"]').exists()).toBe(true)
+    expect(
+      wrapper
+        .findAll('[data-testid^="table-session-toolbar-"]')
+        .filter((node) => node.attributes('data-testid') !== 'table-session-toolbar-bar')
+        .map((node) => node.attributes('data-testid')?.replace('table-session-toolbar-', '')),
+    ).toEqual(ids)
+    expect(
+      wrapper.find('[data-testid="table-session-toolbar-minor"]').attributes('disabled'),
+    ).toBeDefined()
+  })
+
+  it('navigates differences from the Table session toolbar', async () => {
+    const wrapper = mountTableCompareView()
+
+    await wrapper.find('[data-testid="run-table-compare"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-testid="table-session-toolbar-next-diff"]').trigger('click')
 
     expect(wrapper.find('[data-testid="active-table-cell"]').text()).toContain('12 -> 14')
   })

--- a/src/views/TableCompareView.vue
+++ b/src/views/TableCompareView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { compareTable, readTextFile } from '@/api/diff'
 import { extensionOf } from '@/app/fileFormats'
 import type {
@@ -10,7 +11,9 @@ import type {
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import StatusSummaryGrid from '@/components/workbench/StatusSummaryGrid.vue'
+import { buildTableCompareToolbar, pathPairTitle } from '@/app/sessionToolbars'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 import { useI18n } from '@/i18n'
 
 interface TableColumnModel {
@@ -57,6 +60,8 @@ const rightSheet = ref('')
 const keyColumnsInput = ref('0')
 const delimiterInput = ref('')
 const sessionLaunch = useSessionLaunchStore()
+const tabs = useTabsStore()
+const router = useRouter()
 const { t } = useI18n()
 const leftColumns = ref<TableColumnModel[]>([])
 const rightColumns = ref<TableColumnModel[]>([])
@@ -420,6 +425,96 @@ function goToNextTableDifference(): void {
   activeDifferenceIndex.value =
     (activeDifferenceIndex.value + 1) % tableDifferenceCells.value.length
 }
+
+function goToPreviousTableDifference(): void {
+  if (tableSearchQuery.value.trim()) {
+    tableSearchQuery.value = ''
+  }
+
+  if (tableDifferenceCells.value.length === 0) {
+    activeDifferenceIndex.value = 0
+
+    return
+  }
+
+  activeDifferenceIndex.value =
+    (activeDifferenceIndex.value - 1 + tableDifferenceCells.value.length) %
+    tableDifferenceCells.value.length
+}
+
+function syncTableTabTitle(): void {
+  if (!leftPath.value || !rightPath.value) {
+    return
+  }
+
+  tabs.setTabTitle('/compare/table', pathPairTitle(leftPath.value, rightPath.value))
+}
+
+function goHomeFromTable(): void {
+  tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+  void router.push('/')
+}
+
+function swapTablePaths(): void {
+  const nextLeftPath = rightPath.value
+
+  rightPath.value = leftPath.value
+  leftPath.value = nextLeftPath
+  const nextLeftCsv = rightCsv.value
+
+  rightCsv.value = leftCsv.value
+  leftCsv.value = nextLeftCsv
+  const nextLeftSheet = rightSheet.value
+
+  rightSheet.value = leftSheet.value
+  leftSheet.value = nextLeftSheet
+  syncTableTabTitle()
+  if ((leftCsv.value && rightCsv.value) || (leftPath.value && rightPath.value)) {
+    void runTableCompare()
+  }
+}
+
+const tableSessionToolbar = computed(() =>
+  buildTableCompareToolbar({
+    home: true,
+    all: false,
+    diffs: false,
+    same: false,
+    minor: false,
+    rules: false,
+    copy: false,
+    'next-diff': tableDifferenceCells.value.length > 0,
+    'prev-diff': tableDifferenceCells.value.length > 0,
+    swap: Boolean(leftPath.value || rightPath.value || leftCsv.value || rightCsv.value),
+    reload: Boolean((leftPath.value && rightPath.value) || (leftCsv.value && rightCsv.value)),
+  }),
+)
+
+function runTableToolbarCommand(commandId: string): void {
+  switch (commandId) {
+    case 'home':
+      goHomeFromTable()
+      break
+    case 'next-diff':
+      goToNextTableDifference()
+      break
+    case 'prev-diff':
+      goToPreviousTableDifference()
+      break
+    case 'swap':
+      swapTablePaths()
+      break
+    case 'reload':
+      void runTableCompare()
+      break
+    default:
+      break
+  }
+}
+
+watch([leftPath, rightPath], () => {
+  syncTableTabTitle()
+})
 </script>
 
 <template>
@@ -428,6 +523,9 @@ function goToNextTableDifference(): void {
     :eyebrow="$t('ui.table')"
     :subtitle="$t('status.rowColumnCount', { rows: visibleRowCount, columns: visibleColumns })"
     :inspector-label="$t('ui.tableCompareInspector')"
+    :toolbar-commands="tableSessionToolbar"
+    toolbar-test-id-prefix="table-session-toolbar"
+    @toolbar-command="runTableToolbarCommand"
   >
     <section class="table-compare-view">
       <header class="table-compare-header">

--- a/src/views/VersionCompareView.test.ts
+++ b/src/views/VersionCompareView.test.ts
@@ -5,6 +5,10 @@ import VersionCompareView from './VersionCompareView.vue'
 import { compareVersionFiles } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
 vi.mock('@/api/diff', () => ({
   compareVersionFiles: vi.fn().mockResolvedValue({
     left: {
@@ -99,8 +103,12 @@ describe('VersionCompareView', () => {
     expect(wrapper.text()).toContain('Version Compare')
     expect(wrapper.text()).not.toContain('left-app.exe')
     expect(wrapper.find('[data-testid="version-summary-modified"]').text()).toContain('0')
+    expect(wrapper.find('[data-testid="version-toolbar-home"]').exists()).toBe(true)
     expect(
-      wrapper.find('[data-testid="version-toolbar-home"]').attributes('disabled'),
+      wrapper.find('[data-testid="version-toolbar-minor"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(
+      wrapper.find('[data-testid="version-toolbar-rules"]').attributes('disabled'),
     ).toBeDefined()
   })
 

--- a/src/views/VersionCompareView.vue
+++ b/src/views/VersionCompareView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { compareVersionFiles } from '@/api/diff'
 import { useI18n } from '@/i18n'
 import type {
@@ -8,7 +9,9 @@ import type {
   VersionFieldStatus,
   VersionSideSummary,
 } from '@/types/diff'
+import { buildVersionCompareToolbar } from '@/app/sessionToolbars'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 
 const versionStatuses: VersionFieldStatus[] = ['added', 'removed', 'modified', 'unchanged']
 
@@ -21,42 +24,12 @@ const emptyVersionSide: VersionSideSummary = {
   fileVersion: '',
   productVersion: '',
 }
-const versionToolbarCommands = computed(() => [
-  { id: 'home', glyph: 'H', labelKey: 'ui.home', enabled: false },
-  { id: 'all', glyph: '*', labelKey: 'ui.all', enabled: true },
-  { id: 'diffs', glyph: '!=', labelKey: 'ui.diffs', enabled: true },
-  { id: 'same', glyph: '=', labelKey: 'ui.same', enabled: true },
-  { id: 'minor', glyph: '~', labelKey: 'ui.minor', enabled: false },
-  { id: 'rules', glyph: 'R', labelKey: 'ui.rules', enabled: false },
-  {
-    id: 'next',
-    glyph: 'N',
-    labelKey: 'ui.nextDifference',
-    enabled: differenceFields.value.length > 0,
-  },
-  {
-    id: 'prev',
-    glyph: 'P',
-    labelKey: 'ui.previousDifference',
-    enabled: differenceFields.value.length > 0,
-  },
-  {
-    id: 'swap',
-    glyph: '<>',
-    labelKey: 'ui.swap',
-    enabled: Boolean(leftPath.value || rightPath.value),
-  },
-  {
-    id: 'reload',
-    glyph: 'R',
-    labelKey: 'ui.reload',
-    enabled: Boolean(leftPath.value && rightPath.value),
-  },
-])
 const { t } = useI18n()
 const leftPath = ref('')
 const rightPath = ref('')
 const sessionLaunch = useSessionLaunchStore()
+const tabs = useTabsStore()
+const router = useRouter()
 const leftVersion = ref<VersionSideSummary>({ ...emptyVersionSide })
 const rightVersion = ref<VersionSideSummary>({ ...emptyVersionSide })
 const versionFields = ref<VersionFieldRow[]>([])
@@ -114,7 +87,29 @@ const differenceFields = computed(() =>
   versionFields.value.filter((field) => field.status !== 'unchanged'),
 )
 
+const versionToolbarCommands = computed(() =>
+  buildVersionCompareToolbar({
+    home: true,
+    all: true,
+    diffs: true,
+    same: true,
+    minor: false,
+    rules: false,
+    'next-diff': differenceFields.value.length > 0,
+    'prev-diff': differenceFields.value.length > 0,
+    swap: Boolean(leftPath.value || rightPath.value),
+    reload: Boolean(leftPath.value && rightPath.value),
+  }),
+)
+
 function runVersionToolbarCommand(commandId: string): void {
+  if (commandId === 'home') {
+    tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+    void router.push('/')
+
+    return
+  }
+
   if (commandId === 'all' || commandId === 'diffs' || commandId === 'same') {
     fieldFilter.value = commandId
     activeFieldIndex.value = 0
@@ -141,13 +136,13 @@ function runVersionToolbarCommand(commandId: string): void {
     return
   }
 
-  if (commandId === 'next' && differenceFields.value.length > 0) {
+  if (commandId === 'next-diff' && differenceFields.value.length > 0) {
     activeFieldIndex.value = (activeFieldIndex.value + 1) % differenceFields.value.length
 
     return
   }
 
-  if (commandId === 'prev' && differenceFields.value.length > 0) {
+  if (commandId === 'prev-diff' && differenceFields.value.length > 0) {
     activeFieldIndex.value =
       (activeFieldIndex.value - 1 + differenceFields.value.length) % differenceFields.value.length
   }
@@ -204,8 +199,8 @@ async function runVersionCompare(): Promise<void> {
       :data-testid="`version-toolbar-${command.id}`"
       @click="runVersionToolbarCommand(command.id)"
     >
-      <span class="bc-toolbar-glyph">{{ command.glyph }}</span
-      ><span>{{ $t(command.labelKey) }}</span>
+      <span class="bc-toolbar-glyph">{{ command.glyph }}</span>
+      <span>{{ $t(command.labelKey) }}</span>
     </button>
   </section>
   <section class="version-compare-view">


### PR DESCRIPTION
## Summary
- Shared session toolbar builders now cover Hex, Table, Picture, Registry, Media, and Version with the same ordered pattern as Folder/Text.
- Hex: offset browse stays; toolbar wires home / all / diffs / next-prev difference / swap / reload; unfinished Same/Rules/Copy stay disabled.
- Picture: real compare kept; pre-run stats show `--` instead of hardcoded zeros; Tol/Range/Blend/Minor/Rules/Meta stay disabled without fake labels; swap/reload work.
- Table: already passes column mapping/ignore to the backend; toolbar adds next/prev difference, swap, and reload.
- Registry/Media/Version: empty demos already cleared; unfinished toolbar items stay disabled; home/swap/reload wired where cheap. Picture menus omit Search.

## Test plan
- [x] `vitest` for sessionToolbars + Hex/Picture/Table/Registry/Media/Version + AppLayout
- [x] eslint / prettier / stylelint via lint-staged
- [x] `vue-tsc --noEmit`
- [ ] Manual smoke: open Hex/Picture/Table sessions, confirm toolbars and empty-start behavior