### PR TITLE
Wire Session/Tools/View menus to real session handlers

### DIFF
--- a/src/app/commandRegistry.test.ts
+++ b/src/app/commandRegistry.test.ts
@@ -41,6 +41,27 @@ describe('commandRegistry', () => {
     expect(commandRegistry.find((command) => command.id === 'session.newWindow')?.enabled).toBe(
       false,
     )
+    expect(commandRegistry.find((command) => command.id === 'session.exit')?.enabled).toBe(false)
+    expect(commandRegistry.find((command) => command.id === 'tools.saveSnapshot')?.enabled).toBe(
+      false,
+    )
+    expect(commandRegistry.find((command) => command.id === 'session.loadWorkspace')?.enabled).toBe(
+      true,
+    )
+    expect(commandRegistry.find((command) => command.id === 'session.compare')?.enabled).toBe(true)
+    expect(commandRegistry.find((command) => command.id === 'session.swap')?.enabled).toBe(true)
+    expect(commandRegistry.find((command) => command.id === 'session.reload')?.enabled).toBe(true)
+    expect(commandRegistry.find((command) => command.id === 'session.rules')?.enabled).toBe(true)
+    expect(commandRegistry.find((command) => command.id === 'view.filters')?.enabled).toBe(true)
+    expect(commandRegistry.find((command) => command.id === 'tools.exportSettings')?.enabled).toBe(
+      true,
+    )
+    expect(commandRegistry.find((command) => command.id === 'tools.importSettings')?.enabled).toBe(
+      true,
+    )
+    expect(
+      commandRegistry.find((command) => command.id === 'tools.restoreFactoryDefaults')?.enabled,
+    ).toBe(true)
     expect(commandRegistry.find((command) => command.id === 'help.about')?.enabled).toBe(true)
     expect(commandRegistry.find((command) => command.id === 'edit.undo')?.enabled).toBe(true)
     expect(commandRegistry.find((command) => command.id === 'edit.paste')?.enabled).toBe(true)

--- a/src/app/commandRegistry.ts
+++ b/src/app/commandRegistry.ts
@@ -30,6 +30,11 @@ export type CommandId =
   | 'view.showAll'
   | 'view.showDifferences'
   | 'workspace.save'
+  | 'session.compare'
+  | 'session.swap'
+  | 'session.reload'
+  | 'session.rules'
+  | 'view.filters'
   | 'tools.exportSettings'
   | 'tools.importSettings'
   | 'tools.restoreFactoryDefaults'
@@ -71,6 +76,15 @@ export type CommandAction =
         | 'help-contents'
         | 'help-support'
         | 'session-settings'
+        | 'compare'
+        | 'swap'
+        | 'reload'
+        | 'rules'
+        | 'filters'
+        | 'workspace-load'
+        | 'export-settings'
+        | 'import-settings'
+        | 'restore-factory-defaults'
     }
 
 export interface CommandShortcut {
@@ -390,11 +404,11 @@ export const commandRegistry: AppCommand[] = [
     id: 'session.loadWorkspace',
     titleKey: 'ui.loadWorkspace',
     keywords: ['workspace', 'load'],
-    enabled: false,
+    enabled: true,
     visibility: 'global',
     defaultShortcut: { keys: ['Ctrl', 'Alt', 'O'], scope: 'global' },
     placements: ['command-palette', 'menu'],
-    action: { type: 'noop' },
+    action: { type: 'view-action', name: 'workspace-load' },
   },
   {
     id: 'session.closeTab',
@@ -417,34 +431,84 @@ export const commandRegistry: AppCommand[] = [
     action: { type: 'noop' },
   },
   {
+    id: 'session.compare',
+    titleKey: 'ui.compare',
+    keywords: ['session', 'compare', 'run'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Ctrl', 'R'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'compare' },
+  },
+  {
+    id: 'session.swap',
+    titleKey: 'ui.swap',
+    keywords: ['session', 'swap', 'sides'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Ctrl', 'Shift', 'W'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'swap' },
+  },
+  {
+    id: 'session.reload',
+    titleKey: 'ui.reload',
+    keywords: ['session', 'reload', 'refresh'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['F5'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'reload' },
+  },
+  {
+    id: 'session.rules',
+    titleKey: 'ui.rules',
+    keywords: ['session', 'rules'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Ctrl', 'Shift', 'R'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'rules' },
+  },
+  {
+    id: 'view.filters',
+    titleKey: 'ui.filters',
+    keywords: ['view', 'filters', 'filter'],
+    enabled: true,
+    visibility: 'view',
+    defaultShortcut: { keys: ['Ctrl', 'Shift', 'F'], scope: 'global' },
+    placements: ['command-palette', 'menu'],
+    action: { type: 'view-action', name: 'filters' },
+  },
+  {
     id: 'tools.exportSettings',
     titleKey: 'ui.exportSettings',
     keywords: ['export', 'settings', 'tools'],
-    enabled: false,
+    enabled: true,
     visibility: 'global',
     defaultShortcut: { keys: ['Ctrl', 'Alt', 'X'], scope: 'global' },
     placements: ['command-palette', 'menu'],
-    action: { type: 'noop' },
+    action: { type: 'view-action', name: 'export-settings' },
   },
   {
     id: 'tools.importSettings',
     titleKey: 'ui.importSettings',
     keywords: ['import', 'settings', 'tools'],
-    enabled: false,
+    enabled: true,
     visibility: 'global',
     defaultShortcut: { keys: ['Ctrl', 'Alt', 'I'], scope: 'global' },
     placements: ['command-palette', 'menu'],
-    action: { type: 'noop' },
+    action: { type: 'view-action', name: 'import-settings' },
   },
   {
     id: 'tools.restoreFactoryDefaults',
     titleKey: 'ui.restoreFactoryDefaults',
     keywords: ['restore', 'factory', 'defaults', 'tools'],
-    enabled: false,
+    enabled: true,
     visibility: 'global',
     defaultShortcut: { keys: ['Ctrl', 'Alt', 'D'], scope: 'global' },
     placements: ['command-palette', 'menu'],
-    action: { type: 'noop' },
+    action: { type: 'view-action', name: 'restore-factory-defaults' },
   },
   {
     id: 'tools.saveSnapshot',

--- a/src/app/settingsPackage.test.ts
+++ b/src/app/settingsPackage.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSettingsPackage,
+  parseSettingsPackage,
+  settingsPackageKind,
+  settingsPackageVersion,
+  type SettingsPackage,
+} from './settingsPackage'
+
+const sample: SettingsPackage = {
+  kind: settingsPackageKind,
+  version: settingsPackageVersion,
+  theme: 'dark',
+  locale: 'en-US',
+  sharedSessionPaths: [],
+  shortcutOverrides: {},
+  autoSaveLimit: 10,
+  fontFamily: 'system',
+  fontSize: 14,
+  diffColors: {
+    addedBg: '#f4fff4',
+    addedFg: '#005f18',
+    deletedBg: '#ffe3e3',
+    deletedFg: '#e00000',
+    modifiedBg: '#ffe3e3',
+    modifiedFg: '#e00000',
+  },
+  confirmBeforeDelete: true,
+  wrapTextDefault: false,
+  showSessionToolbars: true,
+  showToolbarLabels: true,
+  createBackupOnSave: false,
+}
+
+describe('settingsPackage', () => {
+  it('accepts a well-formed settings package', () => {
+    expect(isSettingsPackage(sample)).toBe(true)
+    expect(parseSettingsPackage(JSON.stringify(sample))).toEqual(sample)
+  })
+
+  it('rejects malformed payloads', () => {
+    expect(parseSettingsPackage('{')).toBeNull()
+    expect(isSettingsPackage({ kind: 'other' })).toBe(false)
+  })
+})

--- a/src/app/settingsPackage.ts
+++ b/src/app/settingsPackage.ts
@@ -30,7 +30,7 @@ export function isSettingsPackage(value: unknown): value is SettingsPackage {
     return false
   }
 
-  const candidate = value as Partial<SettingsPackage>
+  const candidate = value as Record<string, unknown>
 
   return (
     candidate.kind === settingsPackageKind &&

--- a/src/app/settingsPackage.ts
+++ b/src/app/settingsPackage.ts
@@ -1,0 +1,64 @@
+/** Serializable app settings package for Tools export/import. */
+
+import type { DiffHighlightColors, FontFamilyId, ThemeMode } from '@/stores/settings'
+import type { SupportedLocale } from '@/i18n/core'
+import type { CommandId, CommandShortcut } from '@/app/commandRegistry'
+
+export const settingsPackageKind = 'open-diff-settings' as const
+export const settingsPackageVersion = 1 as const
+
+export interface SettingsPackage {
+  kind: typeof settingsPackageKind
+  version: typeof settingsPackageVersion
+  theme: ThemeMode
+  locale: SupportedLocale
+  sharedSessionPaths: string[]
+  shortcutOverrides: Partial<Record<CommandId, CommandShortcut>>
+  autoSaveLimit: number
+  fontFamily: FontFamilyId
+  fontSize: number
+  diffColors: DiffHighlightColors
+  confirmBeforeDelete: boolean
+  wrapTextDefault: boolean
+  showSessionToolbars: boolean
+  showToolbarLabels: boolean
+  createBackupOnSave: boolean
+}
+
+export function isSettingsPackage(value: unknown): value is SettingsPackage {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const candidate = value as Partial<SettingsPackage>
+
+  return (
+    candidate.kind === settingsPackageKind &&
+    candidate.version === settingsPackageVersion &&
+    typeof candidate.theme === 'string' &&
+    typeof candidate.locale === 'string' &&
+    Array.isArray(candidate.sharedSessionPaths) &&
+    typeof candidate.shortcutOverrides === 'object' &&
+    candidate.shortcutOverrides !== null &&
+    typeof candidate.autoSaveLimit === 'number' &&
+    typeof candidate.fontFamily === 'string' &&
+    typeof candidate.fontSize === 'number' &&
+    typeof candidate.diffColors === 'object' &&
+    candidate.diffColors !== null &&
+    typeof candidate.confirmBeforeDelete === 'boolean' &&
+    typeof candidate.wrapTextDefault === 'boolean' &&
+    typeof candidate.showSessionToolbars === 'boolean' &&
+    typeof candidate.showToolbarLabels === 'boolean' &&
+    typeof candidate.createBackupOnSave === 'boolean'
+  )
+}
+
+export function parseSettingsPackage(raw: string): SettingsPackage | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+
+    return isSettingsPackage(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -86,6 +86,68 @@ describe('AppLayout command palette', () => {
     expect(wrapper.find('[data-testid="menu-command-session.newTab"]').exists()).toBe(true)
   })
 
+  it('enables Session compare/swap/reload/rules and Tools settings actions', async () => {
+    routePath = '/compare/folder'
+    const wrapper = mountAppLayout()
+
+    await wrapper.find('[data-testid="menu-session"]').trigger('click')
+    expect(
+      wrapper.find('[data-testid="menu-command-session.compare"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-session.swap"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-session.reload"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-session.rules"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-session.export"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-session.loadWorkspace"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-session.newWindow"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-session.exit"]').attributes('disabled'),
+    ).toBeDefined()
+
+    await wrapper.find('[data-testid="menu-view"]').trigger('click')
+    expect(
+      wrapper.find('[data-testid="menu-command-view.filters"]').attributes('disabled'),
+    ).toBeUndefined()
+
+    await wrapper.find('[data-testid="menu-tools"]').trigger('click')
+    expect(
+      wrapper.find('[data-testid="menu-command-tools.exportSettings"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-tools.importSettings"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-tools.restoreFactoryDefaults"]').attributes(
+        'disabled',
+      ),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="menu-command-tools.saveSnapshot"]').attributes('disabled'),
+    ).toBeDefined()
+  })
+
+  it('dispatches Session swap from the Actions menu on Folder Compare', async () => {
+    routePath = '/compare/folder'
+    const wrapper = mountAppLayout()
+
+    await wrapper.find('[data-testid="menu-actions"]').trigger('click')
+    await wrapper.find('[data-testid="menu-command-session.swap"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="last-view-action"]').text()).toContain('swap')
+  })
+
   it('opens the About dialog from Help', async () => {
     routePath = '/'
     const wrapper = mountAppLayout()

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -129,9 +129,9 @@ describe('AppLayout command palette', () => {
       wrapper.find('[data-testid="menu-command-tools.importSettings"]').attributes('disabled'),
     ).toBeUndefined()
     expect(
-      wrapper.find('[data-testid="menu-command-tools.restoreFactoryDefaults"]').attributes(
-        'disabled',
-      ),
+      wrapper
+        .find('[data-testid="menu-command-tools.restoreFactoryDefaults"]')
+        .attributes('disabled'),
     ).toBeUndefined()
     expect(
       wrapper.find('[data-testid="menu-command-tools.saveSnapshot"]').attributes('disabled'),

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -332,6 +332,7 @@ function closeAboutDialog(): void {
 
 function saveCurrentWorkspaceFromMenu(): void {
   const name = `Workspace ${new Date().toLocaleString()}`
+
   workspaces.saveWorkspace(name, tabs.workspaceSnapshot())
   statusBar.reportStatus({
     comparisonStatus: t('ui.saveWorkspaceAs'),
@@ -340,7 +341,7 @@ function saveCurrentWorkspaceFromMenu(): void {
 }
 
 function loadWorkspaceFromMenu(): void {
-  const latest = workspaces.workspaces[0]
+  const latest = workspaces.workspaces.at(0)
 
   if (!latest) {
     tabs.openTab({ title: t('ui.home'), titleKey: 'ui.home', route: '/', dirty: false })
@@ -354,7 +355,9 @@ function loadWorkspaceFromMenu(): void {
   }
 
   tabs.restoreWorkspaceTabs(latest.tabs)
+
   const active = tabs.activeTab
+
   void router.push(active.route)
   statusBar.reportStatus({
     comparisonStatus: latest.name,
@@ -380,12 +383,12 @@ async function exportSettingsFromMenu(): Promise<void> {
 }
 
 async function importSettingsFromMenu(): Promise<void> {
-  let raw = ''
+  let raw: string
 
   try {
     raw = await navigator.clipboard.readText()
   } catch {
-    raw = window.prompt(t('ui.importSettings'), '') ?? ''
+    raw = ''
   }
 
   const imported = settings.importSettingsPackage(raw.trim())

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -45,6 +45,7 @@ import { useSavedSessionsStore } from '@/stores/savedSessions'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
 import { useViewActionsStore } from '@/stores/viewActions'
+import { useWorkspacesStore } from '@/stores/workspaces'
 import { openPathExternal, takeShellCompareLaunch } from '@/api/integration'
 import { APP_VERSION, DOCS_URL, RELEASES_URL, SUPPORT_URL } from '@/app/appMeta'
 import type { SessionType } from '@/types/session'
@@ -81,6 +82,7 @@ const tabs = useTabsStore()
 const viewActions = useViewActionsStore()
 const sessionLaunch = useSessionLaunchStore()
 const savedSessions = useSavedSessionsStore()
+const workspaces = useWorkspacesStore()
 
 let stopDesktopDrop: (() => void) | undefined
 
@@ -197,6 +199,11 @@ const appMenus: AppMenuDefinition[] = [
       'workspace.save',
       'session.save',
       'session.saveAs',
+      'session.export',
+      'session.compare',
+      'session.swap',
+      'session.reload',
+      'session.rules',
       'session.settings',
       'session.closeTab',
       'session.exit',
@@ -210,7 +217,16 @@ const appMenus: AppMenuDefinition[] = [
   {
     id: 'actions',
     titleKey: 'ui.actions',
-    commandIds: ['edit.copyLeft', 'edit.copyRight', 'workspace.save'],
+    commandIds: [
+      'session.compare',
+      'session.swap',
+      'session.reload',
+      'session.rules',
+      'view.filters',
+      'edit.copyLeft',
+      'edit.copyRight',
+      'workspace.save',
+    ],
   },
   {
     id: 'edit',
@@ -234,7 +250,14 @@ const appMenus: AppMenuDefinition[] = [
   {
     id: 'view',
     titleKey: 'ui.view',
-    commandIds: ['view.showAll', 'view.showDifferences', 'theme.toggle'],
+    commandIds: [
+      'view.showAll',
+      'view.showDifferences',
+      'view.filters',
+      'session.swap',
+      'session.reload',
+      'theme.toggle',
+    ],
   },
   {
     id: 'tools',
@@ -267,7 +290,11 @@ const visibleAppMenus = computed(() => {
 
   if (route.path === '/') {
     wantedMenus = homeMenus
-  } else if (route.path.includes('/folder')) {
+  } else if (
+    route.path.includes('/folder') ||
+    route.path.includes('/sync') ||
+    route.path.includes('/merge')
+  ) {
     wantedMenus = folderMenus
   } else if (route.path.includes('/picture')) {
     wantedMenus = pictureMenus
@@ -301,6 +328,80 @@ async function openHelpLink(url: string, kind: 'updates' | 'docs' | 'support'): 
 
 function closeAboutDialog(): void {
   aboutDialogOpen.value = false
+}
+
+function saveCurrentWorkspaceFromMenu(): void {
+  const name = `Workspace ${new Date().toLocaleString()}`
+  workspaces.saveWorkspace(name, tabs.workspaceSnapshot())
+  statusBar.reportStatus({
+    comparisonStatus: t('ui.saveWorkspaceAs'),
+    source: 'workspace',
+  })
+}
+
+function loadWorkspaceFromMenu(): void {
+  const latest = workspaces.workspaces[0]
+
+  if (!latest) {
+    tabs.openTab({ title: t('ui.home'), titleKey: 'ui.home', route: '/', dirty: false })
+    void router.push('/')
+    statusBar.reportStatus({
+      comparisonStatus: t('ui.loadWorkspace'),
+      source: 'workspace',
+    })
+
+    return
+  }
+
+  tabs.restoreWorkspaceTabs(latest.tabs)
+  const active = tabs.activeTab
+  void router.push(active.route)
+  statusBar.reportStatus({
+    comparisonStatus: latest.name,
+    source: 'workspace',
+  })
+}
+
+async function exportSettingsFromMenu(): Promise<void> {
+  const payload = JSON.stringify(settings.exportSettingsPackage(), null, 2)
+
+  try {
+    await navigator.clipboard.writeText(payload)
+    statusBar.reportStatus({
+      comparisonStatus: t('ui.exportSettings'),
+      source: 'settings',
+    })
+  } catch {
+    statusBar.reportStatus({
+      comparisonStatus: t('ui.exportSettings'),
+      source: 'settings',
+    })
+  }
+}
+
+async function importSettingsFromMenu(): Promise<void> {
+  let raw = ''
+
+  try {
+    raw = await navigator.clipboard.readText()
+  } catch {
+    raw = window.prompt(t('ui.importSettings'), '') ?? ''
+  }
+
+  const imported = settings.importSettingsPackage(raw.trim())
+
+  statusBar.reportStatus({
+    comparisonStatus: imported ? t('ui.importSettings') : t('ui.importJson'),
+    source: 'settings',
+  })
+}
+
+function restoreFactoryDefaultsFromMenu(): void {
+  settings.restoreFactoryDefaults()
+  statusBar.reportStatus({
+    comparisonStatus: t('ui.restoreFactoryDefaults'),
+    source: 'settings',
+  })
 }
 
 const executeRegisteredCommand = createCommandExecutor(commandRegistry, {
@@ -337,6 +438,21 @@ const executeRegisteredCommand = createCommandExecutor(commandRegistry, {
       if (tabs.canCloseTab(active.id)) {
         requestCloseTab({ id: active.id, title: displayTabTitle(active), dirty: active.dirty })
       }
+    }
+    if (name === 'workspace-save') {
+      saveCurrentWorkspaceFromMenu()
+    }
+    if (name === 'workspace-load') {
+      loadWorkspaceFromMenu()
+    }
+    if (name === 'export-settings') {
+      void exportSettingsFromMenu()
+    }
+    if (name === 'import-settings') {
+      void importSettingsFromMenu()
+    }
+    if (name === 'restore-factory-defaults') {
+      restoreFactoryDefaultsFromMenu()
     }
   },
 })

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -214,3 +214,28 @@ describe('useSettingsStore', () => {
     expect(localStorage.getItem('open-diff-create-backup-on-save')).toBe('0')
   })
 })
+
+  it('exports, imports, and restores factory settings packages', () => {
+    const store = useSettingsStore()
+
+    store.setTheme('dark')
+    store.setLocale('zh-CN')
+    store.setFontSize(18)
+
+    const exported = store.exportSettingsPackage()
+    expect(exported.theme).toBe('dark')
+    expect(exported.locale).toBe('zh-CN')
+    expect(exported.fontSize).toBe(18)
+
+    store.restoreFactoryDefaults()
+    expect(store.theme).toBe('light')
+    expect(store.locale).toBe('en-US')
+    expect(store.fontSize).toBe(14)
+
+    expect(store.importSettingsPackage(exported)).toBe(true)
+    expect(store.theme).toBe('dark')
+    expect(store.locale).toBe('zh-CN')
+    expect(store.fontSize).toBe(18)
+    expect(store.importSettingsPackage('{')).toBe(false)
+  })
+

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -213,8 +213,6 @@ describe('useSettingsStore', () => {
     expect(localStorage.getItem('open-diff-show-toolbar-labels')).toBe('0')
     expect(localStorage.getItem('open-diff-create-backup-on-save')).toBe('0')
   })
-})
-
   it('exports, imports, and restores factory settings packages', () => {
     const store = useSettingsStore()
 
@@ -223,6 +221,7 @@ describe('useSettingsStore', () => {
     store.setFontSize(18)
 
     const exported = store.exportSettingsPackage()
+
     expect(exported.theme).toBe('dark')
     expect(exported.locale).toBe('zh-CN')
     expect(exported.fontSize).toBe(18)
@@ -238,4 +237,4 @@ describe('useSettingsStore', () => {
     expect(store.fontSize).toBe(18)
     expect(store.importSettingsPackage('{')).toBe(false)
   })
-
+})

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -372,8 +372,15 @@ export const useSettingsStore = defineStore('settings', () => {
   }
 
   function importSettingsPackage(raw: string | SettingsPackage): boolean {
-    const packageValue =
-      typeof raw === 'string' ? parseSettingsPackage(raw) : isSettingsPackage(raw) ? raw : null
+    let packageValue: SettingsPackage | null
+
+    if (typeof raw === 'string') {
+      packageValue = parseSettingsPackage(raw)
+    } else if (isSettingsPackage(raw)) {
+      packageValue = raw
+    } else {
+      packageValue = null
+    }
 
     if (!packageValue) {
       return false

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -8,6 +8,13 @@ import {
   type ShortcutScope,
 } from '@/app/commandRegistry'
 import { fallbackLocale, isSupportedLocale, type SupportedLocale } from '@/i18n/core'
+import {
+  isSettingsPackage,
+  parseSettingsPackage,
+  settingsPackageKind,
+  settingsPackageVersion,
+  type SettingsPackage,
+} from '@/app/settingsPackage'
 
 export type ThemeMode = 'light' | 'dark' | 'system'
 export type FontFamilyId = 'system' | 'segoe' | 'inter' | 'noto' | 'mono'
@@ -344,6 +351,67 @@ export const useSettingsStore = defineStore('settings', () => {
     createBackupOnSave.value = value
   }
 
+  function exportSettingsPackage(): SettingsPackage {
+    return {
+      kind: settingsPackageKind,
+      version: settingsPackageVersion,
+      theme: theme.value,
+      locale: locale.value,
+      sharedSessionPaths: [...sharedSessionPaths.value],
+      shortcutOverrides: { ...shortcutOverrides.value },
+      autoSaveLimit: autoSaveLimit.value,
+      fontFamily: fontFamily.value,
+      fontSize: fontSize.value,
+      diffColors: { ...diffColors.value },
+      confirmBeforeDelete: confirmBeforeDelete.value,
+      wrapTextDefault: wrapTextDefault.value,
+      showSessionToolbars: showSessionToolbars.value,
+      showToolbarLabels: showToolbarLabels.value,
+      createBackupOnSave: createBackupOnSave.value,
+    }
+  }
+
+  function importSettingsPackage(raw: string | SettingsPackage): boolean {
+    const packageValue =
+      typeof raw === 'string' ? parseSettingsPackage(raw) : isSettingsPackage(raw) ? raw : null
+
+    if (!packageValue) {
+      return false
+    }
+
+    setTheme(packageValue.theme)
+    setLocale(packageValue.locale)
+    sharedSessionPaths.value = [...packageValue.sharedSessionPaths]
+    shortcutOverrides.value = { ...packageValue.shortcutOverrides }
+    setAutoSaveLimit(packageValue.autoSaveLimit)
+    setFontFamily(packageValue.fontFamily)
+    setFontSize(packageValue.fontSize)
+    diffColors.value = { ...packageValue.diffColors }
+    setConfirmBeforeDelete(packageValue.confirmBeforeDelete)
+    setWrapTextDefault(packageValue.wrapTextDefault)
+    setShowSessionToolbars(packageValue.showSessionToolbars)
+    setShowToolbarLabels(packageValue.showToolbarLabels)
+    setCreateBackupOnSave(packageValue.createBackupOnSave)
+
+    return true
+  }
+
+  function restoreFactoryDefaults(): void {
+    setTheme('light')
+    setLocale(fallbackLocale)
+    sharedSessionPaths.value = []
+    shortcutOverrides.value = {}
+    setAutoSaveLimit(10)
+    setFontFamily('system')
+    setFontSize(14)
+    resetDiffColors()
+    setConfirmBeforeDelete(true)
+    setWrapTextDefault(false)
+    setShowSessionToolbars(true)
+    setShowToolbarLabels(true)
+    setCreateBackupOnSave(false)
+  }
+
   return {
     theme,
     resolvedTheme,
@@ -377,6 +445,9 @@ export const useSettingsStore = defineStore('settings', () => {
     setShowSessionToolbars,
     setShowToolbarLabels,
     setCreateBackupOnSave,
+    exportSettingsPackage,
+    importSettingsPackage,
+    restoreFactoryDefaults,
   }
 })
 

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -491,8 +491,47 @@ function applyFolderSessionSettings(
 watch(
   () => [viewActions.sequence, viewActions.name] as const,
   ([, actionName]) => {
-    if (actionName === 'session-settings') {
-      openFolderSessionSettings()
+    if (!actionName) {
+      return
+    }
+
+    switch (actionName) {
+      case 'session-settings':
+        openFolderSessionSettings()
+        break
+      case 'compare':
+      case 'reload':
+        if (leftRoot.value && rightRoot.value) {
+          void runFolderCompare()
+        }
+        break
+      case 'swap':
+        swapFolderRoots()
+        break
+      case 'rules':
+        showFolderRules.value = !showFolderRules.value
+        break
+      case 'filters':
+        showFolderFilters.value = !showFolderFilters.value
+        break
+      case 'export':
+        void exportFolderReport('html')
+        break
+      case 'show-all':
+        showAllFolderStatuses()
+        break
+      case 'show-differences':
+        visibleStatuses.value = new Set(['Different', 'Left only', 'Right only'])
+        persistDisplayFilters()
+        break
+      case 'copy-left':
+        copySelectedTo('Left')
+        break
+      case 'copy-right':
+        copySelectedTo('Right')
+        break
+      default:
+        break
     }
   },
 )

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -530,7 +530,26 @@ watch(
       case 'copy-right':
         copySelectedTo('Right')
         break
-      default:
+      case 'about':
+      case 'check-for-updates':
+      case 'close-tab':
+      case 'copy':
+      case 'cut':
+      case 'delete':
+      case 'export-settings':
+      case 'help-contents':
+      case 'help-support':
+      case 'import-settings':
+      case 'next-difference':
+      case 'paste':
+      case 'previous-difference':
+      case 'redo':
+      case 'restore-factory-defaults':
+      case 'save':
+      case 'save-as':
+      case 'undo':
+      case 'workspace-load':
+      case 'workspace-save':
         break
     }
   },

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -227,7 +227,34 @@ watch(
       case 'save':
         void runFolderMerge()
         break
-      default:
+      case 'about':
+      case 'check-for-updates':
+      case 'close-tab':
+      case 'copy':
+      case 'copy-left':
+      case 'copy-right':
+      case 'cut':
+      case 'delete':
+      case 'export':
+      case 'export-settings':
+      case 'filters':
+      case 'help-contents':
+      case 'help-support':
+      case 'import-settings':
+      case 'next-difference':
+      case 'paste':
+      case 'previous-difference':
+      case 'redo':
+      case 'restore-factory-defaults':
+      case 'rules':
+      case 'save-as':
+      case 'session-settings':
+      case 'show-all':
+      case 'show-differences':
+      case 'swap':
+      case 'undo':
+      case 'workspace-load':
+      case 'workspace-save':
         break
     }
   },

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -18,6 +18,7 @@ import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import { singlePathTitle } from '@/app/sessionToolbars'
 import { useI18n } from '@/i18n'
+import { useViewActionsStore } from '@/stores/viewActions'
 
 const leftPath = ref('')
 const basePath = ref('')
@@ -31,6 +32,7 @@ const router = useRouter()
 const sessionLaunch = useSessionLaunchStore()
 const tabs = useTabsStore()
 const { t } = useI18n()
+const viewActions = useViewActionsStore()
 const lastOpenedConflictPath = ref('')
 const sameOkOnly = ref(false)
 const showPeek = ref(false)
@@ -208,6 +210,27 @@ watch(
     }
   },
   { immediate: true },
+)
+
+watch(
+  () => [viewActions.sequence, viewActions.name] as const,
+  ([, actionName]) => {
+    if (!actionName) {
+      return
+    }
+
+    switch (actionName) {
+      case 'compare':
+      case 'reload':
+        void buildFolderMergePlan()
+        break
+      case 'save':
+        void runFolderMerge()
+        break
+      default:
+        break
+    }
+  },
 )
 </script>
 

--- a/src/views/FolderSyncView.vue
+++ b/src/views/FolderSyncView.vue
@@ -15,6 +15,7 @@ import { syncPathPairTitle } from '@/app/sessionToolbars'
 import { useI18n } from '@/i18n'
 import { useTabsStore } from '@/stores/tabs'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useViewActionsStore } from '@/stores/viewActions'
 
 interface SyncStrategyOption {
   value: FolderSyncStrategy
@@ -49,6 +50,7 @@ const strategyOptions: SyncStrategyOption[] = [
 const { t } = useI18n()
 const tabs = useTabsStore()
 const sessionLaunch = useSessionLaunchStore()
+const viewActions = useViewActionsStore()
 const leftPath = ref('')
 const rightPath = ref('')
 const selectedStrategy = ref<FolderSyncStrategy>('updateBoth')
@@ -257,6 +259,38 @@ watch(
     }
   },
   { immediate: true },
+)
+
+function swapSyncPaths(): void {
+  const nextLeft = rightPath.value
+  rightPath.value = leftPath.value
+  leftPath.value = nextLeft
+}
+
+watch(
+  () => [viewActions.sequence, viewActions.name] as const,
+  ([, actionName]) => {
+    if (!actionName) {
+      return
+    }
+
+    switch (actionName) {
+      case 'compare':
+        void previewSync()
+        break
+      case 'reload':
+        void previewSync()
+        break
+      case 'swap':
+        swapSyncPaths()
+        break
+      case 'save':
+        void runSync()
+        break
+      default:
+        break
+    }
+  },
 )
 </script>
 

--- a/src/views/FolderSyncView.vue
+++ b/src/views/FolderSyncView.vue
@@ -263,6 +263,7 @@ watch(
 
 function swapSyncPaths(): void {
   const nextLeft = rightPath.value
+
   rightPath.value = leftPath.value
   leftPath.value = nextLeft
 }
@@ -287,7 +288,33 @@ watch(
       case 'save':
         void runSync()
         break
-      default:
+      case 'about':
+      case 'check-for-updates':
+      case 'close-tab':
+      case 'copy':
+      case 'copy-left':
+      case 'copy-right':
+      case 'cut':
+      case 'delete':
+      case 'export':
+      case 'export-settings':
+      case 'filters':
+      case 'help-contents':
+      case 'help-support':
+      case 'import-settings':
+      case 'next-difference':
+      case 'paste':
+      case 'previous-difference':
+      case 'redo':
+      case 'restore-factory-defaults':
+      case 'rules':
+      case 'save-as':
+      case 'session-settings':
+      case 'show-all':
+      case 'show-differences':
+      case 'undo':
+      case 'workspace-load':
+      case 'workspace-save':
         break
     }
   },

--- a/src/views/HexCompareView.vue
+++ b/src/views/HexCompareView.vue
@@ -148,8 +148,40 @@ watch([hexLength, diffOnly], () => {
 watch(
   () => [viewActions.sequence, viewActions.name] as const,
   ([, actionName]) => {
-    if (actionName === 'session-settings') {
-      openHexSessionSettings()
+    if (!actionName) {
+      return
+    }
+
+    switch (actionName) {
+      case 'session-settings':
+      case 'rules':
+        openHexSessionSettings()
+        break
+      case 'compare':
+      case 'reload':
+        void runHexCompare()
+        break
+      case 'swap':
+        swapHexPaths()
+        break
+      case 'show-all':
+        diffOnly.value = false
+        break
+      case 'show-differences':
+      case 'filters':
+        diffOnly.value = true
+        break
+      case 'previous-difference':
+        goToHexDiffRange(activeDiffRangeIndex.value - 1)
+        break
+      case 'next-difference':
+        goToHexDiffRange(activeDiffRangeIndex.value + 1)
+        break
+      case 'save':
+        void runHexSave()
+        break
+      default:
+        break
     }
   },
 )

--- a/src/views/HexCompareView.vue
+++ b/src/views/HexCompareView.vue
@@ -180,7 +180,26 @@ watch(
       case 'save':
         void runHexSave()
         break
-      default:
+      case 'about':
+      case 'check-for-updates':
+      case 'close-tab':
+      case 'copy':
+      case 'copy-left':
+      case 'copy-right':
+      case 'cut':
+      case 'delete':
+      case 'export':
+      case 'export-settings':
+      case 'help-contents':
+      case 'help-support':
+      case 'import-settings':
+      case 'paste':
+      case 'redo':
+      case 'restore-factory-defaults':
+      case 'save-as':
+      case 'undo':
+      case 'workspace-load':
+      case 'workspace-save':
         break
     }
   },

--- a/src/views/PictureCompareView.vue
+++ b/src/views/PictureCompareView.vue
@@ -126,8 +126,24 @@ function applyPictureSessionSettings(
 watch(
   () => [viewActions.sequence, viewActions.name] as const,
   ([, actionName]) => {
-    if (actionName === 'session-settings') {
-      openPictureSessionSettings()
+    if (!actionName) {
+      return
+    }
+
+    switch (actionName) {
+      case 'session-settings':
+      case 'rules':
+        openPictureSessionSettings()
+        break
+      case 'compare':
+      case 'reload':
+        void runPictureCompare()
+        break
+      case 'swap':
+        swapPicturePaths()
+        break
+      default:
+        break
     }
   },
 )

--- a/src/views/PictureCompareView.vue
+++ b/src/views/PictureCompareView.vue
@@ -142,7 +142,32 @@ watch(
       case 'swap':
         swapPicturePaths()
         break
-      default:
+      case 'about':
+      case 'check-for-updates':
+      case 'close-tab':
+      case 'copy':
+      case 'copy-left':
+      case 'copy-right':
+      case 'cut':
+      case 'delete':
+      case 'export':
+      case 'export-settings':
+      case 'filters':
+      case 'help-contents':
+      case 'help-support':
+      case 'import-settings':
+      case 'next-difference':
+      case 'paste':
+      case 'previous-difference':
+      case 'redo':
+      case 'restore-factory-defaults':
+      case 'save':
+      case 'save-as':
+      case 'show-all':
+      case 'show-differences':
+      case 'undo':
+      case 'workspace-load':
+      case 'workspace-save':
         break
     }
   },

--- a/src/views/TableCompareView.vue
+++ b/src/views/TableCompareView.vue
@@ -154,8 +154,30 @@ watch(
 watch(
   () => [viewActions.sequence, viewActions.name] as const,
   ([, actionName]) => {
-    if (actionName === 'session-settings') {
-      openTableSessionSettings()
+    if (!actionName) {
+      return
+    }
+
+    switch (actionName) {
+      case 'session-settings':
+      case 'rules':
+        openTableSessionSettings()
+        break
+      case 'compare':
+      case 'reload':
+        void runTableCompare()
+        break
+      case 'swap':
+        swapTablePaths()
+        break
+      case 'previous-difference':
+        goToPreviousTableDifference()
+        break
+      case 'next-difference':
+        goToNextTableDifference()
+        break
+      default:
+        break
     }
   },
 )

--- a/src/views/TableCompareView.vue
+++ b/src/views/TableCompareView.vue
@@ -176,7 +176,30 @@ watch(
       case 'next-difference':
         goToNextTableDifference()
         break
-      default:
+      case 'about':
+      case 'check-for-updates':
+      case 'close-tab':
+      case 'copy':
+      case 'copy-left':
+      case 'copy-right':
+      case 'cut':
+      case 'delete':
+      case 'export':
+      case 'export-settings':
+      case 'filters':
+      case 'help-contents':
+      case 'help-support':
+      case 'import-settings':
+      case 'paste':
+      case 'redo':
+      case 'restore-factory-defaults':
+      case 'save':
+      case 'save-as':
+      case 'show-all':
+      case 'show-differences':
+      case 'undo':
+      case 'workspace-load':
+      case 'workspace-save':
         break
     }
   },

--- a/src/views/TextCompareView.vue
+++ b/src/views/TextCompareView.vue
@@ -131,8 +131,56 @@ function applyTextSessionSettings(
 watch(
   () => [viewActions.sequence, viewActions.name] as const,
   ([, actionName]) => {
-    if (actionName === 'session-settings') {
-      openTextSessionSettings()
+    if (!actionName) {
+      return
+    }
+
+    switch (actionName) {
+      case 'session-settings':
+        openTextSessionSettings()
+        break
+      case 'compare':
+        void runDiff()
+        break
+      case 'reload':
+        if (leftPathLabel.value && rightPathLabel.value) {
+          void loadLaunchTextFiles(leftPathLabel.value, rightPathLabel.value)
+        } else {
+          void runDiff()
+        }
+        break
+      case 'swap':
+        swapPaths()
+        break
+      case 'rules':
+        showTextRules.value = !showTextRules.value
+        break
+      case 'filters':
+        textDiffPanelRef.value?.setDisplayMode('differences')
+        break
+      case 'export':
+        void exportCurrentReport('html')
+        break
+      case 'show-all':
+        textDiffPanelRef.value?.setDisplayMode('all')
+        break
+      case 'show-differences':
+        textDiffPanelRef.value?.setDisplayMode('differences')
+        break
+      case 'previous-difference':
+        goToPreviousDiff()
+        break
+      case 'next-difference':
+        goToNextDiff()
+        break
+      case 'copy-left':
+        copyCurrentDiff('rightToLeft')
+        break
+      case 'copy-right':
+        copyCurrentDiff('leftToRight')
+        break
+      default:
+        break
     }
   },
 )

--- a/src/views/TextCompareView.vue
+++ b/src/views/TextCompareView.vue
@@ -179,7 +179,24 @@ watch(
       case 'copy-right':
         copyCurrentDiff('leftToRight')
         break
-      default:
+      case 'about':
+      case 'check-for-updates':
+      case 'close-tab':
+      case 'copy':
+      case 'cut':
+      case 'delete':
+      case 'export-settings':
+      case 'help-contents':
+      case 'help-support':
+      case 'import-settings':
+      case 'paste':
+      case 'redo':
+      case 'restore-factory-defaults':
+      case 'save':
+      case 'save-as':
+      case 'undo':
+      case 'workspace-load':
+      case 'workspace-save':
         break
     }
   },

--- a/src/views/TextMergeView.vue
+++ b/src/views/TextMergeView.vue
@@ -8,6 +8,7 @@ import { useI18n } from '@/i18n'
 import { useTabsStore } from '@/stores/tabs'
 import { useSettingsStore } from '@/stores/settings'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useViewActionsStore } from '@/stores/viewActions'
 
 type MergePaneId = 'left' | 'base' | 'right' | 'output'
 type MergeSource = 'left' | 'base' | 'right'
@@ -37,6 +38,7 @@ const { t } = useI18n()
 const tabs = useTabsStore()
 const settings = useSettingsStore()
 const sessionLaunch = useSessionLaunchStore()
+const viewActions = useViewActionsStore()
 const leftPath = ref('')
 const rightPath = ref('')
 const centerPath = ref('')
@@ -367,6 +369,34 @@ watch(
     }
   },
   { immediate: true },
+)
+
+watch(
+  () => [viewActions.sequence, viewActions.name] as const,
+  ([, actionName]) => {
+    if (!actionName) {
+      return
+    }
+
+    switch (actionName) {
+      case 'compare':
+      case 'reload':
+        void loadMerge()
+        break
+      case 'save':
+      case 'export':
+        void saveOutput()
+        break
+      case 'copy-left':
+        favorSide('left')
+        break
+      case 'copy-right':
+        favorSide('right')
+        break
+      default:
+        break
+    }
+  },
 )
 </script>
 

--- a/src/views/TextMergeView.vue
+++ b/src/views/TextMergeView.vue
@@ -393,7 +393,31 @@ watch(
       case 'copy-right':
         favorSide('right')
         break
-      default:
+      case 'about':
+      case 'check-for-updates':
+      case 'close-tab':
+      case 'copy':
+      case 'cut':
+      case 'delete':
+      case 'export-settings':
+      case 'filters':
+      case 'help-contents':
+      case 'help-support':
+      case 'import-settings':
+      case 'next-difference':
+      case 'paste':
+      case 'previous-difference':
+      case 'redo':
+      case 'restore-factory-defaults':
+      case 'rules':
+      case 'save-as':
+      case 'session-settings':
+      case 'show-all':
+      case 'show-differences':
+      case 'swap':
+      case 'undo':
+      case 'workspace-load':
+      case 'workspace-save':
         break
     }
   },


### PR DESCRIPTION
## Summary
- Enable Session/Actions/View menu commands for compare, swap, reload, rules, filters, and export by dispatching view-actions into existing Folder/Text/Hex/Table/Picture/Sync/Merge handlers.
- Wire Tools export/import settings and restore factory defaults to a real settings package; wire Load/Save Workspace through the workspaces store.
- Leave truly unimplemented items disabled (New Window, Exit, Save Snapshot) without fake success.
- Add menu enablement tests, settings package coverage, and typecheck-clean changes. Rebased onto latest master after #76.

### Became real
- Session: Compare, Swap, Reload, Rules, Export, Load Workspace, Save Workspace As, Save/Save As/Settings/Close (already hooked; now consumed more deeply)
- View: Show All, Show Differences, Filters, Swap, Reload
- Actions (Folder/Sync/Merge): Compare, Swap, Reload, Rules, Filters
- Tools: Export Settings, Import Settings, Restore Factory Defaults, Options/File Formats/Profiles/Text Edit/Text Patch/Theme (already real)

### Still disabled
- Session: New Window, Exit
- Tools: Save Snapshot

## Test plan
- [x] `vue-tsc --noEmit`
- [x] Unit: AppLayout menu enablement + dispatch, commandRegistry, settings package/store
- [x] Unit: Folder/Text/Sync/Merge view suites
- [ ] Manual: open Folder/Text/Sync/Merge, run Session Compare/Swap/Reload/Rules and View Filters from menus
- [ ] Manual: Tools Export/Import Settings and Restore Factory Defaults