### PR TITLE
Fix Folder Compare narrow overlap and clipped home menus

### DIFF
--- a/src/app/desktopDrop.test.ts
+++ b/src/app/desktopDrop.test.ts
@@ -1,17 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { isTauriRuntime, listenDesktopPathDrop, resolveDropInputsFromPaths } from './desktopDrop'
 
 describe('desktopDrop', () => {
   beforeEach(() => {
+    vi.resetModules()
     vi.unstubAllGlobals()
+    vi.doUnmock('@tauri-apps/api/webview')
+    vi.doUnmock('@tauri-apps/api/event')
     Reflect.deleteProperty(window, '__TAURI_INTERNALS__')
   })
 
-  it('detects non-Tauri runtimes', () => {
+  it('detects non-Tauri runtimes', async () => {
+    const { isTauriRuntime } = await import('./desktopDrop')
+
     expect(isTauriRuntime()).toBe(false)
   })
 
   it('returns a no-op unlisten outside Tauri', async () => {
+    const { listenDesktopPathDrop } = await import('./desktopDrop')
     const onPaths = vi.fn()
     const onPhase = vi.fn()
     const stop = await listenDesktopPathDrop(onPaths, onPhase)
@@ -23,11 +28,59 @@ describe('desktopDrop', () => {
   })
 
   it('falls back to path heuristics when classify_paths is unavailable', async () => {
+    const { resolveDropInputsFromPaths } = await import('./desktopDrop')
     const inputs = await resolveDropInputsFromPaths(['/tmp/left.txt', '/tmp/right.txt'])
 
     expect(inputs).toEqual([
       { path: '/tmp/left.txt', kind: 'file' },
       { path: '/tmp/right.txt', kind: 'file' },
     ])
+  })
+
+  it('registers webview drag-drop and Linux desktop-drop bridge listeners', async () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+
+    const unlistenDrag = vi.fn()
+    const unlistenDrop = vi.fn()
+    const unlistenEnter = vi.fn()
+    const unlistenLeave = vi.fn()
+    const onDragDropEvent = vi.fn(() => Promise.resolve(unlistenDrag))
+    const listen = vi.fn((event: string) => {
+      if (event === 'open-diff://desktop-drop') {
+        return Promise.resolve(unlistenDrop)
+      }
+      if (event === 'open-diff://desktop-drag-enter') {
+        return Promise.resolve(unlistenEnter)
+      }
+
+      return Promise.resolve(unlistenLeave)
+    })
+
+    vi.doMock('@tauri-apps/api/webview', () => ({
+      getCurrentWebview: () => ({ onDragDropEvent }),
+    }))
+    vi.doMock('@tauri-apps/api/event', () => ({ listen }))
+
+    const { listenDesktopPathDrop } = await import('./desktopDrop')
+    const onPaths = vi.fn()
+    const onPhase = vi.fn()
+    const stop = await listenDesktopPathDrop(onPaths, onPhase)
+
+    expect(onDragDropEvent).toHaveBeenCalledTimes(1)
+    expect(listen).toHaveBeenCalledWith('open-diff://desktop-drop', expect.any(Function))
+    expect(listen).toHaveBeenCalledWith('open-diff://desktop-drag-enter', expect.any(Function))
+    expect(listen).toHaveBeenCalledWith('open-diff://desktop-drag-leave', expect.any(Function))
+    expect(onPhase).toHaveBeenCalledWith('listening', 'webview')
+
+    stop()
+    expect(unlistenDrag).toHaveBeenCalledTimes(1)
+    expect(unlistenDrop).toHaveBeenCalledTimes(1)
+    expect(unlistenEnter).toHaveBeenCalledTimes(1)
+    expect(unlistenLeave).toHaveBeenCalledTimes(1)
+
+    Reflect.deleteProperty(window, '__TAURI_INTERNALS__')
   })
 })

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -243,6 +246,28 @@ describe('AppLayout command palette', () => {
     expect(wrapper.find('[data-testid="menu-command-edit.copyLeft"]').exists()).toBe(false)
   })
 
+  it('closes an open application menu with Escape', async () => {
+    const wrapper = mountAppLayout()
+
+    await wrapper.find('[data-testid="menu-file"]').trigger('click')
+    expect(wrapper.find('[data-testid="menu-panel"]').exists()).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="menu-panel"]').exists()).toBe(false)
+  })
+
+  it('exposes clickable menus with aria-haspopup on Home', async () => {
+    routePath = '/'
+    const wrapper = mountAppLayout()
+
+    expect(wrapper.find('[data-testid="menu-session"]').attributes('aria-haspopup')).toBe('menu')
+    await wrapper.find('[data-testid="menu-session"]').trigger('click')
+    expect(wrapper.find('[data-testid="menu-panel"]').attributes('role')).toBe('menu')
+    expect(wrapper.find('[data-testid="menu-command-open.textCompare"]').exists()).toBe(true)
+  })
+
   it('closes an open application menu when clicking outside it', async () => {
     const wrapper = mountAppLayout()
 
@@ -380,6 +405,19 @@ describe('AppLayout command palette', () => {
     expect(launchStore.pendingLaunch).toBeUndefined()
     expect(statusBar.report.comparisonStatus).toBe('Drop exactly two files or folders.')
     expect(statusBar.report.source).toBe('drop')
+  })
+
+  it('does not clip application menus with overflow-y hidden on .menus', () => {
+    const source = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), './AppLayout.vue'),
+      'utf8',
+    )
+    const menusBlock = /\.menus\s*\{[^}]+\}/.exec(source)
+
+    expect(menusBlock?.[0]).toBeTruthy()
+
+    expect(menusBlock?.[0]).toContain('overflow: visible')
+    expect(menusBlock?.[0]).not.toContain('overflow: auto hidden')
   })
 
   it('shows tab context menu actions and closes others', async () => {

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -159,10 +159,13 @@ onMounted(() => {
   ).then((stop) => {
     stopDesktopDrop = stop
   })
+
+  window.addEventListener('keydown', onChromeKeydown)
 })
 
 onUnmounted(() => {
   stopDesktopDrop?.()
+  window.removeEventListener('keydown', onChromeKeydown)
 })
 
 const commandPaletteOpen = ref(false)
@@ -409,6 +412,21 @@ function closeChromeMenus(): void {
   tabContextMenu.value = undefined
 }
 
+function onChromeKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    if (
+      activeMenu.value ||
+      languageMenuOpen.value ||
+      tabContextMenu.value ||
+      commandPaletteOpen.value
+    ) {
+      event.preventDefault()
+      closeChromeMenus()
+      commandPaletteOpen.value = false
+    }
+  }
+}
+
 function requestCloseTab(tab: { id: string; title: string; dirty: boolean }): void {
   if (tab.dirty) {
     pendingCloseTab.value = { id: tab.id, title: tab.title }
@@ -560,6 +578,7 @@ const sourceSessionTypes = new Set<SessionType>([
             type="button"
             :class="{ active: activeMenu === menu.id }"
             :aria-expanded="activeMenu === menu.id"
+            aria-haspopup="menu"
             :data-testid="`menu-${menu.id}`"
             @click="toggleApplicationMenu(menu.id)"
           >
@@ -568,6 +587,7 @@ const sourceSessionTypes = new Set<SessionType>([
           <section
             v-if="activeMenu === menu.id"
             class="menu-panel"
+            role="menu"
             data-testid="menu-panel"
             @click.stop
           >
@@ -921,6 +941,8 @@ const sourceSessionTypes = new Set<SessionType>([
 }
 
 .menu-bar {
+  position: relative;
+  z-index: 80;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   grid-template-rows: 40px 38px;
@@ -928,6 +950,7 @@ const sourceSessionTypes = new Set<SessionType>([
   gap: 0;
   min-width: 0;
   padding: 0;
+  overflow: visible;
   border-bottom: 1px solid #c7cbd1;
   background: #ffffff;
 }
@@ -936,7 +959,7 @@ const sourceSessionTypes = new Set<SessionType>([
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
-  z-index: 60;
+  z-index: 90;
   display: grid;
   width: 210px;
   max-height: calc(100vh - 72px);
@@ -1003,13 +1026,14 @@ const sourceSessionTypes = new Set<SessionType>([
   min-width: 0;
   height: 38px;
   padding: 0 10px;
-  overflow: auto hidden;
+  overflow: visible;
   border-top: 1px solid #e7e9ed;
   background: #ffffff;
 }
 
 .menu-group {
   position: relative;
+  z-index: 70;
 }
 
 .menus button,

--- a/src/styles/folderToolbarLayout.test.ts
+++ b/src/styles/folderToolbarLayout.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+describe('folder toolbar narrow layout CSS', () => {
+  it('keeps path-pair and toolbar from collapsing under results', () => {
+    const mainCss = readFileSync(resolve(root, 'src/styles/main.css'), 'utf8')
+    const view = readFileSync(resolve(root, 'src/views/FolderCompareView.vue'), 'utf8')
+
+    expect(mainCss).toMatch(/\.folder-toolbar\s*\{[\s\S]*?min-height:\s*min-content\s*!important/)
+    expect(mainCss).toMatch(
+      /\.folder-toolbar \.path-pair\s*\{[\s\S]*?min-height:\s*min-content\s*!important/,
+    )
+    expect(mainCss).toMatch(
+      /@media \(width <= 1100px\)\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\)\s*!important/,
+    )
+    expect(view).toContain('min-height: min-content')
+    expect(view).toContain(
+      'grid-template-rows: max-content max-content max-content max-content max-content minmax(0, 1fr)',
+    )
+    expect(view).toMatch(
+      /@media \(width <= 1100px\)[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\)/,
+    )
+  })
+})

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -558,8 +558,10 @@ select {
   grid-auto-flow: row !important;
   grid-auto-rows: auto !important;
   align-items: stretch !important;
+  align-content: start !important;
   gap: 10px !important;
-  min-height: 0 !important;
+  height: auto !important;
+  min-height: min-content !important;
   padding: 8px 10px !important;
   overflow: visible !important;
 }
@@ -573,6 +575,7 @@ select {
   grid-row: auto !important;
   width: 100% !important;
   min-width: 0 !important;
+  min-height: min-content !important;
   margin: 0 !important;
   overflow: visible !important;
 }
@@ -582,7 +585,8 @@ select {
   grid-template-columns: minmax(140px, 1fr) minmax(140px, 1fr) !important;
   grid-auto-rows: auto !important;
   gap: 8px !important;
-  min-height: 0 !important;
+  height: auto !important;
+  min-height: min-content !important;
 }
 
 .folder-toolbar .path-pair > label {
@@ -946,4 +950,11 @@ select {
 .home-primary-cta:focus-visible {
   outline: 2px solid var(--app-primary, #4aa3ff);
   outline-offset: 1px;
+}
+
+/* Keep Folder Compare path/criteria/actions from collapsing under results */
+.folder-compare-view > .folder-toolbar {
+  align-self: start !important;
+  height: auto !important;
+  min-height: min-content !important;
 }

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -2252,7 +2252,7 @@ onUnmounted(() => {
 <style scoped>
 .folder-compare-view {
   display: grid;
-  grid-template-rows: auto auto auto auto auto minmax(0, 1fr);
+  grid-template-rows: max-content max-content max-content max-content max-content minmax(0, 1fr);
   gap: 12px;
   height: 100%;
   padding: 16px;
@@ -2262,8 +2262,12 @@ onUnmounted(() => {
 .folder-toolbar {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
+  align-content: start;
   align-items: stretch;
+  align-self: start;
   gap: 10px;
+  height: auto;
+  min-height: min-content;
   overflow: visible;
 }
 
@@ -2275,6 +2279,7 @@ onUnmounted(() => {
   grid-column: 1;
   width: 100%;
   min-width: 0;
+  min-height: min-content;
   margin: 0;
 }
 
@@ -2282,6 +2287,8 @@ onUnmounted(() => {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
+  height: auto;
+  min-height: min-content;
 }
 
 .path-pair label {

--- a/tests/e2e/folder-narrow-layout.spec.ts
+++ b/tests/e2e/folder-narrow-layout.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test'
+import { installTauriInvokeMock } from './helpers/tauriMock'
+
+test.beforeEach(async ({ page }) => {
+  await installTauriInvokeMock(page)
+})
+
+test('folder compare path criteria and actions do not overlap at 950px', async ({ page }) => {
+  await page.setViewportSize({ width: 950, height: 700 })
+  await page.goto('/compare/folder')
+  await page.getByTestId('folder-left-root').fill('tests/fixtures/folder/left')
+  await page.getByTestId('folder-right-root').fill('tests/fixtures/folder/right')
+  await page.getByTestId('run-folder-compare').click()
+  await page.waitForTimeout(500)
+
+  const metrics = await page.evaluate(() => {
+    const box = (selector: string): DOMRect | null => {
+      const el = document.querySelector(selector)
+
+      return el ? el.getBoundingClientRect() : null
+    }
+    const overlaps = (a: DOMRect | null, b: DOMRect | null): number => {
+      if (!a || !b) {
+        return 0
+      }
+
+      const x = Math.max(0, Math.min(a.right, b.right) - Math.max(a.left, b.left))
+      const y = Math.max(0, Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top))
+
+      return x * y
+    }
+
+    const left = box('[data-testid="folder-left-root"]')
+    const right = box('[data-testid="folder-right-root"]')
+    const criteria = box('[data-testid="folder-criteria"]')
+    const hint = box('[data-testid="folder-path-hint"]')
+    const pair = document.querySelector('.folder-toolbar .path-pair')
+    const pairCols = pair ? getComputedStyle(pair).gridTemplateColumns : ''
+
+    return {
+      pairCols,
+      leftRight: overlaps(left, right),
+      leftCriteria: overlaps(left, criteria),
+      rightCriteria: overlaps(right, criteria),
+      hintLeft: overlaps(hint, left),
+      hintRight: overlaps(hint, right),
+      pathPairHeight: pair ? pair.getBoundingClientRect().height : 0,
+    }
+  })
+
+  expect(metrics.pairCols.split(' ').length).toBe(1)
+  expect(metrics.pathPairHeight).toBeGreaterThan(40)
+  expect(metrics.leftRight).toBe(0)
+  expect(metrics.leftCriteria).toBe(0)
+  expect(metrics.rightCriteria).toBe(0)
+  expect(metrics.hintLeft).toBe(0)
+  expect(metrics.hintRight).toBe(0)
+})
+
+test('home Session menu panel is hit-testable after click', async ({ page }) => {
+  await page.setViewportSize({ width: 1100, height: 800 })
+  await page.goto('/')
+  await page.getByTestId('menu-session').click()
+  const panel = page.getByTestId('menu-panel')
+
+  await expect(panel).toBeVisible()
+
+  const hit = await page.evaluate(() => {
+    const button = document.querySelector('[data-testid="menu-panel"] button')
+
+    if (!button) {
+      return false
+    }
+    const rect = button.getBoundingClientRect()
+    const el = document.elementFromPoint(rect.left + 8, rect.top + 8)
+
+    return Boolean(el?.closest('[data-testid="menu-panel"]'))
+  })
+
+  expect(hit).toBe(true)
+})


### PR DESCRIPTION
## Summary
- Restore Folder Compare narrow toolbar stacking: path-pair keeps min-content height (no 0px collapse under results), stacks to 1 column under ~1100px, with criteria/actions as full-width siblings and no absolute overlap.
- Fix home/application menus that appeared broken: `.menus { overflow: auto hidden }` was clipping dropdown panels. Menus now open on click, stay hit-testable, support Escape, and expose `aria-haspopup` / `role="menu"`.
- Confirm desktop drop wiring still registers Tauri `onDragDropEvent` plus the Linux `open-diff://desktop-drop` bridge after Home/menu work; unit coverage added for both listeners.

## Test plan
- [x] `vitest` for AppLayout, desktopDrop, folder toolbar CSS contract
- [x] Playwright: no path/criteria overlap at 950px after Compare; Home Session menu hit-testable
- [ ] Manual: open Folder Compare at ~950px with results loaded — paths/criteria/actions stack without overlap
- [ ] Manual: on Home, click Session/View/Tools/Help — panels open and items are clickable
- [ ] Manual/native: Thunar DnD onto Home still launches compare (native-only; not faked in smoke)