### PR TITLE
Tighten Home chrome and wire Edit clipboard actions

### DIFF
--- a/src/app/commandRegistry.test.ts
+++ b/src/app/commandRegistry.test.ts
@@ -25,6 +25,12 @@ describe('commandRegistry', () => {
         'help.checkForUpdates',
         'edit.copyLeft',
         'edit.copyRight',
+        'edit.undo',
+        'edit.redo',
+        'edit.cut',
+        'edit.copy',
+        'edit.paste',
+        'edit.delete',
         'diff.previous',
         'diff.next',
         'view.showAll',
@@ -36,6 +42,8 @@ describe('commandRegistry', () => {
       false,
     )
     expect(commandRegistry.find((command) => command.id === 'help.about')?.enabled).toBe(true)
+    expect(commandRegistry.find((command) => command.id === 'edit.undo')?.enabled).toBe(true)
+    expect(commandRegistry.find((command) => command.id === 'edit.paste')?.enabled).toBe(true)
   })
 
   it('filters commands by title and keywords', () => {

--- a/src/app/commandRegistry.ts
+++ b/src/app/commandRegistry.ts
@@ -18,6 +18,12 @@ export type CommandId =
   | 'session.exit'
   | 'edit.copyLeft'
   | 'edit.copyRight'
+  | 'edit.undo'
+  | 'edit.redo'
+  | 'edit.cut'
+  | 'edit.copy'
+  | 'edit.paste'
+  | 'edit.delete'
   | 'diff.previous'
   | 'diff.next'
   | 'view.showAll'
@@ -46,6 +52,12 @@ export type CommandAction =
         | 'next-difference'
         | 'copy-left'
         | 'copy-right'
+        | 'undo'
+        | 'redo'
+        | 'cut'
+        | 'copy'
+        | 'paste'
+        | 'delete'
         | 'save'
         | 'save-as'
         | 'export'
@@ -187,6 +199,66 @@ export const commandRegistry: AppCommand[] = [
     defaultShortcut: { keys: ['Alt', 'Right'], scope: 'global' },
     placements: ['command-palette', 'toolbar', 'menu'],
     action: { type: 'view-action', name: 'copy-right' },
+  },
+  {
+    id: 'edit.undo',
+    titleKey: 'ui.undo',
+    keywords: ['edit', 'undo'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Ctrl', 'Z'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'undo' },
+  },
+  {
+    id: 'edit.redo',
+    titleKey: 'ui.redo',
+    keywords: ['edit', 'redo'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Ctrl', 'Y'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'redo' },
+  },
+  {
+    id: 'edit.cut',
+    titleKey: 'ui.cut',
+    keywords: ['edit', 'cut', 'clipboard'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Ctrl', 'X'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'cut' },
+  },
+  {
+    id: 'edit.copy',
+    titleKey: 'ui.copy',
+    keywords: ['edit', 'copy', 'clipboard'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Ctrl', 'C'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'copy' },
+  },
+  {
+    id: 'edit.paste',
+    titleKey: 'ui.paste',
+    keywords: ['edit', 'paste', 'clipboard'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Ctrl', 'V'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'paste' },
+  },
+  {
+    id: 'edit.delete',
+    titleKey: 'ui.delete',
+    keywords: ['edit', 'delete'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Delete'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'delete' },
   },
   {
     id: 'diff.previous',

--- a/src/components/workbench/WorkbenchShell.vue
+++ b/src/components/workbench/WorkbenchShell.vue
@@ -10,6 +10,8 @@ const props = defineProps<{
   inspectorLabel?: string
   toolbarCommands?: SessionToolbarCommand[]
   toolbarTestIdPrefix?: string
+  /** Home-style frame: no titlebar/toolbar chrome; inspector stays offscreen for tests. */
+  compact?: boolean
 }>()
 const emit = defineEmits<{
   'toolbar-command': [id: string]
@@ -241,8 +243,15 @@ function onToolbarCommand(command: SessionToolbarCommand): void {
 </script>
 
 <template>
-  <section class="workbench-shell">
-    <header class="workbench-titlebar">
+  <section
+    class="workbench-shell"
+    :class="{ 'workbench-shell-compact': compact }"
+    :data-compact="compact ? 'true' : 'false'"
+  >
+    <header
+      v-if="!compact"
+      class="workbench-titlebar"
+    >
       <div class="workbench-titlecopy">
         <span
           v-if="eyebrow"
@@ -261,7 +270,10 @@ function onToolbarCommand(command: SessionToolbarCommand): void {
       </div>
     </header>
 
-    <div class="workbench-toolbar-stack">
+    <div
+      v-if="!compact"
+      class="workbench-toolbar-stack"
+    >
       <section
         v-if="toolbarItems.length > 0"
         class="bc-session-toolbar"
@@ -283,12 +295,16 @@ function onToolbarCommand(command: SessionToolbarCommand): void {
       <slot name="toolbar" />
     </div>
 
-    <div class="workbench-grid">
+    <div
+      class="workbench-grid"
+      :class="{ 'workbench-grid-compact': compact }"
+    >
       <main class="workbench-main">
         <slot />
       </main>
       <aside
         class="workbench-inspector"
+        :class="{ 'workbench-inspector-compact-host': compact }"
         :aria-label="resolvedInspectorLabel"
       >
         <slot name="inspector" />

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -254,6 +254,10 @@ describe('AppLayout command palette', () => {
       wrapper.find('[data-testid="menu-edit-group"] [data-testid="menu-panel"]').exists(),
     ).toBe(true)
     expect(wrapper.find('[data-testid="menu-command-edit.copyLeft"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="menu-command-edit.undo"]').exists()).toBe(true)
+    expect(
+      wrapper.find('[data-testid="menu-command-edit.paste"]').attributes('disabled'),
+    ).toBeUndefined()
     expect(wrapper.find('[data-testid="menu-command-open.textCompare"]').exists()).toBe(false)
 
     await wrapper.find('[data-testid="menu-view"]').trigger('click')

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -44,6 +44,7 @@ import { useStatusBarStore } from '@/stores/statusBar'
 import { useSavedSessionsStore } from '@/stores/savedSessions'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
+import { useViewActionsStore } from '@/stores/viewActions'
 import { openPathExternal, takeShellCompareLaunch } from '@/api/integration'
 import { APP_VERSION, DOCS_URL, RELEASES_URL, SUPPORT_URL } from '@/app/appMeta'
 import type { SessionType } from '@/types/session'
@@ -77,6 +78,7 @@ const settings = useSettingsStore()
 const policy = usePolicyStore()
 const statusBar = useStatusBarStore()
 const tabs = useTabsStore()
+const viewActions = useViewActionsStore()
 const sessionLaunch = useSessionLaunchStore()
 const savedSessions = useSavedSessionsStore()
 
@@ -212,7 +214,16 @@ const appMenus: AppMenuDefinition[] = [
   {
     id: 'edit',
     titleKey: 'ui.edit',
-    commandIds: ['edit.copyLeft', 'edit.copyRight'],
+    commandIds: [
+      'edit.undo',
+      'edit.redo',
+      'edit.cut',
+      'edit.copy',
+      'edit.paste',
+      'edit.delete',
+      'edit.copyLeft',
+      'edit.copyRight',
+    ],
   },
   {
     id: 'search',
@@ -302,6 +313,7 @@ const executeRegisteredCommand = createCommandExecutor(commandRegistry, {
   toggleTheme: settings.toggleTheme,
   dispatchViewAction: (name) => {
     lastViewAction.value = name
+    viewActions.dispatch(name)
     if (name === 'about') {
       aboutDialogOpen.value = true
       helpStatusMessage.value = ''

--- a/src/stores/viewActions.ts
+++ b/src/stores/viewActions.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { ViewActionName } from '@/app/commandSystem'
+
+export const useViewActionsStore = defineStore('viewActions', () => {
+  const name = ref<ViewActionName | null>(null)
+  const sequence = ref(0)
+
+  function dispatch(action: ViewActionName): void {
+    name.value = action
+    sequence.value += 1
+  }
+
+  return {
+    name,
+    sequence,
+    dispatch,
+  }
+})

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -134,6 +134,25 @@ select {
   background: #ffffff;
 }
 
+.workbench-shell-compact {
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.workbench-grid-compact {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.workbench-inspector-compact-host {
+  position: fixed;
+  top: auto;
+  left: -10000px;
+  display: block;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  border: 0;
+}
+
 .workbench-titlebar {
   display: none;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/src/views/HomeView.test.ts
+++ b/src/views/HomeView.test.ts
@@ -222,10 +222,29 @@ describe('HomeView', () => {
     expect(wrapper.text()).not.toContain('Release v1.2')
     expect(wrapper.find('[data-testid="home-session-history-empty"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="home-edit-selected"]').attributes('disabled')).toBeDefined()
-    expect(wrapper.find('[data-testid="home-tree-add"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('[data-testid="home-tree-add"]').attributes('disabled')).toBeUndefined()
     expect(wrapper.find('[data-testid="home-tree-remove"]').attributes('disabled')).toBeDefined()
     expect(wrapper.find('[data-testid="home-edit-selected"]').text()).toBe('Edit')
     expect(wrapper.find('[data-testid="home-edit-selected"]').text()).not.toContain('unimplemented')
+    expect(wrapper.find('.workbench-shell').attributes('data-compact')).toBe('true')
+  })
+
+  it('enables Edit for a selected saved session and renames it', async () => {
+    seedSampleSessions()
+    const wrapper = mountHomeView()
+
+    expect(
+      wrapper.find('[data-testid="home-edit-selected"]').attributes('disabled'),
+    ).toBeUndefined()
+
+    await wrapper.find('[data-testid="home-edit-selected"]').trigger('click')
+    expect(wrapper.find('[data-testid="home-edit-panel"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="home-edit-name-input"]').setValue('Renamed from Edit')
+    await wrapper.find('[data-testid="home-edit-confirm"]').trigger('click')
+
+    expect(wrapper.text()).toContain('Renamed from Edit')
+    expect(wrapper.find('[data-testid="home-edit-panel"]').exists()).toBe(false)
   })
 
   it('shows saved sessions in a dense recent sessions table', () => {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -139,6 +139,8 @@ const sessionSearch = ref('')
 const clipboardStatus = ref(t('ui.clipboardTextSourceNotLoaded'))
 const saveDialogOpen = ref(false)
 const sessionNameDraft = ref('')
+const editDialogOpen = ref(false)
+const editNameDraft = ref('')
 const filteredSavedSessions = computed(() =>
   filterSavedSessions(savedSessions.sessions, {
     query: sessionSearch.value,
@@ -500,6 +502,62 @@ function selectSavedSession(session: SessionDocument): void {
   selectedSessionId.value = session.id
 }
 
+const canEditSelected = computed(() => {
+  const session = selectedSavedSession.value
+
+  return Boolean(session && !session.metadata.locked)
+})
+
+const canRemoveSelected = computed(() => {
+  const session = selectedSavedSession.value
+
+  return Boolean(session && !session.metadata.locked)
+})
+
+function isTreeSessionSelected(sessionId: string): boolean {
+  return selectedSavedSession.value?.id === sessionId
+}
+
+function openEditSelectedDialog(): void {
+  const session = selectedSavedSession.value
+
+  if (!session || session.metadata.locked) {
+    return
+  }
+
+  editDialogOpen.value = true
+  editNameDraft.value = session.name
+}
+
+function confirmEditSelected(): void {
+  const session = selectedSavedSession.value
+  const name = editNameDraft.value.trim()
+
+  if (!session || !name) {
+    return
+  }
+
+  savedSessions.renameSession(session.id, name)
+  editDialogOpen.value = false
+  editNameDraft.value = ''
+}
+
+function cancelEditSelected(): void {
+  editDialogOpen.value = false
+  editNameDraft.value = ''
+}
+
+function removeSelectedFromTree(): void {
+  const session = selectedSavedSession.value
+
+  if (!session || session.metadata.locked) {
+    return
+  }
+
+  selectedSessionId.value = undefined
+  savedSessions.requestDeleteSession(session.id)
+}
+
 async function browseFoldersToCompare(): Promise<void> {
   const left = await pickNativePath({ directory: true })
 
@@ -548,15 +606,10 @@ function openSelectedPreview(): void {
 <template>
   <WorkbenchShell
     class="home-view"
+    compact
     :title="$t('ui.newSession')"
-    :subtitle="$t('ui.chooseAComparisonWorkspace')"
-    :eyebrow="$t('ui.workspace')"
     :inspector-label="$t('ui.workspaceInspector')"
   >
-    <template #title-actions>
-      <span class="home-title-count">{{ sessionCatalog.length }} {{ $t('ui.sessionTypes') }}</span>
-    </template>
-
     <section class="home-workspace bc-home-workspace">
       <aside
         class="bc-session-tree"
@@ -601,6 +654,7 @@ function openSelectedPreview(): void {
             :key="`tree-autosaved-${session.id}`"
             type="button"
             class="bc-tree-row saved"
+            :class="{ selected: isTreeSessionSelected(session.id) }"
             :data-testid="`home-tree-autosaved-${session.id}`"
             @click="selectSavedSession(session)"
             @dblclick="openSavedSession(session)"
@@ -623,6 +677,7 @@ function openSelectedPreview(): void {
             :key="`tree-today-${session.id}`"
             type="button"
             class="bc-tree-row saved"
+            :class="{ selected: isTreeSessionSelected(session.id) }"
             :data-testid="`home-tree-today-${session.id}`"
             @click="selectSavedSession(session)"
             @dblclick="openSavedSession(session)"
@@ -635,17 +690,18 @@ function openSelectedPreview(): void {
         <footer class="bc-tree-footer">
           <button
             type="button"
-            disabled
             data-testid="home-tree-add"
             :aria-label="$t('ui.add')"
+            @click="openSaveCurrentSessionDialog"
           >
             +
           </button>
           <button
             type="button"
-            disabled
             data-testid="home-tree-remove"
             :aria-label="$t('ui.remove')"
+            :disabled="!canRemoveSelected"
+            @click="removeSelectedFromTree"
           >
             −
           </button>
@@ -684,12 +740,40 @@ function openSelectedPreview(): void {
             </button>
             <button
               type="button"
-              disabled
               data-testid="home-edit-selected"
+              :disabled="!canEditSelected"
+              @click="openEditSelectedDialog"
             >
               {{ $t('ui.edit') }}
             </button>
           </div>
+          <section
+            v-if="editDialogOpen"
+            class="session-edit-panel"
+            data-testid="home-edit-panel"
+          >
+            <input
+              v-model="editNameDraft"
+              data-testid="home-edit-name-input"
+              type="text"
+              :placeholder="$t('ui.name')"
+              :aria-label="$t('ui.rename')"
+            />
+            <button
+              type="button"
+              data-testid="home-edit-confirm"
+              @click="confirmEditSelected"
+            >
+              {{ $t('ui.save') }}
+            </button>
+            <button
+              type="button"
+              data-testid="home-edit-cancel"
+              @click="cancelEditSelected"
+            >
+              {{ $t('ui.cancel') }}
+            </button>
+          </section>
         </section>
 
         <section
@@ -1159,6 +1243,7 @@ function openSelectedPreview(): void {
 
 .bc-home-main {
   display: grid;
+  align-content: start;
   grid-template-rows: auto minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
@@ -1236,6 +1321,10 @@ function openSelectedPreview(): void {
   min-width: 0;
 }
 
+.new-session-panel {
+  padding: 8px 12px 28px;
+}
+
 .new-session-panel h2,
 .recent-session-panel h2 {
   margin: 0;
@@ -1248,7 +1337,7 @@ function openSelectedPreview(): void {
   grid-template-columns: repeat(3, minmax(150px, 1fr));
   gap: 34px 76px;
   width: min(780px, calc(100% - 64px));
-  margin: 0 auto;
+  margin: 8px auto 12px;
 }
 
 .bc-home-instructions {
@@ -1630,5 +1719,41 @@ tr:hover .row-actions,
 
 .session-maturity[data-maturity='limited'] {
   background: color-mix(in srgb, #b45309 18%, transparent);
+}
+
+.bc-tree-row.selected {
+  background: #c7dcf6;
+}
+
+.session-edit-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 8px;
+  max-width: 520px;
+}
+
+.session-edit-panel input {
+  min-width: 0;
+  height: 38px;
+  padding: 0 10px;
+  border: 1px solid #c6ccd5;
+  border-radius: 3px;
+  background: #ffffff;
+  color: #111827;
+}
+
+.session-edit-panel button {
+  height: 38px;
+  padding: 0 14px;
+  border: 1px solid #c7cdd6;
+  border-radius: 3px;
+  background: #ffffff;
+  color: #111827;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.home-view :deep(.workbench-main) {
+  background: #ffffff;
 }
 </style>

--- a/src/views/TextEditView.vue
+++ b/src/views/TextEditView.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { readTextFile, saveTextFile } from '@/api/diff'
+import { useRouter } from 'vue-router'
 import { useI18n } from '@/i18n'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useViewActionsStore } from '@/stores/viewActions'
+import { useTabsStore } from '@/stores/tabs'
 import type { FileStamp } from '@/types/diff'
 
 interface LoadedTextDocument {
@@ -16,6 +19,9 @@ interface LoadedTextDocument {
 const pathInput = ref('')
 const { t } = useI18n()
 const sessionLaunch = useSessionLaunchStore()
+const viewActions = useViewActionsStore()
+const tabs = useTabsStore()
+const router = useRouter()
 const document = ref<LoadedTextDocument | null>(null)
 const editorText = ref('')
 const savedText = ref('')
@@ -244,7 +250,18 @@ function deleteEdit(): void {
   updateEditorText('')
 }
 
+function goHome(): void {
+  tabs.openTab({ title: t('ui.home'), titleKey: 'ui.home', route: '/', dirty: false })
+  void router.push('/')
+}
+
 function runTextEditCommand(commandId: string): void {
+  if (commandId === 'home') {
+    goHome()
+
+    return
+  }
+
   if (commandId === 'undo') {
     undoEdit()
 
@@ -353,8 +370,29 @@ function setSaveStatus(key: string, params: Record<string, string | number> = {}
 }
 
 const saveStatus = computed(() => t(saveStatusKey.value, saveStatusParams.value))
+
+watch(
+  () => [viewActions.sequence, viewActions.name] as const,
+  ([, actionName]) => {
+    if (!actionName) {
+      return
+    }
+
+    if (
+      actionName === 'undo' ||
+      actionName === 'redo' ||
+      actionName === 'cut' ||
+      actionName === 'copy' ||
+      actionName === 'paste' ||
+      actionName === 'delete'
+    ) {
+      runTextEditCommand(actionName)
+    }
+  },
+)
+
 const textEditToolbarCommands = [
-  { id: 'home', glyph: 'H', labelKey: 'ui.home', enabled: false },
+  { id: 'home', glyph: 'H', labelKey: 'ui.home', enabled: true },
   { id: 'undo', glyph: 'U', labelKey: 'ui.undo', enabled: true },
   { id: 'redo', glyph: 'R', labelKey: 'ui.redo', enabled: true },
   { id: 'cut', glyph: 'X', labelKey: 'ui.cut', enabled: true },


### PR DESCRIPTION
## Summary
- Home uses a compact workbench frame so the session tree and 12-card launch grid stay primary (less generic title/toolbar/inspector chrome).
- Home **Edit** renames the selected saved session; tree **+** saves the current session and **−** removes the selected unlocked session; tree selection highlight added.
- Edit menu gains Undo / Redo / Cut / Copy / Paste / Delete, enabled and dispatched through a shared view-actions channel into Text Edit (existing handlers). Text Edit toolbar Home is enabled.

## Still short of captures
- Launch cards still use Lucide glyphs (no trademark/brand tiles).
- Pixel spacing/iconography of the 12-grid and session tree still differ from `home.png`.
- Edit menu clipboard/undo primarily affect Text Edit; other sessions do not fully consume those actions yet.
- Session Edit is rename-focused (not a full path/rules session editor).
- Many other Session/Tools items remain disabled/noop outside this PR.

## Test plan
- [x] vitest: HomeView, AppLayout, commandRegistry, TextEditView
- [x] `vue-tsc --noEmit`
- [x] eslint / stylelint / prettier via pre-commit
- [x] cargo fmt --check + clippy -D warnings
- [ ] Manual: Home Edit rename; Edit menu Undo/Paste on Text Edit; Home compact frame vs tree+grid