### PR TITLE
Deepen session path-pair titles, folder name filters, and Home density

### DIFF
--- a/src-tauri/crates/folder-core/src/lib.rs
+++ b/src-tauri/crates/folder-core/src/lib.rs
@@ -255,11 +255,7 @@ impl Default for FileFilters {
 impl FileFilters {
     pub fn allows(&self, relative_path: &str) -> bool {
         let path = filter_path(relative_path, self.case_sensitive);
-        let name = path
-            .rsplit('/')
-            .next()
-            .unwrap_or(path.as_str())
-            .to_owned();
+        let name = path.rsplit('/').next().unwrap_or(path.as_str()).to_owned();
         let included = self.include.is_empty()
             || self.include.iter().any(|pattern| {
                 let normalized = filter_path(pattern, self.case_sensitive);
@@ -297,8 +293,7 @@ pub fn filter_alignment_rows(
         }
     }
 
-    rows
-        .into_iter()
+    rows.into_iter()
         .filter(|row| keep.contains(&row.relative_path))
         .collect()
 }

--- a/src-tauri/crates/folder-core/src/lib.rs
+++ b/src-tauri/crates/folder-core/src/lib.rs
@@ -255,18 +255,52 @@ impl Default for FileFilters {
 impl FileFilters {
     pub fn allows(&self, relative_path: &str) -> bool {
         let path = filter_path(relative_path, self.case_sensitive);
+        let name = path
+            .rsplit('/')
+            .next()
+            .unwrap_or(path.as_str())
+            .to_owned();
         let included = self.include.is_empty()
-            || self
-                .include
-                .iter()
-                .any(|pattern| wildcard_matches(&filter_path(pattern, self.case_sensitive), &path));
-        let excluded = self
-            .exclude
-            .iter()
-            .any(|pattern| wildcard_matches(&filter_path(pattern, self.case_sensitive), &path));
+            || self.include.iter().any(|pattern| {
+                let normalized = filter_path(pattern, self.case_sensitive);
+                wildcard_matches(&normalized, &path) || wildcard_matches(&normalized, &name)
+            });
+        let excluded = self.exclude.iter().any(|pattern| {
+            let normalized = filter_path(pattern, self.case_sensitive);
+            wildcard_matches(&normalized, &path) || wildcard_matches(&normalized, &name)
+        });
 
         included && !excluded
     }
+}
+
+pub fn filter_alignment_rows(
+    rows: Vec<FolderAlignmentRow>,
+    filters: &FileFilters,
+) -> Vec<FolderAlignmentRow> {
+    if filters.include.is_empty() && filters.exclude.is_empty() {
+        return rows;
+    }
+
+    let matched: std::collections::HashSet<String> = rows
+        .iter()
+        .filter(|row| filters.allows(&row.relative_path))
+        .map(|row| row.relative_path.clone())
+        .collect();
+
+    let mut keep = matched.clone();
+    for path in &matched {
+        let mut end = path.len();
+        while let Some(slash) = path[..end].rfind('/') {
+            keep.insert(path[..slash].to_owned());
+            end = slash;
+        }
+    }
+
+    rows
+        .into_iter()
+        .filter(|row| keep.contains(&row.relative_path))
+        .collect()
 }
 
 impl FolderScanNode {
@@ -1710,6 +1744,50 @@ mod tests {
         assert!(!filters.allows("src/main.ts"));
         assert!(!filters.allows("target/debug/app.rs"));
         assert!(!filters.allows("notes.tmp"));
+        assert!(!filters.allows("build/notes.tmp"));
+    }
+
+    #[test]
+    fn filter_alignment_rows_keeps_matches_and_ancestors() {
+        let filters = FileFilters {
+            include: vec!["*.rs".to_owned()],
+            exclude: Vec::new(),
+            case_sensitive: true,
+        };
+        let rows = vec![
+            FolderAlignmentRow {
+                relative_path: "src".to_owned(),
+                depth: 0,
+                left: None,
+                right: None,
+            },
+            FolderAlignmentRow {
+                relative_path: "src/main.rs".to_owned(),
+                depth: 1,
+                left: None,
+                right: None,
+            },
+            FolderAlignmentRow {
+                relative_path: "src/main.ts".to_owned(),
+                depth: 1,
+                left: None,
+                right: None,
+            },
+            FolderAlignmentRow {
+                relative_path: "README.md".to_owned(),
+                depth: 0,
+                left: None,
+                right: None,
+            },
+        ];
+
+        let filtered = filter_alignment_rows(rows, &filters);
+        let paths: Vec<_> = filtered
+            .iter()
+            .map(|row| row.relative_path.as_str())
+            .collect();
+
+        assert_eq!(paths, vec!["src", "src/main.rs"]);
     }
 
     fn metadata(kind: VfsEntryKind, name: &str, extension: Option<&str>, size: u64) -> VfsMetadata {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -367,6 +367,31 @@ impl FolderCompareCriteria {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderNameFilters {
+    #[serde(default)]
+    pub include: Vec<String>,
+    #[serde(default)]
+    pub exclude: Vec<String>,
+    #[serde(default)]
+    pub case_sensitive: bool,
+}
+
+impl FolderNameFilters {
+    fn to_file_filters(&self) -> folder_core::FileFilters {
+        folder_core::FileFilters {
+            include: self.include.clone(),
+            exclude: self.exclude.clone(),
+            case_sensitive: self.case_sensitive,
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        !self.include.is_empty() || !self.exclude.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct FolderCompareRow {
@@ -731,9 +756,11 @@ pub fn compare_folder_paths(
     left_root: String,
     right_root: String,
     criteria: Option<FolderCompareCriteria>,
+    filters: Option<FolderNameFilters>,
 ) -> Result<FolderCompareResponse, AppErrorPayload> {
     let criteria = criteria.unwrap_or_default();
     let options = criteria.to_options();
+    let name_filters = filters.unwrap_or_default();
     let left_source = crate::sources::load_compare_source(&left_root)
         .map_err(|error| compare_source_error(&left_root, error))?;
     let right_source = crate::sources::load_compare_source(&right_root)
@@ -744,6 +771,11 @@ pub fn compare_folder_paths(
         .map_err(|error| compare_source_error(&right_root, error))?;
     let alignment_rows =
         folder_core::align_folder_trees_with_options(&left_tree, &right_tree, &options);
+    let alignment_rows = if name_filters.is_active() {
+        folder_core::filter_alignment_rows(alignment_rows, &name_filters.to_file_filters())
+    } else {
+        alignment_rows
+    };
     let rows = alignment_rows
         .iter()
         .map(|row| {
@@ -4494,10 +4526,11 @@ mod tests {
         fs::write(right.join("README.md"), "same").expect("right readme should be writable");
 
         let response = compare_folder_paths(
-            left.display().to_string(),
-            right.display().to_string(),
-            None,
-        )
+        left.display().to_string(),
+        right.display().to_string(),
+        None,
+        None,
+    )
         .expect("valid folders should compare");
 
         assert_eq!(response.left_root, left.display().to_string());
@@ -5250,10 +5283,11 @@ mod tests {
         fs::write(&right, archive_core::write_zip_bytes(&right_doc).unwrap()).unwrap();
 
         let response = compare_folder_paths(
-            left.display().to_string(),
-            right.display().to_string(),
-            None,
-        )
+        left.display().to_string(),
+        right.display().to_string(),
+        None,
+        None,
+    )
         .expect("zip archives should compare as folders");
 
         assert!(response

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4562,6 +4562,7 @@ mod tests {
                 compare_contents: false,
                 compare_crc: false,
             }),
+            None,
         )
         .expect("size-only compare");
         let contents = compare_folder_paths(
@@ -4573,6 +4574,7 @@ mod tests {
                 compare_contents: true,
                 compare_crc: false,
             }),
+            None,
         )
         .expect("contents compare");
         let crc = compare_folder_paths(
@@ -4584,6 +4586,7 @@ mod tests {
                 compare_contents: false,
                 compare_crc: true,
             }),
+            None,
         )
         .expect("crc compare");
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4526,11 +4526,11 @@ mod tests {
         fs::write(right.join("README.md"), "same").expect("right readme should be writable");
 
         let response = compare_folder_paths(
-        left.display().to_string(),
-        right.display().to_string(),
-        None,
-        None,
-    )
+            left.display().to_string(),
+            right.display().to_string(),
+            None,
+            None,
+        )
         .expect("valid folders should compare");
 
         assert_eq!(response.left_root, left.display().to_string());
@@ -5283,11 +5283,11 @@ mod tests {
         fs::write(&right, archive_core::write_zip_bytes(&right_doc).unwrap()).unwrap();
 
         let response = compare_folder_paths(
-        left.display().to_string(),
-        right.display().to_string(),
-        None,
-        None,
-    )
+            left.display().to_string(),
+            right.display().to_string(),
+            None,
+            None,
+        )
         .expect("zip archives should compare as folders");
 
         assert!(response

--- a/src/api/diff.test.ts
+++ b/src/api/diff.test.ts
@@ -145,6 +145,7 @@ describe('diff api', () => {
       leftRoot: 'D:/left',
       rightRoot: 'D:/right',
       criteria: undefined,
+      filters: undefined,
     })
     expect(result.rows[0]?.relativePath).toBe('src/main.ts')
   })

--- a/src/api/diff.ts
+++ b/src/api/diff.ts
@@ -104,6 +104,7 @@ export function compareFolderPaths(request: FolderCompareRequest): Promise<Folde
     leftRoot: request.leftRoot,
     rightRoot: request.rightRoot,
     criteria: request.criteria,
+    filters: request.filters,
   })
 }
 

--- a/src/app/folderNameFilters.test.ts
+++ b/src/app/folderNameFilters.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  defaultFolderNameFilters,
+  folderNameFiltersAreActive,
+  folderNameFiltersStorageKey,
+  formatFolderNameFilterDraft,
+  loadFolderNameFilters,
+  normalizeFolderNameFilters,
+  parseFolderNameFilterDraft,
+  saveFolderNameFilters,
+} from './folderNameFilters'
+
+describe('folderNameFilters', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('parses and formats include/exclude drafts', () => {
+    expect(parseFolderNameFilterDraft('*.ts, src/**\n*.tmp ; docs')).toEqual([
+      '*.ts',
+      'src/**',
+      '*.tmp',
+      'docs',
+    ])
+    expect(formatFolderNameFilterDraft(['*.ts', '*.md'])).toBe('*.ts\n*.md')
+  })
+
+  it('normalizes partial payloads', () => {
+    expect(
+      normalizeFolderNameFilters({
+        include: ['  *.rs ', '', 12 as unknown as string],
+        exclude: ['target/**'],
+        caseSensitive: true,
+      }),
+    ).toEqual({
+      include: ['*.rs'],
+      exclude: ['target/**'],
+      caseSensitive: true,
+    })
+    expect(defaultFolderNameFilters()).toEqual({
+      include: [],
+      exclude: [],
+      caseSensitive: false,
+    })
+  })
+
+  it('persists and reloads name filters', () => {
+    saveFolderNameFilters({
+      include: ['*.vue'],
+      exclude: ['node_modules/**'],
+      caseSensitive: false,
+    })
+
+    const stored = JSON.parse(localStorage.getItem(folderNameFiltersStorageKey) ?? '{}') as {
+      include: string[]
+      exclude: string[]
+    }
+
+    expect(stored.include).toEqual(['*.vue'])
+    expect(stored.exclude).toEqual(['node_modules/**'])
+    expect(loadFolderNameFilters()).toEqual({
+      include: ['*.vue'],
+      exclude: ['node_modules/**'],
+      caseSensitive: false,
+    })
+    expect(
+      folderNameFiltersAreActive({
+        include: ['*.vue'],
+        exclude: [],
+        caseSensitive: false,
+      }),
+    ).toBe(true)
+    expect(folderNameFiltersAreActive(defaultFolderNameFilters())).toBe(false)
+  })
+})

--- a/src/app/folderNameFilters.ts
+++ b/src/app/folderNameFilters.ts
@@ -67,6 +67,7 @@ export function saveFolderNameFilters(
   storage: Pick<Storage, 'setItem'> = localStorage,
 ): void {
   const normalized = normalizeFolderNameFilters(state)
+
   storage.setItem(
     folderNameFiltersStorageKey,
     JSON.stringify({

--- a/src/app/folderNameFilters.ts
+++ b/src/app/folderNameFilters.ts
@@ -1,0 +1,82 @@
+export const folderNameFiltersStorageKey = 'open-diff-folder-name-filters'
+
+export interface FolderNameFilters {
+  include: string[]
+  exclude: string[]
+  caseSensitive: boolean
+}
+
+export function defaultFolderNameFilters(): FolderNameFilters {
+  return {
+    include: [],
+    exclude: [],
+    caseSensitive: false,
+  }
+}
+
+function parsePatternList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+export function normalizeFolderNameFilters(
+  value: Partial<FolderNameFilters> | null | undefined,
+): FolderNameFilters {
+  return {
+    include: parsePatternList(value?.include),
+    exclude: parsePatternList(value?.exclude),
+    caseSensitive: Boolean(value?.caseSensitive),
+  }
+}
+
+export function parseFolderNameFilterDraft(raw: string): string[] {
+  return raw
+    .split(/[\n,;]/u)
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+export function formatFolderNameFilterDraft(patterns: string[]): string {
+  return patterns.join('\n')
+}
+
+export function loadFolderNameFilters(
+  storage: Pick<Storage, 'getItem'> = localStorage,
+): FolderNameFilters {
+  try {
+    const raw = storage.getItem(folderNameFiltersStorageKey)
+
+    if (!raw) {
+      return defaultFolderNameFilters()
+    }
+
+    return normalizeFolderNameFilters(JSON.parse(raw) as Partial<FolderNameFilters>)
+  } catch {
+    return defaultFolderNameFilters()
+  }
+}
+
+export function saveFolderNameFilters(
+  state: FolderNameFilters,
+  storage: Pick<Storage, 'setItem'> = localStorage,
+): void {
+  const normalized = normalizeFolderNameFilters(state)
+  storage.setItem(
+    folderNameFiltersStorageKey,
+    JSON.stringify({
+      include: normalized.include,
+      exclude: normalized.exclude,
+      caseSensitive: normalized.caseSensitive,
+    }),
+  )
+}
+
+export function folderNameFiltersAreActive(filters: FolderNameFilters): boolean {
+  return filters.include.length > 0 || filters.exclude.length > 0
+}

--- a/src/components/session/SessionSettingsDialog.vue
+++ b/src/components/session/SessionSettingsDialog.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import type { FolderCompareCriteria } from '@/types/diff'
+import {
+  formatFolderNameFilterDraft,
+  normalizeFolderNameFilters,
+  parseFolderNameFilterDraft,
+  type FolderNameFilters,
+} from '@/app/folderNameFilters'
 import type { TextCompareSessionOptions } from '@/app/textCompareSessionOptions'
 import type { TableCompareSessionOptions } from '@/app/tableCompareSessionOptions'
 import type { HexCompareSessionOptions } from '@/app/hexCompareSessionOptions'
@@ -16,6 +22,7 @@ const props = withDefaults(
     open: boolean
     kind: SessionSettingsKind
     folderCriteria?: FolderCompareCriteria
+    folderFilters?: FolderNameFilters
     textOptions?: TextCompareSessionOptions
     tableOptions?: TableCompareSessionOptions
     hexOptions?: HexCompareSessionOptions
@@ -27,6 +34,11 @@ const props = withDefaults(
       compareModifiedTime: false,
       compareContents: true,
       compareCrc: false,
+    }),
+    folderFilters: () => ({
+      include: [],
+      exclude: [],
+      caseSensitive: false,
     }),
     textOptions: () => ({
       algorithm: 'myers',
@@ -52,7 +64,7 @@ const emit = defineEmits<{
   close: []
   apply: [
     payload:
-      | { kind: 'folder'; criteria: FolderCompareCriteria }
+      | { kind: 'folder'; criteria: FolderCompareCriteria; filters: FolderNameFilters }
       | { kind: 'text'; options: TextCompareSessionOptions }
       | { kind: 'table'; options: TableCompareSessionOptions }
       | { kind: 'hex'; options: HexCompareSessionOptions }
@@ -66,6 +78,9 @@ type TextTab = 'importance' | 'alignment'
 const folderTab = ref<FolderTab>('comparison')
 const textTab = ref<TextTab>('importance')
 const draftFolder = ref<FolderCompareCriteria>({ ...props.folderCriteria })
+const draftFolderFilters = ref<FolderNameFilters>(normalizeFolderNameFilters(props.folderFilters))
+const includeFiltersDraft = ref(formatFolderNameFilterDraft(props.folderFilters.include))
+const excludeFiltersDraft = ref(formatFolderNameFilterDraft(props.folderFilters.exclude))
 const draftText = ref<TextCompareSessionOptions>({
   ...props.textOptions,
   ignoreRegexes: [...props.textOptions.ignoreRegexes],
@@ -84,6 +99,7 @@ watch(
     [
       props.open,
       props.folderCriteria,
+      props.folderFilters,
       props.textOptions,
       props.tableOptions,
       props.hexOptions,
@@ -95,6 +111,9 @@ watch(
     }
 
     draftFolder.value = { ...props.folderCriteria }
+    draftFolderFilters.value = normalizeFolderNameFilters(props.folderFilters)
+    includeFiltersDraft.value = formatFolderNameFilterDraft(props.folderFilters.include)
+    excludeFiltersDraft.value = formatFolderNameFilterDraft(props.folderFilters.exclude)
     draftText.value = {
       ...props.textOptions,
       ignoreRegexes: [...props.textOptions.ignoreRegexes],
@@ -131,7 +150,15 @@ const titleKey = computed(() => {
 
 function applySettings(): void {
   if (props.kind === 'folder') {
-    emit('apply', { kind: 'folder', criteria: { ...draftFolder.value } })
+    emit('apply', {
+      kind: 'folder',
+      criteria: { ...draftFolder.value },
+      filters: normalizeFolderNameFilters({
+        include: parseFolderNameFilterDraft(includeFiltersDraft.value),
+        exclude: parseFolderNameFilterDraft(excludeFiltersDraft.value),
+        caseSensitive: draftFolderFilters.value.caseSensitive,
+      }),
+    })
 
     return
   }
@@ -292,6 +319,32 @@ function applySettings(): void {
         data-testid="session-settings-folder-filters"
       >
         <p>{{ $t('ui.sessionSettingsFiltersHint') }}</p>
+        <label class="stack">
+          <span>{{ $t('ui.includePatterns') }}</span>
+          <textarea
+            v-model="includeFiltersDraft"
+            rows="4"
+            data-testid="session-settings-include-patterns"
+            :placeholder="$t('ui.globPatterns')"
+          />
+        </label>
+        <label class="stack">
+          <span>{{ $t('ui.excludePatterns') }}</span>
+          <textarea
+            v-model="excludeFiltersDraft"
+            rows="4"
+            data-testid="session-settings-exclude-patterns"
+            :placeholder="$t('ui.globPatterns')"
+          />
+        </label>
+        <label>
+          <input
+            v-model="draftFolderFilters.caseSensitive"
+            type="checkbox"
+            data-testid="session-settings-filters-case-sensitive"
+          />
+          <span>{{ $t('ui.caseSensitiveNames') }}</span>
+        </label>
       </div>
 
       <div
@@ -515,6 +568,18 @@ h2 {
 .settings-body label.stack {
   display: grid;
   gap: 4px;
+}
+
+.settings-body textarea {
+  width: 100%;
+  min-height: 84px;
+  padding: 8px;
+  border: 1px solid var(--app-border);
+  border-radius: 4px;
+  background: var(--app-surface-low, #ffffff);
+  color: var(--app-text);
+  font: inherit;
+  resize: vertical;
 }
 
 footer {

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -881,8 +881,11 @@ export const deDE: LanguagePack = {
     'ui.alignment': 'Ausrichtung',
     'ui.replacements': 'Ersetzungen',
     'ui.apply': 'Übernehmen',
+    'ui.includePatterns': 'Namen einschließen',
+    'ui.excludePatterns': 'Namen ausschließen',
+    'ui.caseSensitiveNames': 'Groß-/Kleinschreibung beachten',
     'ui.sessionSettingsFiltersHint':
-      'Anzeigefilter bleiben im Filter-Werkzeugleistenpanel und bleiben über erneute Scans hinweg erhalten.',
+      'Einschluss-/Ausschlussmuster für Namen gelten beim nächsten Scan/Vergleich und bleiben auf diesem Gerät erhalten. Anzeigestatusfilter bleiben im Filter-Werkzeugleistenbereich.',
     'ui.goTo': 'Gehe zu',
     'ui.goToOffset': 'Zu Offset gehen',
     'ui.hexOffsetHint': 'Dezimal oder Hex (0x…); Werte über 0x7FFFFFFF werden unterstützt',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -861,8 +861,11 @@ export const enUS: LanguagePack = {
     'ui.alignment': 'Alignment',
     'ui.replacements': 'Replacements',
     'ui.apply': 'Apply',
+    'ui.includePatterns': 'Include names',
+    'ui.excludePatterns': 'Exclude names',
+    'ui.caseSensitiveNames': 'Case-sensitive names',
     'ui.sessionSettingsFiltersHint':
-      'Display filters stay on the Filters toolbar panel and persist across rescans.',
+      'Name include/exclude patterns apply on the next scan/compare and persist for this workstation. Display status filters stay on the Filters toolbar panel.',
     'ui.goTo': 'Go To',
     'ui.goToOffset': 'Go to offset',
     'ui.hexOffsetHint': 'Decimal or hex (0x…); values past 0x7FFFFFFF are supported',

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -876,8 +876,11 @@ export const esES: LanguagePack = {
     'ui.alignment': 'Alineación',
     'ui.replacements': 'Reemplazos',
     'ui.apply': 'Aplicar',
+    'ui.includePatterns': 'Incluir nombres',
+    'ui.excludePatterns': 'Excluir nombres',
+    'ui.caseSensitiveNames': 'Nombres sensibles a mayúsculas',
     'ui.sessionSettingsFiltersHint':
-      'Los filtros de visualización permanecen en el panel Filtros y se conservan tras volver a explorar.',
+      'Los patrones de inclusión/exclusión de nombres se aplican en el próximo análisis/comparación y se conservan en este equipo. Los filtros de estado de visualización permanecen en el panel Filtros de la barra de herramientas.',
     'ui.goTo': 'Ir a',
     'ui.goToOffset': 'Ir al desplazamiento',
     'ui.hexOffsetHint': 'Decimal o hex (0x…); se admiten valores mayores que 0x7FFFFFFF',

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -878,8 +878,11 @@ export const frFR: LanguagePack = {
     'ui.alignment': 'Alignement',
     'ui.replacements': 'Remplacements',
     'ui.apply': 'Appliquer',
+    'ui.includePatterns': 'Inclure les noms',
+    'ui.excludePatterns': 'Exclure les noms',
+    'ui.caseSensitiveNames': 'Noms sensibles à la casse',
     'ui.sessionSettingsFiltersHint':
-      'Les filtres d’affichage restent dans le panneau Filtres et persistent après rescan.',
+      'Les motifs d’inclusion/exclusion de noms s’appliquent au prochain scan/comparaison et sont conservés sur ce poste. Les filtres d’état d’affichage restent dans le panneau Filtres de la barre d’outils.',
     'ui.goTo': 'Aller à',
     'ui.goToOffset': 'Aller à l’offset',
     'ui.hexOffsetHint': 'Décimal ou hex (0x…) ; valeurs au-delà de 0x7FFFFFFF prises en charge',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -861,8 +861,11 @@ export const jaJP: LanguagePack = {
     'ui.alignment': '整列',
     'ui.replacements': '置換',
     'ui.apply': '適用',
+    'ui.includePatterns': '名前を含める',
+    'ui.excludePatterns': '名前を除外',
+    'ui.caseSensitiveNames': '名前の大文字小文字を区別',
     'ui.sessionSettingsFiltersHint':
-      '表示フィルターはフィルターツールバーパネルにあり、再スキャン後も保持されます。',
+      '名前の含め/除外パターンは次回のスキャン/比較で適用され、この端末に保持されます。表示ステータスフィルタはフィルタツールバーパネルに残ります。',
     'ui.goTo': '移動',
     'ui.goToOffset': 'オフセットへ移動',
     'ui.hexOffsetHint': '10 進または 16 進 (0x…)；0x7FFFFFFF を超える値に対応',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -855,8 +855,11 @@ export const koKR: LanguagePack = {
     'ui.alignment': '정렬',
     'ui.replacements': '치환',
     'ui.apply': '적용',
+    'ui.includePatterns': '이름 포함',
+    'ui.excludePatterns': '이름 제외',
+    'ui.caseSensitiveNames': '이름 대소문자 구분',
     'ui.sessionSettingsFiltersHint':
-      '표시 필터는 필터 도구 모음 패널에 있으며 다시 검색한 후에도 유지됩니다.',
+      '이름 포함/제외 패턴은 다음 스캔/비교 때 적용되며 이 워크스테이션에 유지됩니다. 표시 상태 필터는 필터 도구 모음 패널에 그대로 있습니다.',
     'ui.goTo': '이동',
     'ui.goToOffset': '오프셋으로 이동',
     'ui.hexOffsetHint': '십진수 또는 십육진수(0x…); 0x7FFFFFFF보다 큰 값 지원',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -836,7 +836,11 @@ export const zhCN: LanguagePack = {
     'ui.alignment': '对齐',
     'ui.replacements': '替换规则',
     'ui.apply': '应用',
-    'ui.sessionSettingsFiltersHint': '显示过滤器位于过滤器工具栏面板，并在重新扫描后保留。',
+    'ui.includePatterns': '包含名称',
+    'ui.excludePatterns': '排除名称',
+    'ui.caseSensitiveNames': '区分大小写的名称',
+    'ui.sessionSettingsFiltersHint':
+      '名称包含/排除模式在下次扫描/比较时生效，并在本机保留。显示状态过滤器仍在过滤器工具栏面板中。',
     'ui.goTo': '转到',
     'ui.goToOffset': '转到偏移',
     'ui.hexOffsetHint': '十进制或十六进制（0x…）；支持超过 0x7FFFFFFF 的值',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -837,7 +837,11 @@ export const zhTW: LanguagePack = {
     'ui.alignment': '對齊',
     'ui.replacements': '取代規則',
     'ui.apply': '套用',
-    'ui.sessionSettingsFiltersHint': '顯示篩選器位於篩選器工具列面板，並在重新掃描後保留。',
+    'ui.includePatterns': '包含名稱',
+    'ui.excludePatterns': '排除名稱',
+    'ui.caseSensitiveNames': '區分大小寫的名稱',
+    'ui.sessionSettingsFiltersHint':
+      '名稱包含/排除模式會在下次掃描/比較時生效，並在本機保留。顯示狀態篩選器仍在篩選器工具列面板中。',
     'ui.goTo': '前往',
     'ui.goToOffset': '前往偏移',
     'ui.hexOffsetHint': '十進位或十六進位（0x…）；支援超過 0x7FFFFFFF 的值',

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -165,10 +165,17 @@ export interface FolderCompareCriteria {
   compareCrc: boolean
 }
 
+export interface FolderNameFilters {
+  include: string[]
+  exclude: string[]
+  caseSensitive?: boolean
+}
+
 export interface FolderCompareRequest {
   leftRoot: string
   rightRoot: string
   criteria?: FolderCompareCriteria
+  filters?: FolderNameFilters
 }
 
 export type FolderCompareStatus = 'Same' | 'Different' | 'Left only' | 'Right only'

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -709,6 +709,7 @@ describe('FolderCompareView', () => {
     const storedFilters = JSON.parse(
       localStorage.getItem('open-diff-folder-name-filters') ?? '{}',
     ) as { include: string[]; exclude: string[] }
+
     expect(storedFilters.include).toEqual(['*.md', '*.txt'])
     expect(storedFilters.exclude).toEqual(['node_modules/**'])
 

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -375,6 +375,11 @@ describe('FolderCompareView', () => {
         compareContents: true,
         compareCrc: false,
       },
+      filters: {
+        include: [],
+        exclude: [],
+        caseSensitive: false,
+      },
     })
     expect(wrapper.text()).toContain('main.ts')
     expect(wrapper.text()).toContain('Different')
@@ -691,11 +696,19 @@ describe('FolderCompareView', () => {
     await wrapper.find('[data-testid="open-folder-session-settings"]').trigger('click')
     expect(wrapper.find('[data-testid="session-settings-dialog"]').exists()).toBe(true)
     await wrapper.find('[data-testid="session-settings-compare-crc"]').setValue(true)
+    await wrapper.find('[data-testid="session-settings-tab-filters"]').trigger('click')
+    await wrapper.find('[data-testid="session-settings-include-patterns"]').setValue('*.md\n*.txt')
+    await wrapper.find('[data-testid="session-settings-exclude-patterns"]').setValue('node_modules/**')
     await wrapper.find('[data-testid="session-settings-apply"]').trigger('click')
     expect(wrapper.find('[data-testid="session-settings-dialog"]').exists()).toBe(false)
     expect(
       (wrapper.find('[data-testid="folder-criteria-crc"]').element as HTMLInputElement).checked,
     ).toBe(true)
+    const storedFilters = JSON.parse(
+      localStorage.getItem('open-diff-folder-name-filters') ?? '{}',
+    ) as { include: string[]; exclude: string[] }
+    expect(storedFilters.include).toEqual(['*.md', '*.txt'])
+    expect(storedFilters.exclude).toEqual(['node_modules/**'])
 
     await wrapper.find('[data-testid="folder-session-toolbar-peek"]').trigger('click')
     expect(wrapper.find('[data-testid="folder-peek-panel"]').isVisible()).toBe(true)

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -698,7 +698,9 @@ describe('FolderCompareView', () => {
     await wrapper.find('[data-testid="session-settings-compare-crc"]').setValue(true)
     await wrapper.find('[data-testid="session-settings-tab-filters"]').trigger('click')
     await wrapper.find('[data-testid="session-settings-include-patterns"]').setValue('*.md\n*.txt')
-    await wrapper.find('[data-testid="session-settings-exclude-patterns"]').setValue('node_modules/**')
+    await wrapper
+      .find('[data-testid="session-settings-exclude-patterns"]')
+      .setValue('node_modules/**')
     await wrapper.find('[data-testid="session-settings-apply"]').trigger('click')
     expect(wrapper.find('[data-testid="session-settings-dialog"]').exists()).toBe(false)
     expect(

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -17,6 +17,11 @@ import { pickNativePath } from '@/app/filePicker'
 import { formatCompareError } from '@/app/compareError'
 import { loadFolderDisplayFilters, saveFolderDisplayFilters } from '@/app/folderDisplayFilters'
 import { loadFolderCompareCriteria, saveFolderCompareCriteria } from '@/app/folderCompareCriteria'
+import {
+  loadFolderNameFilters,
+  saveFolderNameFilters,
+  type FolderNameFilters,
+} from '@/app/folderNameFilters'
 import { loadExternalApplications } from '@/app/externalApplications'
 import {
   folderCopyTargetsForDirection,
@@ -123,6 +128,7 @@ const expandedDirectoryIds = ref<Set<string>>(new Set())
 const leftRoot = ref('')
 const rightRoot = ref('')
 const folderCriteria = ref<FolderCompareCriteria>(loadFolderCompareCriteria())
+const folderNameFilters = ref<FolderNameFilters>(loadFolderNameFilters())
 const showSessionSettings = ref(false)
 const showPeekPanel = ref(false)
 const viewActions = useViewActionsStore()
@@ -468,9 +474,13 @@ function openFolderSessionSettings(): void {
   showSessionSettings.value = true
 }
 
+function persistFolderNameFilters(): void {
+  saveFolderNameFilters({ ...folderNameFilters.value })
+}
+
 function applyFolderSessionSettings(
   payload:
-    | { kind: 'folder'; criteria: FolderCompareCriteria }
+    | { kind: 'folder'; criteria: FolderCompareCriteria; filters: FolderNameFilters }
     | { kind: 'text'; options: typeof textSettingsPlaceholder }
     | { kind: 'table'; options: unknown }
     | { kind: 'hex'; options: unknown }
@@ -481,7 +491,9 @@ function applyFolderSessionSettings(
   }
 
   folderCriteria.value = { ...payload.criteria }
+  folderNameFilters.value = { ...payload.filters }
   persistFolderCriteria()
+  persistFolderNameFilters()
   showSessionSettings.value = false
   if (leftRoot.value && rightRoot.value) {
     void runFolderCompare()
@@ -792,6 +804,7 @@ async function runFolderCompare(): Promise<void> {
       leftRoot: leftRoot.value,
       rightRoot: rightRoot.value,
       criteria: { ...folderCriteria.value },
+      filters: { ...folderNameFilters.value },
     })
 
     if (generation !== folderCompareGeneration) {
@@ -2912,6 +2925,7 @@ onUnmounted(() => {
       :open="showSessionSettings"
       kind="folder"
       :folder-criteria="folderCriteria"
+      :folder-filters="folderNameFilters"
       :text-options="textSettingsPlaceholder"
       @close="showSessionSettings = false"
       @apply="applyFolderSessionSettings"

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1803,8 +1803,8 @@ tr:hover .row-actions,
 }
 
 .home-view :deep(.workbench-main) {
-  background: #ffffff;
   padding: 0;
+  background: #ffffff;
 }
 
 .home-view :deep(.workbench-shell-compact) {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -661,7 +661,7 @@ function openSelectedPreview(): void {
             class="bc-tree-row expanded"
           >
             <span>▾</span>
-            <FolderOpen :size="17" />
+            <FolderOpen :size="14" />
             <strong>{{ $t('ui.new') }}</strong>
           </button>
           <button
@@ -675,7 +675,7 @@ function openSelectedPreview(): void {
             <span></span>
             <component
               :is="entry.icon"
-              :size="17"
+              :size="14"
             />
             <strong>{{ $t(entry.titleKey) }}</strong>
           </button>
@@ -685,7 +685,7 @@ function openSelectedPreview(): void {
             data-testid="home-tree-auto-saved"
           >
             <span>▾</span>
-            <FolderOpen :size="17" />
+            <FolderOpen :size="14" />
             <strong>{{ $t('ui.autoSaved') }}</strong>
           </button>
           <button
@@ -699,7 +699,7 @@ function openSelectedPreview(): void {
             @dblclick="openSavedSession(session)"
           >
             <span></span>
-            <FolderOpen :size="16" />
+            <FolderOpen :size="13" />
             <strong>{{ session.name }}</strong>
           </button>
           <button
@@ -708,7 +708,7 @@ function openSelectedPreview(): void {
             data-testid="home-tree-today"
           >
             <span>▾</span>
-            <FolderOpen :size="17" />
+            <FolderOpen :size="14" />
             <strong>{{ $t('ui.today') }}</strong>
           </button>
           <button
@@ -722,7 +722,7 @@ function openSelectedPreview(): void {
             @dblclick="openSavedSession(session)"
           >
             <span></span>
-            <FolderOpen :size="16" />
+            <FolderOpen :size="13" />
             <strong>{{ session.name }}</strong>
           </button>
         </section>
@@ -867,7 +867,7 @@ function openSelectedPreview(): void {
               <span class="session-card-icon">
                 <component
                   :is="entry.icon"
-                  :size="54"
+                  :size="40"
                 />
               </span>
               <h3>{{ $t(entry.titleKey) }}</h3>
@@ -1180,13 +1180,13 @@ function openSelectedPreview(): void {
 
 .bc-home-workspace {
   display: grid;
-  grid-template-columns: 380px minmax(0, 1fr);
+  grid-template-columns: 300px minmax(0, 1fr);
   background: #ffffff;
 }
 
 .bc-session-tree {
   display: grid;
-  grid-template-rows: 52px minmax(0, 1fr) 56px;
+  grid-template-rows: 34px minmax(0, 1fr) 44px;
   min-width: 0;
   min-height: 0;
   border-right: 1px solid #b9bec7;
@@ -1197,12 +1197,13 @@ function openSelectedPreview(): void {
   display: flex;
   align-items: center;
   min-width: 0;
-  padding: 0 18px;
+  padding: 0 12px;
   overflow: hidden;
   border-bottom: 1px solid #c6ccd5;
   background: #eef1f5;
   color: #111827;
-  font-size: 22px;
+  font-size: 14px;
+  font-weight: 600;
   line-height: 1;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1210,35 +1211,35 @@ function openSelectedPreview(): void {
 
 .bc-tree-list {
   min-height: 0;
-  padding: 4px 10px;
+  padding: 2px 6px;
   overflow: auto;
 }
 
 .bc-tree-row {
   display: grid;
-  grid-template-columns: 18px 22px minmax(0, 1fr);
+  grid-template-columns: 14px 18px minmax(0, 1fr);
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   width: 100%;
-  min-height: 26px;
-  padding: 0 4px;
+  min-height: 22px;
+  padding: 0 2px;
   border: 0;
   background: transparent;
   color: #111827;
-  font-size: 19px;
-  line-height: 23px;
+  font-size: 13px;
+  line-height: 18px;
   text-align: left;
   cursor: pointer;
 }
 
 .bc-tree-row.child {
-  padding-left: 34px;
-  font-size: 19px;
+  padding-left: 22px;
+  font-size: 13px;
 }
 
 .bc-tree-row.saved {
-  padding-left: 64px;
-  font-size: 18px;
+  padding-left: 40px;
+  font-size: 12px;
 }
 
 .bc-tree-row:hover,
@@ -1256,34 +1257,35 @@ function openSelectedPreview(): void {
 
 .bc-tree-footer {
   display: grid;
-  grid-template-columns: 48px 48px minmax(0, 1fr);
+  grid-template-columns: 36px 36px minmax(0, 1fr);
   align-items: center;
   gap: 4px;
-  padding: 8px 8px 10px;
+  padding: 4px 6px 6px;
   border-top: 1px solid #c6ccd5;
   background: #eef1f5;
 }
 
 .bc-tree-footer button {
-  height: 38px;
+  height: 30px;
   border: 1px solid #d1d5db;
-  border-radius: 4px;
+  border-radius: 3px;
   background: #ffffff;
   color: #2f343a;
-  font-size: 24px;
+  font-size: 16px;
   line-height: 1;
 }
 
 .bc-tree-footer input {
   width: 100%;
   min-width: 0;
-  height: 38px;
-  padding: 0 10px;
+  height: 30px;
+  padding: 0 8px;
   overflow: hidden;
   border: 1px solid #c6ccd5;
   border-radius: 3px;
   background: #ffffff;
   color: #111827;
+  font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1381,35 +1383,35 @@ function openSelectedPreview(): void {
 
 .new-session-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(150px, 1fr));
-  gap: 28px 64px;
-  width: min(780px, calc(100% - 64px));
-  margin: 10px auto 14px;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  gap: 14px 28px;
+  width: min(720px, calc(100% - 40px));
+  margin: 6px auto 10px;
 }
 
 .bc-home-instructions {
   display: grid;
-  gap: 6px;
+  gap: 4px;
   justify-items: center;
-  margin: 0 0 28px;
+  margin: 0 0 14px;
   color: #111827;
-  font-size: 21px;
-  line-height: 1.15;
+  font-size: 13px;
+  line-height: 1.2;
 }
 
 .bc-home-instructions strong {
-  font-size: 23px;
-  font-weight: 400;
+  font-size: 14px;
+  font-weight: 500;
 }
 
 .new-session-card {
   display: grid;
-  gap: 6px;
+  gap: 4px;
   width: 100%;
   min-width: 0;
   max-width: 100%;
-  min-height: 100px;
-  padding: 6px;
+  min-height: 84px;
+  padding: 4px;
   overflow: hidden;
   border: 0;
   border-radius: 2px;
@@ -1428,8 +1430,8 @@ function openSelectedPreview(): void {
 
 .session-card-icon {
   display: inline-grid;
-  width: 74px;
-  height: 62px;
+  width: 56px;
+  height: 48px;
   color: #4b5563;
   place-items: center;
 }
@@ -1802,5 +1804,14 @@ tr:hover .row-actions,
 
 .home-view :deep(.workbench-main) {
   background: #ffffff;
+  padding: 0;
+}
+
+.home-view :deep(.workbench-shell-compact) {
+  background: #ffffff;
+}
+
+.home-view :deep(.workbench-grid-compact) {
+  gap: 0;
 }
 </style>

--- a/src/views/MediaCompareView.test.ts
+++ b/src/views/MediaCompareView.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MediaCompareView from './MediaCompareView.vue'
 import { compareMediaFiles } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -125,5 +126,22 @@ describe('MediaCompareView', () => {
     expect(wrapper.find('[data-testid="media-right-audio"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="media-scrub"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="media-play-toggle"]').exists()).toBe(true)
+  })
+
+  it('sets path-pair tab titles for media sessions', async () => {
+    const wrapper = mount(MediaCompareView)
+    const tabs = useTabsStore()
+    tabs.openTab({
+      title: 'Media Compare',
+      titleKey: 'ui.mediaCompare',
+      route: '/compare/media',
+      dirty: false,
+    })
+
+    await wrapper.find('[data-testid="media-left-path"]').setValue('C:/music/fixture-left.mp3')
+    await wrapper.find('[data-testid="media-right-path"]').setValue('C:/music/fixture-right.mp3')
+    await wrapper.vm.$nextTick()
+
+    expect(tabs.activeTab.title).toBe('fixture-left.mp3 <--> fixture-right.mp3')
   })
 })

--- a/src/views/MediaCompareView.test.ts
+++ b/src/views/MediaCompareView.test.ts
@@ -131,6 +131,7 @@ describe('MediaCompareView', () => {
   it('sets path-pair tab titles for media sessions', async () => {
     const wrapper = mount(MediaCompareView)
     const tabs = useTabsStore()
+
     tabs.openTab({
       title: 'Media Compare',
       titleKey: 'ui.mediaCompare',

--- a/src/views/MediaCompareView.vue
+++ b/src/views/MediaCompareView.vue
@@ -12,7 +12,7 @@ import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import { localFileSrc } from '@/app/localFileSrc'
 import { prefersVideoElement } from '@/app/mediaPlayback'
-import { buildMediaCompareToolbar } from '@/app/sessionToolbars'
+import { buildMediaCompareToolbar, pathPairTitle } from '@/app/sessionToolbars'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
 import { useI18n } from '@/i18n'
@@ -142,10 +142,19 @@ const rightMediaSrc = computed(() => (rightPath.value ? localFileSrc(rightPath.v
 const useVideoPlayers = computed(() => prefersVideoElement(leftPath.value, rightPath.value))
 const canPreviewMedia = computed(() => Boolean(leftMediaSrc.value || rightMediaSrc.value))
 
+function syncMediaTabTitle(): void {
+  if (!leftPath.value || !rightPath.value) {
+    return
+  }
+
+  tabs.setTabTitle('/compare/media', pathPairTitle(leftPath.value, rightPath.value))
+}
+
 watch([leftPath, rightPath], () => {
   playbackPosition.value = 0
   playbackDuration.value = 0
   isPlaying.value = false
+  syncMediaTabTitle()
 })
 
 function onMediaMeta(side: 'left' | 'right'): void {

--- a/src/views/RegistryCompareView.test.ts
+++ b/src/views/RegistryCompareView.test.ts
@@ -5,6 +5,7 @@ import RegistryCompareView from './RegistryCompareView.vue'
 import { compareRegistryExports, readTextFile } from '@/api/diff'
 import { queryLiveWindowsRegistry } from '@/api/policy'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -152,5 +153,19 @@ describe('RegistryCompareView', () => {
 
     expect(queryLiveWindowsRegistry).toHaveBeenCalled()
     expect(wrapper.find('[data-testid="registry-live-error"]').exists()).toBe(true)
+  })
+
+  it('sets path-pair tab titles for registry sessions', async () => {
+    const tabs = useTabsStore()
+    tabs.openTab({
+      title: 'Registry Compare',
+      titleKey: 'ui.registryCompare',
+      route: '/compare/registry',
+      dirty: false,
+    })
+    mount(RegistryCompareView)
+    await Promise.resolve()
+
+    expect(tabs.activeTab.title).toBe('left.reg <--> right.reg')
   })
 })

--- a/src/views/RegistryCompareView.test.ts
+++ b/src/views/RegistryCompareView.test.ts
@@ -157,6 +157,7 @@ describe('RegistryCompareView', () => {
 
   it('sets path-pair tab titles for registry sessions', async () => {
     const tabs = useTabsStore()
+
     tabs.openTab({
       title: 'Registry Compare',
       titleKey: 'ui.registryCompare',

--- a/src/views/RegistryCompareView.vue
+++ b/src/views/RegistryCompareView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { compareRegistryExports, readTextFile } from '@/api/diff'
 import { queryLiveWindowsRegistry } from '@/api/policy'
@@ -18,7 +18,7 @@ import {
   registryValueMatchesFilter,
   type RegistryValueFilter,
 } from '@/app/registryWorkspace'
-import { buildRegistryCompareToolbar } from '@/app/sessionToolbars'
+import { buildRegistryCompareToolbar, pathPairTitle } from '@/app/sessionToolbars'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
 import { useI18n } from '@/i18n'
@@ -68,6 +68,22 @@ onMounted(() => {
     void loadLaunchRegistryExports(launch.locations.left.uri, launch.locations.right.uri)
   }
 })
+
+function syncRegistryTabTitle(): void {
+  if (!leftName.value || !rightName.value) {
+    return
+  }
+
+  tabs.setTabTitle('/compare/registry', pathPairTitle(leftName.value, rightName.value))
+}
+
+watch(
+  [leftName, rightName],
+  () => {
+    syncRegistryTabTitle()
+  },
+  { immediate: true },
+)
 
 const flatRegistryKeys = computed<FlatRegistryKeyNode[]>(() =>
   flattenRegistryKeys(registryTree.value),

--- a/src/views/VersionCompareView.test.ts
+++ b/src/views/VersionCompareView.test.ts
@@ -167,6 +167,7 @@ describe('VersionCompareView', () => {
   it('sets path-pair tab titles for version sessions', async () => {
     const wrapper = mount(VersionCompareView)
     const tabs = useTabsStore()
+
     tabs.openTab({
       title: 'Version Compare',
       titleKey: 'ui.versionCompare',

--- a/src/views/VersionCompareView.test.ts
+++ b/src/views/VersionCompareView.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import VersionCompareView from './VersionCompareView.vue'
 import { compareVersionFiles } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useTabsStore } from '@/stores/tabs'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -161,5 +162,22 @@ describe('VersionCompareView', () => {
     expect(
       (wrapper.find('[data-testid="version-left-path"]').element as HTMLInputElement).value,
     ).toBe('C:/apps/fixture-right.exe')
+  })
+
+  it('sets path-pair tab titles for version sessions', async () => {
+    const wrapper = mount(VersionCompareView)
+    const tabs = useTabsStore()
+    tabs.openTab({
+      title: 'Version Compare',
+      titleKey: 'ui.versionCompare',
+      route: '/compare/version',
+      dirty: false,
+    })
+
+    await wrapper.find('[data-testid="version-left-path"]').setValue('C:/apps/fixture-left.exe')
+    await wrapper.find('[data-testid="version-right-path"]').setValue('C:/apps/fixture-right.exe')
+    await wrapper.vm.$nextTick()
+
+    expect(tabs.activeTab.title).toBe('fixture-left.exe <--> fixture-right.exe')
   })
 })

--- a/src/views/VersionCompareView.vue
+++ b/src/views/VersionCompareView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { compareVersionFiles } from '@/api/diff'
 import { useI18n } from '@/i18n'
@@ -138,6 +138,18 @@ const versionToolbarCommands = computed(() =>
   }),
 )
 
+function syncVersionTabTitle(): void {
+  if (!leftPath.value || !rightPath.value) {
+    return
+  }
+
+  tabs.setTabTitle('/compare/version', pathPairTitle(leftPath.value, rightPath.value))
+}
+
+watch([leftPath, rightPath], () => {
+  syncVersionTabTitle()
+})
+
 function runVersionToolbarCommand(commandId: string): void {
   if (commandId === 'home') {
     tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
@@ -173,6 +185,7 @@ function runVersionToolbarCommand(commandId: string): void {
 
     rightVersion.value = leftVersion.value
     leftVersion.value = nextLeft
+    syncVersionTabTitle()
 
     return
   }
@@ -217,14 +230,6 @@ function applyVersionResult(result: VersionCompareResponse): void {
   versionSummaryOverride.value = result.summary
   activeFieldIndex.value = 0
   syncVersionTabTitle()
-}
-
-function syncVersionTabTitle(): void {
-  if (!leftPath.value || !rightPath.value) {
-    return
-  }
-
-  tabs.setTabTitle('/compare/version', pathPairTitle(leftPath.value, rightPath.value))
 }
 
 function persistVersionOptions(): void {


### PR DESCRIPTION
## Summary
- **Session titles**: Version/Media/Registry now set `left <--> right` tab titles like Folder/Text/Hex/Table/Picture; window title stays `pathPair - SessionName`.
- **Folder Compare Filters**: Session Settings Filters tab has include/exclude name patterns that are passed into `compare_folder_paths`, applied via `FileFilters` (basename + path wildcards, ancestors kept), and persisted on this workstation.
- **Home**: Denser session tree + new-session grid spacing and less WorkbenchShell chrome; no brand tiles.
- i18n keys across locales; unit tests + `vue-tsc` + folder-core filter tests. Rebased onto latest master after #77/#78.

### Became real
- Path-pair titles for Version/Media/Registry compare sessions
- Folder name include/exclude affecting compare results through the existing filter API
- Persisted folder name filters + Session Settings Filters UI
- Home tree/grid density toward capture layout

### Still short
- Folder Merge output title remains single-path (not left/right pair)
- Name filters do not prune during VFS scan (filter after align); deep exclude of huge trees still scans first
- Home capture parity is denser but not pixel-matched (selected-session header/actions still larger than capture)
- Clipboard Compare has no path-pair title wiring
- Further AppLayout chrome outside Home is unchanged

## Test plan
- [x] `vitest` folder name filters, Folder/Version/Media/Registry/Home/AppLayout/i18n (+ Picture/Sync/Merge smoke)
- [x] `vue-tsc --noEmit`
- [x] `cargo test -p folder-core filter_alignment` / `cargo check`
- [ ] Manual: open Version/Media/Registry with both paths; confirm tab/window `left <--> right - Session`
- [ ] Manual: Folder Session Settings → Filters include `*.md`, exclude `node_modules/**`, rescan
- [ ] Manual: Home tree/grid spacing looks denser without brand tiles

Do not merge until reviewed.