### PR TITLE
Deepen script report commands and Folder Sync/Merge session chrome

### DIFF
--- a/src-tauri/crates/script-core/src/lib.rs
+++ b/src-tauri/crates/script-core/src/lib.rs
@@ -23,6 +23,12 @@ pub enum ScriptCommandKind {
     Compare,
     TextReport { output: String },
     FolderReport { output: String },
+    FileReport { output: String },
+    HexReport { output: String },
+    TableReport { output: String },
+    PictureReport { output: String },
+    VersionReport { output: String },
+    RegistryReport { output: String },
     Log { message: String },
     Beep,
     Option { key: String, value: String },
@@ -147,6 +153,12 @@ pub trait ScriptCompareEngine {
 pub enum ScriptReportType {
     Text,
     Folder,
+    File,
+    Hex,
+    Table,
+    Picture,
+    Version,
+    Registry,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -353,6 +365,66 @@ where
                     &mut state,
                     report_engine,
                     ScriptReportType::Folder,
+                    output,
+                    &execution.variables,
+                )?;
+            }
+            ScriptCommandKind::FileReport { output } => {
+                run_report_command(
+                    command,
+                    &mut state,
+                    report_engine,
+                    ScriptReportType::File,
+                    output,
+                    &execution.variables,
+                )?;
+            }
+            ScriptCommandKind::HexReport { output } => {
+                run_report_command(
+                    command,
+                    &mut state,
+                    report_engine,
+                    ScriptReportType::Hex,
+                    output,
+                    &execution.variables,
+                )?;
+            }
+            ScriptCommandKind::TableReport { output } => {
+                run_report_command(
+                    command,
+                    &mut state,
+                    report_engine,
+                    ScriptReportType::Table,
+                    output,
+                    &execution.variables,
+                )?;
+            }
+            ScriptCommandKind::PictureReport { output } => {
+                run_report_command(
+                    command,
+                    &mut state,
+                    report_engine,
+                    ScriptReportType::Picture,
+                    output,
+                    &execution.variables,
+                )?;
+            }
+            ScriptCommandKind::VersionReport { output } => {
+                run_report_command(
+                    command,
+                    &mut state,
+                    report_engine,
+                    ScriptReportType::Version,
+                    output,
+                    &execution.variables,
+                )?;
+            }
+            ScriptCommandKind::RegistryReport { output } => {
+                run_report_command(
+                    command,
+                    &mut state,
+                    report_engine,
+                    ScriptReportType::Registry,
                     output,
                     &execution.variables,
                 )?;
@@ -681,6 +753,12 @@ impl ScriptCommandKind {
             ScriptCommandKind::Compare => "COMPARE",
             ScriptCommandKind::TextReport { .. } => "TEXT-REPORT",
             ScriptCommandKind::FolderReport { .. } => "FOLDER-REPORT",
+            ScriptCommandKind::FileReport { .. } => "FILE-REPORT",
+            ScriptCommandKind::HexReport { .. } => "HEX-REPORT",
+            ScriptCommandKind::TableReport { .. } => "TABLE-REPORT",
+            ScriptCommandKind::PictureReport { .. } => "PICTURE-REPORT",
+            ScriptCommandKind::VersionReport { .. } => "VERSION-REPORT",
+            ScriptCommandKind::RegistryReport { .. } => "REGISTRY-REPORT",
             ScriptCommandKind::Log { .. } => "LOG",
             ScriptCommandKind::Beep => "BEEP",
             ScriptCommandKind::Option { .. } => "OPTION",
@@ -736,16 +814,20 @@ impl ScriptCompareEngine for FilesystemScriptEngine {
 
 impl ScriptReportEngine for FilesystemScriptEngine {
     fn write_report(&mut self, request: ScriptReportRequest) -> Result<(), String> {
-        let content = match request.report_type {
-            ScriptReportType::Text => format!(
-                "TEXT-REPORT\ncompared: {}\ndifferent: {}\n",
-                request.compare_summary.compared, request.compare_summary.different
-            ),
-            ScriptReportType::Folder => format!(
-                "FOLDER-REPORT\ncompared: {}\ndifferent: {}\n",
-                request.compare_summary.compared, request.compare_summary.different
-            ),
+        let label = match request.report_type {
+            ScriptReportType::Text => "TEXT-REPORT",
+            ScriptReportType::Folder => "FOLDER-REPORT",
+            ScriptReportType::File => "FILE-REPORT",
+            ScriptReportType::Hex => "HEX-REPORT",
+            ScriptReportType::Table => "TABLE-REPORT",
+            ScriptReportType::Picture => "PICTURE-REPORT",
+            ScriptReportType::Version => "VERSION-REPORT",
+            ScriptReportType::Registry => "REGISTRY-REPORT",
         };
+        let content = format!(
+            "{label}\ncompared: {}\ndifferent: {}\n",
+            request.compare_summary.compared, request.compare_summary.different
+        );
 
         if let Some(parent) = std::path::Path::new(&request.output).parent() {
             std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
@@ -791,23 +873,81 @@ fn compare_script_paths(
     let right_path = std::path::Path::new(right);
 
     if left_path.is_file() && right_path.is_file() {
-        let left_text = file_core::read_text_file(left).map_err(|error| format!("{error:?}"))?;
-        let right_text = file_core::read_text_file(right).map_err(|error| format!("{error:?}"))?;
-        let diff = diff_core::diff_text(&shared_types::TextDiffRequest {
-            left: left_text.text,
-            right: right_text.text,
-            algorithm: None,
-            ignore_whitespace: false,
-            ignore_case: false,
-            ignore_line_endings: false,
-            ignore_regexes: Vec::new(),
+        let left_name = left_path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let right_name = right_path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let looks_tabular = [left_name.as_str(), right_name.as_str()].iter().any(|name| {
+            name.ends_with(".csv")
+                || name.ends_with(".tsv")
+                || name.ends_with(".xlsx")
+                || name.ends_with(".xls")
         });
-        let different = diff.stats.added + diff.stats.deleted + diff.stats.modified;
 
-        return Ok(ScriptCompareSummary {
-            compared: 2,
-            different,
-        });
+        match (
+            file_core::read_text_file(left),
+            file_core::read_text_file(right),
+        ) {
+            (Ok(left_text), Ok(right_text)) if !looks_tabular => {
+                let diff = diff_core::diff_text(&shared_types::TextDiffRequest {
+                    left: left_text.text,
+                    right: right_text.text,
+                    algorithm: None,
+                    ignore_whitespace: false,
+                    ignore_case: false,
+                    ignore_line_endings: false,
+                    ignore_regexes: Vec::new(),
+                });
+                let different = diff.stats.added + diff.stats.deleted + diff.stats.modified;
+
+                return Ok(ScriptCompareSummary {
+                    compared: 2,
+                    different,
+                });
+            }
+            (Ok(left_text), Ok(right_text)) => {
+                // Tabular files still compare as text rows for script automation.
+                let left_rows = left_text.text.lines().count();
+                let right_rows = right_text.text.lines().count();
+                let diff = diff_core::diff_text(&shared_types::TextDiffRequest {
+                    left: left_text.text,
+                    right: right_text.text,
+                    algorithm: None,
+                    ignore_whitespace: false,
+                    ignore_case: false,
+                    ignore_line_endings: false,
+                    ignore_regexes: Vec::new(),
+                });
+                let different = diff.stats.added + diff.stats.deleted + diff.stats.modified;
+
+                return Ok(ScriptCompareSummary {
+                    compared: left_rows.max(right_rows).max(1),
+                    different,
+                });
+            }
+            _ => {
+                let left_bytes = std::fs::read(left).map_err(|error| error.to_string())?;
+                let right_bytes = std::fs::read(right).map_err(|error| error.to_string())?;
+                let shared = left_bytes.len().min(right_bytes.len());
+                let mut different = left_bytes.len().abs_diff(right_bytes.len());
+                different += left_bytes[..shared]
+                    .iter()
+                    .zip(right_bytes[..shared].iter())
+                    .filter(|(left_byte, right_byte)| left_byte != right_byte)
+                    .count();
+
+                return Ok(ScriptCompareSummary {
+                    compared: left_bytes.len().max(right_bytes.len()).max(1),
+                    different,
+                });
+            }
+        }
     }
 
     if left_path.is_dir() && right_path.is_dir() {
@@ -893,6 +1033,24 @@ fn parse_command(
         "FOLDER-REPORT" => parse_single_output_command(line, args, |output| {
             ScriptCommandKind::FolderReport { output }
         }),
+        "FILE-REPORT" | "REPORT" => parse_single_output_command(line, args, |output| {
+            ScriptCommandKind::FileReport { output }
+        }),
+        "HEX-REPORT" => parse_single_output_command(line, args, |output| {
+            ScriptCommandKind::HexReport { output }
+        }),
+        "TABLE-REPORT" => parse_single_output_command(line, args, |output| {
+            ScriptCommandKind::TableReport { output }
+        }),
+        "PICTURE-REPORT" => parse_single_output_command(line, args, |output| {
+            ScriptCommandKind::PictureReport { output }
+        }),
+        "VERSION-REPORT" => parse_single_output_command(line, args, |output| {
+            ScriptCommandKind::VersionReport { output }
+        }),
+        "REGISTRY-REPORT" => parse_single_output_command(line, args, |output| {
+            ScriptCommandKind::RegistryReport { output }
+        }),
         "LOG" => {
             parse_single_output_command(line, args, |message| ScriptCommandKind::Log { message })
         }
@@ -967,10 +1125,51 @@ fn parse_command(
 }
 
 fn is_unsupported_script_command(command: &str) -> bool {
-    matches!(
-        command,
-        "ATTRIB" | "EXPAND" | "FILE-REPORT" | "HEX-REPORT" | "MEDIA-REPORT" | "MOVE" | "MOVETO"
-    )
+    unsupported_script_commands()
+        .iter()
+        .any(|name| name.eq_ignore_ascii_case(command))
+}
+
+/// Commands that parse and execute for real in the automation runner.
+pub fn supported_script_commands() -> &'static [&'static str] {
+    &[
+        "LOAD",
+        "FILTER",
+        "COMPARE",
+        "TEXT-REPORT",
+        "FOLDER-REPORT",
+        "FILE-REPORT",
+        "REPORT",
+        "HEX-REPORT",
+        "TABLE-REPORT",
+        "PICTURE-REPORT",
+        "VERSION-REPORT",
+        "REGISTRY-REPORT",
+        "LOG",
+        "BEEP",
+        "OPTION",
+        "SELECT",
+        "COPY",
+        "COPYTO",
+        "DELETE",
+        "RENAME",
+        "TOUCH",
+        "SNAPSHOT",
+        "SYNC",
+    ]
+}
+
+/// Known legacy commands that parse but fail at execution with an honest unsupported error.
+pub fn unsupported_script_commands() -> &'static [&'static str] {
+    &[
+        "ATTRIB",
+        "COLLAPSE",
+        "CRITERIA",
+        "EXPAND",
+        "MEDIA-REPORT",
+        "MOVE",
+        "MOVETO",
+    ]
 }
 
 fn copy_path_recursive(source: &std::path::Path, target: &std::path::Path) -> Result<(), String> {
@@ -1162,7 +1361,58 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unknown_script_commands_with_line_number() {
+    fn lists_supported_and_unsupported_script_commands_honestly() {
+        assert!(supported_script_commands().contains(&"HEX-REPORT"));
+        assert!(supported_script_commands().contains(&"TABLE-REPORT"));
+        assert!(supported_script_commands().contains(&"REPORT"));
+        assert!(unsupported_script_commands().contains(&"ATTRIB"));
+        assert!(unsupported_script_commands().contains(&"CRITERIA"));
+        assert!(unsupported_script_commands().contains(&"MEDIA-REPORT"));
+        assert!(!unsupported_script_commands().contains(&"HEX-REPORT"));
+        assert!(!unsupported_script_commands().contains(&"FILE-REPORT"));
+    }
+
+    #[test]
+    fn parses_extended_compare_report_commands() {
+        let script = parse_script(
+            r#"
+            LOAD "a.bin" "b.bin"
+            COMPARE
+            HEX-REPORT "out/hex.txt"
+            TABLE-REPORT "out/table.txt"
+            FILE-REPORT "out/file.txt"
+            REPORT "out/report.txt"
+            PICTURE-REPORT "out/picture.txt"
+            VERSION-REPORT "out/version.txt"
+            REGISTRY-REPORT "out/registry.txt"
+            "#,
+        )
+        .expect("extended reports should parse");
+
+        assert!(script.commands.iter().any(|command| matches!(
+            command.kind,
+            ScriptCommandKind::HexReport { .. }
+        )));
+        assert!(script.commands.iter().any(|command| matches!(
+            command.kind,
+            ScriptCommandKind::TableReport { .. }
+        )));
+        assert!(script.commands.iter().any(|command| matches!(
+            command.kind,
+            ScriptCommandKind::FileReport { .. }
+        )));
+        assert_eq!(
+            script
+                .commands
+                .iter()
+                .filter(|command| matches!(command.kind, ScriptCommandKind::FileReport { .. }))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+        fn rejects_unknown_script_commands_with_line_number() {
         let error = parse_script("LOAD left right\nNOPE").expect_err("unknown command should fail");
 
         assert_eq!(error.line, 2);

--- a/src-tauri/crates/script-core/src/lib.rs
+++ b/src-tauri/crates/script-core/src/lib.rs
@@ -883,12 +883,14 @@ fn compare_script_paths(
             .and_then(|value| value.to_str())
             .unwrap_or_default()
             .to_ascii_lowercase();
-        let looks_tabular = [left_name.as_str(), right_name.as_str()].iter().any(|name| {
-            name.ends_with(".csv")
-                || name.ends_with(".tsv")
-                || name.ends_with(".xlsx")
-                || name.ends_with(".xls")
-        });
+        let looks_tabular = [left_name.as_str(), right_name.as_str()]
+            .iter()
+            .any(|name| {
+                name.ends_with(".csv")
+                    || name.ends_with(".tsv")
+                    || name.ends_with(".xlsx")
+                    || name.ends_with(".xls")
+            });
 
         match (
             file_core::read_text_file(left),
@@ -1389,18 +1391,18 @@ mod tests {
         )
         .expect("extended reports should parse");
 
-        assert!(script.commands.iter().any(|command| matches!(
-            command.kind,
-            ScriptCommandKind::HexReport { .. }
-        )));
-        assert!(script.commands.iter().any(|command| matches!(
-            command.kind,
-            ScriptCommandKind::TableReport { .. }
-        )));
-        assert!(script.commands.iter().any(|command| matches!(
-            command.kind,
-            ScriptCommandKind::FileReport { .. }
-        )));
+        assert!(script
+            .commands
+            .iter()
+            .any(|command| matches!(command.kind, ScriptCommandKind::HexReport { .. })));
+        assert!(script
+            .commands
+            .iter()
+            .any(|command| matches!(command.kind, ScriptCommandKind::TableReport { .. })));
+        assert!(script
+            .commands
+            .iter()
+            .any(|command| matches!(command.kind, ScriptCommandKind::FileReport { .. })));
         assert_eq!(
             script
                 .commands
@@ -1412,7 +1414,7 @@ mod tests {
     }
 
     #[test]
-        fn rejects_unknown_script_commands_with_line_number() {
+    fn rejects_unknown_script_commands_with_line_number() {
         let error = parse_script("LOAD left right\nNOPE").expect_err("unknown command should fail");
 
         assert_eq!(error.line, 2);

--- a/src/app/folderPathGroups.test.ts
+++ b/src/app/folderPathGroups.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectExpandablePrefixes,
+  isPathHiddenByCollapse,
+  parentPathPrefix,
+} from './folderPathGroups'
+
+describe('folderPathGroups', () => {
+  it('derives parent prefixes and expandable folders', () => {
+    expect(parentPathPrefix('a/b/c.txt')).toBe('a/b')
+    expect(parentPathPrefix('root.txt')).toBe('')
+    expect(collectExpandablePrefixes(['a/b/c.txt', 'a/d.txt', 'alone.txt'])).toEqual(['a', 'a/b'])
+  })
+
+  it('hides nested rows under collapsed prefixes', () => {
+    const collapsed = new Set(['a/b'])
+
+    expect(isPathHiddenByCollapse('a/b/c.txt', collapsed)).toBe(true)
+    expect(isPathHiddenByCollapse('a/d.txt', collapsed)).toBe(false)
+    expect(isPathHiddenByCollapse('a/b', collapsed)).toBe(false)
+  })
+})

--- a/src/app/folderPathGroups.ts
+++ b/src/app/folderPathGroups.ts
@@ -1,0 +1,47 @@
+/** Path-prefix expand/collapse helpers for flat folder plan/preview rows. */
+
+export function parentPathPrefix(relativePath: string): string {
+  const normalized = relativePath.replaceAll('\\', '/').replace(/^\/+|\/+$/gu, '')
+  const parts = normalized.split('/').filter(Boolean)
+
+  if (parts.length <= 1) {
+    return ''
+  }
+
+  return parts.slice(0, -1).join('/')
+}
+
+export function collectExpandablePrefixes(relativePaths: readonly string[]): string[] {
+  const prefixes = new Set<string>()
+
+  for (const relativePath of relativePaths) {
+    const normalized = relativePath.replaceAll('\\', '/').replace(/^\/+|\/+$/gu, '')
+    const parts = normalized.split('/').filter(Boolean)
+
+    for (let index = 1; index < parts.length; index += 1) {
+      prefixes.add(parts.slice(0, index).join('/'))
+    }
+  }
+
+  return [...prefixes].sort((left, right) => left.localeCompare(right))
+}
+
+export function isPathHiddenByCollapse(
+  relativePath: string,
+  collapsedPrefixes: ReadonlySet<string>,
+): boolean {
+  if (collapsedPrefixes.size === 0) {
+    return false
+  }
+
+  const normalized = relativePath.replaceAll('\\', '/').replace(/^\/+|\/+$/gu, '')
+  const parts = normalized.split('/').filter(Boolean)
+
+  for (let index = 1; index < parts.length; index += 1) {
+    if (collapsedPrefixes.has(parts.slice(0, index).join('/'))) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/src/app/scriptCommands.test.ts
+++ b/src/app/scriptCommands.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatCommandList,
+  supportedScriptCommands,
+  unsupportedScriptCommands,
+} from './scriptCommands'
+
+describe('scriptCommands', () => {
+  it('lists supported compare/report commands without trademarked product names', () => {
+    expect(supportedScriptCommands).toContain('COMPARE')
+    expect(supportedScriptCommands).toContain('HEX-REPORT')
+    expect(supportedScriptCommands).toContain('TABLE-REPORT')
+    expect(supportedScriptCommands).toContain('FILE-REPORT')
+    expect(supportedScriptCommands).toContain('REPORT')
+    expect(formatCommandList(supportedScriptCommands)).not.toMatch(/Beyond|BC5?|Scooter/i)
+  })
+
+  it('keeps an honest unsupported list for known legacy gaps', () => {
+    expect(unsupportedScriptCommands).toEqual([
+      'ATTRIB',
+      'COLLAPSE',
+      'CRITERIA',
+      'EXPAND',
+      'MEDIA-REPORT',
+      'MOVE',
+      'MOVETO',
+    ])
+    expect(unsupportedScriptCommands).not.toContain('HEX-REPORT')
+    expect(unsupportedScriptCommands).not.toContain('FILE-REPORT')
+  })
+
+  it('keeps supported and unsupported catalogs disjoint', () => {
+    const overlap = supportedScriptCommands.filter((command) =>
+      (unsupportedScriptCommands as readonly string[]).includes(command),
+    )
+
+    expect(overlap).toEqual([])
+  })
+})

--- a/src/app/scriptCommands.ts
+++ b/src/app/scriptCommands.ts
@@ -44,10 +44,10 @@ export function formatCommandList(commands: readonly string[]): string {
 }
 
 export const compareReportExampleScript = [
-  'load "${left}"',
-  'load "${right}"',
+  `load "\${left}"`,
+  `load "\${right}"`,
   'compare',
-  'text-report "${output}"',
-  'hex-report "${output}.hex.txt"',
-  'folder-report "${output}.folder.txt"',
+  `text-report "\${output}"`,
+  `hex-report "\${output}.hex.txt"`,
+  `folder-report "\${output}.folder.txt"`,
 ].join('\n')

--- a/src/app/scriptCommands.ts
+++ b/src/app/scriptCommands.ts
@@ -1,0 +1,53 @@
+/** Honest script automation command catalogs for Reports/Scripts. */
+
+export const supportedScriptCommands = [
+  'LOAD',
+  'FILTER',
+  'COMPARE',
+  'TEXT-REPORT',
+  'FOLDER-REPORT',
+  'FILE-REPORT',
+  'REPORT',
+  'HEX-REPORT',
+  'TABLE-REPORT',
+  'PICTURE-REPORT',
+  'VERSION-REPORT',
+  'REGISTRY-REPORT',
+  'LOG',
+  'BEEP',
+  'OPTION',
+  'SELECT',
+  'COPY',
+  'COPYTO',
+  'DELETE',
+  'RENAME',
+  'TOUCH',
+  'SNAPSHOT',
+  'SYNC',
+] as const
+
+export const unsupportedScriptCommands = [
+  'ATTRIB',
+  'COLLAPSE',
+  'CRITERIA',
+  'EXPAND',
+  'MEDIA-REPORT',
+  'MOVE',
+  'MOVETO',
+] as const
+
+export type SupportedScriptCommand = (typeof supportedScriptCommands)[number]
+export type UnsupportedScriptCommand = (typeof unsupportedScriptCommands)[number]
+
+export function formatCommandList(commands: readonly string[]): string {
+  return commands.join(', ')
+}
+
+export const compareReportExampleScript = [
+  'load "${left}"',
+  'load "${right}"',
+  'compare',
+  'text-report "${output}"',
+  'hex-report "${output}.hex.txt"',
+  'folder-report "${output}.folder.txt"',
+].join('\n')

--- a/src/app/sessionToolbars.test.ts
+++ b/src/app/sessionToolbars.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   buildClipboardCompareToolbar,
   buildFolderCompareToolbar,
+  buildFolderMergeToolbar,
+  buildFolderSyncToolbar,
   buildHexCompareToolbar,
   buildMediaCompareToolbar,
   buildPictureCompareToolbar,
@@ -12,6 +14,8 @@ import {
   buildVersionCompareToolbar,
   clipboardCompareToolbarOrder,
   folderCompareToolbarOrder,
+  folderMergeToolbarOrder,
+  folderSyncToolbarOrder,
   hexCompareToolbarOrder,
   mergeSessionTitle,
   pathPairTitle,
@@ -157,5 +161,40 @@ describe('sessionToolbars', () => {
 
     expect(toolbar.map((item) => item.id)).toEqual([...textPatchToolbarOrder])
     expect(toolbar.find((item) => item.id === 'prev-section')?.enabled).toBe(false)
+  })
+
+  it('keeps Folder Sync toolbar chrome for expand/collapse/select/filters/home', () => {
+    const toolbar = buildFolderSyncToolbar({
+      home: true,
+      expand: true,
+      collapse: true,
+      select: true,
+      filters: true,
+      refresh: true,
+      swap: true,
+      stop: false,
+    })
+
+    expect(toolbar.map((item) => item.id)).toEqual([...folderSyncToolbarOrder])
+    expect(toolbar.find((item) => item.id === 'home')?.enabled).toBe(true)
+    expect(toolbar.find((item) => item.id === 'select')?.enabled).toBe(true)
+    expect(toolbar.find((item) => item.id === 'stop')?.enabled).toBe(false)
+  })
+
+  it('keeps Folder Merge toolbar chrome for expand/collapse/select', () => {
+    const toolbar = buildFolderMergeToolbar({
+      home: true,
+      expand: true,
+      collapse: true,
+      select: true,
+      same: true,
+      filters: true,
+      refresh: true,
+      peek: true,
+    })
+
+    expect(toolbar.map((item) => item.id)).toEqual([...folderMergeToolbarOrder])
+    expect(toolbar.find((item) => item.id === 'expand')?.enabled).toBe(true)
+    expect(toolbar.find((item) => item.id === 'peek')?.enabled).toBe(true)
   })
 })

--- a/src/app/sessionToolbars.ts
+++ b/src/app/sessionToolbars.ts
@@ -125,6 +125,28 @@ export const clipboardCompareToolbarOrder = [
   'reload',
 ] as const
 
+export const folderSyncToolbarOrder = [
+  'home',
+  'expand',
+  'collapse',
+  'select',
+  'filters',
+  'refresh',
+  'swap',
+  'stop',
+] as const
+
+export const folderMergeToolbarOrder = [
+  'home',
+  'expand',
+  'collapse',
+  'select',
+  'same',
+  'filters',
+  'refresh',
+  'peek',
+] as const
+
 interface ToolbarMeta {
   glyph: string
   labelKey: string
@@ -252,6 +274,28 @@ const clipboardMeta: Record<(typeof clipboardCompareToolbarOrder)[number], Toolb
   reload: { glyph: 'R', labelKey: 'ui.reload' },
 }
 
+const folderSyncMeta: Record<(typeof folderSyncToolbarOrder)[number], ToolbarMeta> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  expand: { glyph: '+', labelKey: 'ui.expand' },
+  collapse: { glyph: '-', labelKey: 'ui.collapse' },
+  select: { glyph: 'V', labelKey: 'ui.select' },
+  filters: { glyph: 'F', labelKey: 'ui.filters' },
+  refresh: { glyph: 'R', labelKey: 'ui.refresh' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  stop: { glyph: 'X', labelKey: 'ui.stop' },
+}
+
+const folderMergeMeta: Record<(typeof folderMergeToolbarOrder)[number], ToolbarMeta> = {
+  home: { glyph: 'H', labelKey: 'ui.home' },
+  expand: { glyph: '+', labelKey: 'ui.expand' },
+  collapse: { glyph: '-', labelKey: 'ui.collapse' },
+  select: { glyph: 'V', labelKey: 'ui.select' },
+  same: { glyph: '=', labelKey: 'ui.sameOk' },
+  filters: { glyph: 'F', labelKey: 'ui.filters' },
+  refresh: { glyph: 'R', labelKey: 'ui.refresh' },
+  peek: { glyph: 'P', labelKey: 'ui.peek' },
+}
+
 function buildToolbar<T extends string>(
   order: readonly T[],
   meta: Record<T, ToolbarMeta>,
@@ -323,6 +367,18 @@ export function buildClipboardCompareToolbar(
   enabled: Partial<Record<(typeof clipboardCompareToolbarOrder)[number], boolean>>,
 ): SessionToolbarCommand[] {
   return buildToolbar(clipboardCompareToolbarOrder, clipboardMeta, enabled)
+}
+
+export function buildFolderSyncToolbar(
+  enabled: Partial<Record<(typeof folderSyncToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return buildToolbar(folderSyncToolbarOrder, folderSyncMeta, enabled)
+}
+
+export function buildFolderMergeToolbar(
+  enabled: Partial<Record<(typeof folderMergeToolbarOrder)[number], boolean>>,
+): SessionToolbarCommand[] {
+  return buildToolbar(folderMergeToolbarOrder, folderMergeMeta, enabled)
 }
 
 export function pathPairTitle(leftPath: string, rightPath: string): string {

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -729,7 +729,8 @@ export const deDE: LanguagePack = {
       'Die vollständige Legacy-Skriptsprache ist nicht implementiert. Unterstützte Befehle laufen; bekannte Lücken liefern unsupported.',
     'ui.scriptingSupported':
       'Unterstützt: LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
-    'ui.scriptingUnsupported': 'Nicht unterstützt: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupported':
+      'Nicht unterstützt: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
     'ui.scriptingUnsupportedCommands': 'Nicht unterstützte Befehle',
     'ui.scriptingSupportedCommands': 'Unterstützte Befehle',
     'ui.secretsHint':

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -726,9 +726,12 @@ export const deDE: LanguagePack = {
     'ui.scriptPath': 'Skriptdatei',
     'ui.scriptSource': 'Skriptquelle',
     'ui.scriptingNotImplemented':
-      'Die vollständige BC-Skriptsprache ist nicht implementiert. Unterstützte Befehle laufen; andere liefern unsupported.',
+      'Die vollständige Legacy-Skriptsprache ist nicht implementiert. Unterstützte Befehle laufen; bekannte Lücken liefern unsupported.',
     'ui.scriptingSupported':
-      'Unterstützt: LOAD, FILTER, COMPARE, REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT. Andere BC-Befehle liefern unsupported.',
+      'Unterstützt: LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
+    'ui.scriptingUnsupported': 'Nicht unterstützt: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupportedCommands': 'Nicht unterstützte Befehle',
+    'ui.scriptingSupportedCommands': 'Unterstützte Befehle',
     'ui.secretsHint':
       'Passwörter liegen nur in einer lokalen Geheimdatei (Modus 0600), nie in der Profilliste oder in Logs.',
     'ui.sourceFile': 'Source file',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -708,9 +708,12 @@ export const enUS: LanguagePack = {
     'ui.scriptPath': 'Script file',
     'ui.scriptSource': 'Script source',
     'ui.scriptingNotImplemented':
-      'Full legacy scripting is not implemented. Supported commands run; others return unsupported.',
+      'Full legacy scripting is not implemented. Supported commands run; known gaps fail as unsupported.',
     'ui.scriptingSupported':
-      'Supported commands: LOAD, FILTER, COMPARE, REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT. Other script commands return unsupported.',
+      'Supported commands: LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
+    'ui.scriptingUnsupported': 'Unsupported: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupportedCommands': 'Unsupported commands',
+    'ui.scriptingSupportedCommands': 'Supported commands',
     'ui.secretsHint':
       'Passwords are stored only in a local secrets file (mode 0600), never in the profile list or logs.',
     'ui.sourceFile': 'Source file',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -711,7 +711,8 @@ export const enUS: LanguagePack = {
       'Full legacy scripting is not implemented. Supported commands run; known gaps fail as unsupported.',
     'ui.scriptingSupported':
       'Supported commands: LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
-    'ui.scriptingUnsupported': 'Unsupported: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupported':
+      'Unsupported: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
     'ui.scriptingUnsupportedCommands': 'Unsupported commands',
     'ui.scriptingSupportedCommands': 'Supported commands',
     'ui.secretsHint':

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -724,7 +724,8 @@ export const esES: LanguagePack = {
       'El lenguaje de scripts heredado completo no está implementado. Los comandos admitidos se ejecutan; las lagunas conocidas devuelven unsupported.',
     'ui.scriptingSupported':
       'Comandos admitidos: LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
-    'ui.scriptingUnsupported': 'No admitidos: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupported':
+      'No admitidos: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
     'ui.scriptingUnsupportedCommands': 'Comandos no admitidos',
     'ui.scriptingSupportedCommands': 'Comandos admitidos',
     'ui.secretsHint':

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -721,9 +721,12 @@ export const esES: LanguagePack = {
     'ui.scriptPath': 'Archivo de script',
     'ui.scriptSource': 'Origen del script',
     'ui.scriptingNotImplemented':
-      'El lenguaje de scripts BC completo no está implementado. Los comandos admitidos se ejecutan; el resto devuelve unsupported.',
+      'El lenguaje de scripts heredado completo no está implementado. Los comandos admitidos se ejecutan; las lagunas conocidas devuelven unsupported.',
     'ui.scriptingSupported':
-      'Admitidos: LOAD, FILTER, COMPARE, REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT. Otros comandos BC devuelven unsupported.',
+      'Comandos admitidos: LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
+    'ui.scriptingUnsupported': 'No admitidos: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupportedCommands': 'Comandos no admitidos',
+    'ui.scriptingSupportedCommands': 'Comandos admitidos',
     'ui.secretsHint':
       'Las contraseñas se guardan solo en un archivo local (modo 0600), nunca en la lista de perfiles ni en los registros.',
     'ui.sourceFile': 'Source file',

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -724,7 +724,8 @@ export const frFR: LanguagePack = {
       'Le langage de script hérité complet n’est pas implémenté. Les commandes prises en charge s’exécutent ; les lacunes connues renvoient unsupported.',
     'ui.scriptingSupported':
       'Commandes prises en charge : LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
-    'ui.scriptingUnsupported': 'Non prises en charge : ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupported':
+      'Non prises en charge : ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
     'ui.scriptingUnsupportedCommands': 'Commandes non prises en charge',
     'ui.scriptingSupportedCommands': 'Commandes prises en charge',
     'ui.secretsHint':

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -721,9 +721,12 @@ export const frFR: LanguagePack = {
     'ui.scriptPath': 'Fichier de script',
     'ui.scriptSource': 'Source du script',
     'ui.scriptingNotImplemented':
-      'Le langage de script BC complet n’est pas implémenté. Les commandes prises en charge s’exécutent ; les autres renvoient unsupported.',
+      'Le langage de script hérité complet n’est pas implémenté. Les commandes prises en charge s’exécutent ; les lacunes connues renvoient unsupported.',
     'ui.scriptingSupported':
-      'Commandes prises en charge : LOAD, FILTER, COMPARE, REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT. Les autres commandes BC renvoient unsupported.',
+      'Commandes prises en charge : LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
+    'ui.scriptingUnsupported': 'Non prises en charge : ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupportedCommands': 'Commandes non prises en charge',
+    'ui.scriptingSupportedCommands': 'Commandes prises en charge',
     'ui.secretsHint':
       'Les mots de passe sont stockés uniquement dans un fichier local (mode 0600), jamais dans la liste des profils ni dans les journaux.',
     'ui.sourceFile': 'Source file',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -707,9 +707,12 @@ export const jaJP: LanguagePack = {
     'ui.scriptPath': 'スクリプトファイル',
     'ui.scriptSource': 'スクリプトソース',
     'ui.scriptingNotImplemented':
-      '完全な BC スクリプト言語は未実装です。対応コマンドは実行され、それ以外は unsupported を返します。',
+      '完全なレガシースクリプト言語は未実装です。対応コマンドは実行され、既知の欠落は unsupported を返します。',
     'ui.scriptingSupported':
-      '対応: LOAD、FILTER、COMPARE、REPORT、LOG、BEEP、OPTION、SELECT、COPY、COPYTO、DELETE、RENAME、TOUCH、SNAPSHOT、SYNC、TEXT-REPORT、FOLDER-REPORT。その他の BC コマンドは unsupported を返します。',
+      '対応: LOAD、FILTER、COMPARE、REPORT、FILE-REPORT、HEX-REPORT、TABLE-REPORT、PICTURE-REPORT、VERSION-REPORT、REGISTRY-REPORT、LOG、BEEP、OPTION、SELECT、COPY、COPYTO、DELETE、RENAME、TOUCH、SNAPSHOT、SYNC、TEXT-REPORT、FOLDER-REPORT。',
+    'ui.scriptingUnsupported': '未対応: ATTRIB、COLLAPSE、CRITERIA、EXPAND、MEDIA-REPORT、MOVE、MOVETO。',
+    'ui.scriptingUnsupportedCommands': '未対応コマンド',
+    'ui.scriptingSupportedCommands': '対応コマンド',
     'ui.secretsHint':
       'パスワードはローカル秘密ファイル（モード 0600）にのみ保存され、プロファイル一覧やログには書きません。',
     'ui.sourceFile': 'Source file',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -710,7 +710,8 @@ export const jaJP: LanguagePack = {
       '完全なレガシースクリプト言語は未実装です。対応コマンドは実行され、既知の欠落は unsupported を返します。',
     'ui.scriptingSupported':
       '対応: LOAD、FILTER、COMPARE、REPORT、FILE-REPORT、HEX-REPORT、TABLE-REPORT、PICTURE-REPORT、VERSION-REPORT、REGISTRY-REPORT、LOG、BEEP、OPTION、SELECT、COPY、COPYTO、DELETE、RENAME、TOUCH、SNAPSHOT、SYNC、TEXT-REPORT、FOLDER-REPORT。',
-    'ui.scriptingUnsupported': '未対応: ATTRIB、COLLAPSE、CRITERIA、EXPAND、MEDIA-REPORT、MOVE、MOVETO。',
+    'ui.scriptingUnsupported':
+      '未対応: ATTRIB、COLLAPSE、CRITERIA、EXPAND、MEDIA-REPORT、MOVE、MOVETO。',
     'ui.scriptingUnsupportedCommands': '未対応コマンド',
     'ui.scriptingSupportedCommands': '対応コマンド',
     'ui.secretsHint':

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -707,7 +707,8 @@ export const koKR: LanguagePack = {
       '전체 레거시 스크립트 언어는 구현되지 않았습니다. 지원 명령은 실행되고, 알려진 공백은 unsupported를 반환합니다.',
     'ui.scriptingSupported':
       '지원: LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
-    'ui.scriptingUnsupported': '미지원: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupported':
+      '미지원: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
     'ui.scriptingUnsupportedCommands': '미지원 명령',
     'ui.scriptingSupportedCommands': '지원 명령',
     'ui.secretsHint':

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -704,9 +704,12 @@ export const koKR: LanguagePack = {
     'ui.scriptPath': '스크립트 파일',
     'ui.scriptSource': '스크립트 소스',
     'ui.scriptingNotImplemented':
-      '전체 BC 스크립트 언어는 구현되지 않았습니다. 지원 명령은 실행되고 나머지는 unsupported를 반환합니다.',
+      '전체 레거시 스크립트 언어는 구현되지 않았습니다. 지원 명령은 실행되고, 알려진 공백은 unsupported를 반환합니다.',
     'ui.scriptingSupported':
-      '지원: LOAD, FILTER, COMPARE, REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT. 다른 BC 명령은 unsupported를 반환합니다.',
+      '지원: LOAD, FILTER, COMPARE, REPORT, FILE-REPORT, HEX-REPORT, TABLE-REPORT, PICTURE-REPORT, VERSION-REPORT, REGISTRY-REPORT, LOG, BEEP, OPTION, SELECT, COPY, COPYTO, DELETE, RENAME, TOUCH, SNAPSHOT, SYNC, TEXT-REPORT, FOLDER-REPORT.',
+    'ui.scriptingUnsupported': '미지원: ATTRIB, COLLAPSE, CRITERIA, EXPAND, MEDIA-REPORT, MOVE, MOVETO.',
+    'ui.scriptingUnsupportedCommands': '미지원 명령',
+    'ui.scriptingSupportedCommands': '지원 명령',
     'ui.secretsHint':
       '비밀번호는 로컬 비밀 파일(모드 0600)에만 저장되며 프로필 목록이나 로그에는 기록되지 않습니다.',
     'ui.sourceFile': 'Source file',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -691,9 +691,12 @@ export const zhCN: LanguagePack = {
     'ui.scriptPath': '脚本文件',
     'ui.scriptSource': '脚本源',
     'ui.scriptingNotImplemented':
-      '完整 BC 脚本语言尚未实现。已支持的命令会真正执行；其余命令返回 unsupported。',
+      '完整遗留脚本语言尚未实现。已支持的命令会真正执行；已知缺口以 unsupported 返回。',
     'ui.scriptingSupported':
-      '已支持：LOAD、FILTER、COMPARE、REPORT、LOG、BEEP、OPTION、SELECT、COPY、COPYTO、DELETE、RENAME、TOUCH、SNAPSHOT、SYNC、TEXT-REPORT、FOLDER-REPORT。其他 BC 命令返回 unsupported。',
+      '已支持：LOAD、FILTER、COMPARE、REPORT、FILE-REPORT、HEX-REPORT、TABLE-REPORT、PICTURE-REPORT、VERSION-REPORT、REGISTRY-REPORT、LOG、BEEP、OPTION、SELECT、COPY、COPYTO、DELETE、RENAME、TOUCH、SNAPSHOT、SYNC、TEXT-REPORT、FOLDER-REPORT。',
+    'ui.scriptingUnsupported': '未支持：ATTRIB、COLLAPSE、CRITERIA、EXPAND、MEDIA-REPORT、MOVE、MOVETO。',
+    'ui.scriptingUnsupportedCommands': '未支持命令',
+    'ui.scriptingSupportedCommands': '已支持命令',
     'ui.secretsHint': '密码只保存在本地密钥文件（Unix 权限 0600），不会写入配置列表或日志。',
     'ui.sourceFile': '源文件',
     'ui.svnIntegration': 'SVN 集成',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -694,7 +694,8 @@ export const zhCN: LanguagePack = {
       '完整遗留脚本语言尚未实现。已支持的命令会真正执行；已知缺口以 unsupported 返回。',
     'ui.scriptingSupported':
       '已支持：LOAD、FILTER、COMPARE、REPORT、FILE-REPORT、HEX-REPORT、TABLE-REPORT、PICTURE-REPORT、VERSION-REPORT、REGISTRY-REPORT、LOG、BEEP、OPTION、SELECT、COPY、COPYTO、DELETE、RENAME、TOUCH、SNAPSHOT、SYNC、TEXT-REPORT、FOLDER-REPORT。',
-    'ui.scriptingUnsupported': '未支持：ATTRIB、COLLAPSE、CRITERIA、EXPAND、MEDIA-REPORT、MOVE、MOVETO。',
+    'ui.scriptingUnsupported':
+      '未支持：ATTRIB、COLLAPSE、CRITERIA、EXPAND、MEDIA-REPORT、MOVE、MOVETO。',
     'ui.scriptingUnsupportedCommands': '未支持命令',
     'ui.scriptingSupportedCommands': '已支持命令',
     'ui.secretsHint': '密码只保存在本地密钥文件（Unix 权限 0600），不会写入配置列表或日志。',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -692,9 +692,12 @@ export const zhTW: LanguagePack = {
     'ui.scriptPath': '指令碼檔案',
     'ui.scriptSource': '指令碼來源',
     'ui.scriptingNotImplemented':
-      '完整 BC 指令碼語言尚未實作。已支援的命令會真正執行；其餘命令回傳 unsupported。',
+      '完整遺留指令碼語言尚未實作。已支援的命令會真正執行；已知缺口以 unsupported 回傳。',
     'ui.scriptingSupported':
-      '已支援：LOAD、FILTER、COMPARE、REPORT、LOG、BEEP、OPTION、SELECT、COPY、COPYTO、DELETE、RENAME、TOUCH、SNAPSHOT、SYNC、TEXT-REPORT、FOLDER-REPORT。其他 BC 命令回傳 unsupported。',
+      '已支援：LOAD、FILTER、COMPARE、REPORT、FILE-REPORT、HEX-REPORT、TABLE-REPORT、PICTURE-REPORT、VERSION-REPORT、REGISTRY-REPORT、LOG、BEEP、OPTION、SELECT、COPY、COPYTO、DELETE、RENAME、TOUCH、SNAPSHOT、SYNC、TEXT-REPORT、FOLDER-REPORT。',
+    'ui.scriptingUnsupported': '未支援：ATTRIB、COLLAPSE、CRITERIA、EXPAND、MEDIA-REPORT、MOVE、MOVETO。',
+    'ui.scriptingUnsupportedCommands': '未支援命令',
+    'ui.scriptingSupportedCommands': '已支援命令',
     'ui.secretsHint': '密碼只存在本機密鑰檔（Unix 權限 0600），不會寫入設定清單或日誌。',
     'ui.sourceFile': 'Source file',
     'ui.svnIntegration': 'SVN 整合',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -695,7 +695,8 @@ export const zhTW: LanguagePack = {
       '完整遺留指令碼語言尚未實作。已支援的命令會真正執行；已知缺口以 unsupported 回傳。',
     'ui.scriptingSupported':
       '已支援：LOAD、FILTER、COMPARE、REPORT、FILE-REPORT、HEX-REPORT、TABLE-REPORT、PICTURE-REPORT、VERSION-REPORT、REGISTRY-REPORT、LOG、BEEP、OPTION、SELECT、COPY、COPYTO、DELETE、RENAME、TOUCH、SNAPSHOT、SYNC、TEXT-REPORT、FOLDER-REPORT。',
-    'ui.scriptingUnsupported': '未支援：ATTRIB、COLLAPSE、CRITERIA、EXPAND、MEDIA-REPORT、MOVE、MOVETO。',
+    'ui.scriptingUnsupported':
+      '未支援：ATTRIB、COLLAPSE、CRITERIA、EXPAND、MEDIA-REPORT、MOVE、MOVETO。',
     'ui.scriptingUnsupportedCommands': '未支援命令',
     'ui.scriptingSupportedCommands': '已支援命令',
     'ui.secretsHint': '密碼只存在本機密鑰檔（Unix 權限 0600），不會寫入設定清單或日誌。',

--- a/src/views/FolderMergeView.test.ts
+++ b/src/views/FolderMergeView.test.ts
@@ -227,7 +227,29 @@ describe('FolderMergeView', () => {
 
     expect(tabs.activeTab.title).toBe('left <--> right → output')
   })
+
+  it('exposes Expand/Collapse/Select session toolbar polish', async () => {
+    const wrapper = mountFolderMergeView()
+
+    await fillMergePaths(wrapper)
+    await wrapper.find('[data-testid="folder-merge-build-plan"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="folder-merge-session-toolbar-bar"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-merge-session-toolbar-expand"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-merge-session-toolbar-collapse"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-merge-session-toolbar-select"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="folder-merge-session-toolbar-select"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-merge-select-panel"]').exists()).toBe(true)
+    await wrapper.find('[data-testid="folder-merge-select-all"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-merge-selection-status"]').text().length).toBeGreaterThan(0)
+
+    await wrapper.find('[data-testid="folder-merge-session-toolbar-filters"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-merge-filters-panel"]').exists()).toBe(true)
+  })
 })
+
 
 function createMergePlanResponse(): FolderMergePlanResponse {
   return {

--- a/src/views/FolderMergeView.test.ts
+++ b/src/views/FolderMergeView.test.ts
@@ -237,19 +237,22 @@ describe('FolderMergeView', () => {
 
     expect(wrapper.find('[data-testid="folder-merge-session-toolbar-bar"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="folder-merge-session-toolbar-expand"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="folder-merge-session-toolbar-collapse"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-merge-session-toolbar-collapse"]').exists()).toBe(
+      true,
+    )
     expect(wrapper.find('[data-testid="folder-merge-session-toolbar-select"]').exists()).toBe(true)
 
     await wrapper.find('[data-testid="folder-merge-session-toolbar-select"]').trigger('click')
     expect(wrapper.find('[data-testid="folder-merge-select-panel"]').exists()).toBe(true)
     await wrapper.find('[data-testid="folder-merge-select-all"]').trigger('click')
-    expect(wrapper.find('[data-testid="folder-merge-selection-status"]').text().length).toBeGreaterThan(0)
+    expect(
+      wrapper.find('[data-testid="folder-merge-selection-status"]').text().length,
+    ).toBeGreaterThan(0)
 
     await wrapper.find('[data-testid="folder-merge-session-toolbar-filters"]').trigger('click')
     expect(wrapper.find('[data-testid="folder-merge-filters-panel"]').exists()).toBe(true)
   })
 })
-
 
 function createMergePlanResponse(): FolderMergePlanResponse {
   return {

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -17,7 +17,11 @@ import type {
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import { createFolderSnapshot } from '@/api/diff'
-import { mergeSessionTitle, pathBaseName } from '@/app/sessionToolbars'
+import {
+  collectExpandablePrefixes,
+  isPathHiddenByCollapse,
+} from '@/app/folderPathGroups'
+import { buildFolderMergeToolbar, mergeSessionTitle, pathBaseName } from '@/app/sessionToolbars'
 import { useI18n } from '@/i18n'
 import { useViewActionsStore } from '@/stores/viewActions'
 
@@ -38,16 +42,130 @@ const lastOpenedConflictPath = ref('')
 const sameOkOnly = ref(false)
 const showPeek = ref(false)
 const selectedPlanRowId = ref('')
+const collapsedPrefixes = ref<Set<string>>(new Set())
+const showMergeFilters = ref(false)
+const showMergeSelect = ref(false)
+const checkedRowIds = ref<Set<string>>(new Set())
+const lastSelectionAction = ref('')
 
 const planRows = computed<FolderMergePlanRow[]>(() => plan.value?.rows ?? [])
 const hasPlan = computed(() => planRows.value.length > 0)
-const visiblePlanRows = computed(() => {
+const filteredPlanRows = computed(() => {
   if (!sameOkOnly.value) {
     return planRows.value
   }
 
   return planRows.value.filter((row) => row.action === 'Keep output')
 })
+const visiblePlanRows = computed(() =>
+  filteredPlanRows.value.filter(
+    (row) => !isPathHiddenByCollapse(row.path, collapsedPrefixes.value),
+  ),
+)
+const mergeSessionToolbar = computed(() =>
+  buildFolderMergeToolbar({
+    home: true,
+    expand: hasPlan.value,
+    collapse: hasPlan.value,
+    select: hasPlan.value,
+    same: hasPlan.value,
+    filters: hasPlan.value,
+    refresh: Boolean(leftPath.value && basePath.value && rightPath.value),
+    peek: hasPlan.value,
+  }),
+)
+
+function goHomeFromMerge(): void {
+  tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+  void router.push('/')
+}
+
+function expandAllMergePaths(): void {
+  collapsedPrefixes.value = new Set()
+}
+
+function collapseAllMergePaths(): void {
+  collapsedPrefixes.value = new Set(
+    collectExpandablePrefixes(planRows.value.map((row) => row.path)),
+  )
+}
+
+function selectVisibleMergeRows(): void {
+  checkedRowIds.value = new Set(visiblePlanRows.value.map((row) => row.id))
+  lastSelectionAction.value = t('status.selectedRowCount', {
+    count: checkedRowIds.value.size,
+    action: t('ui.selectAll'),
+  })
+}
+
+function clearMergeSelection(): void {
+  checkedRowIds.value = new Set()
+  lastSelectionAction.value = t('status.selectedRowCount', {
+    count: 0,
+    action: t('ui.clearSelection'),
+  })
+}
+
+function invertMergeSelection(): void {
+  const next = new Set(checkedRowIds.value)
+
+  for (const row of visiblePlanRows.value) {
+    if (next.has(row.id)) {
+      next.delete(row.id)
+    } else {
+      next.add(row.id)
+    }
+  }
+
+  checkedRowIds.value = next
+  lastSelectionAction.value = t('status.selectedRowCount', {
+    count: next.size,
+    action: t('ui.invertSelection'),
+  })
+}
+
+function toggleMergeRowChecked(rowId: string): void {
+  const next = new Set(checkedRowIds.value)
+
+  if (next.has(rowId)) {
+    next.delete(rowId)
+  } else {
+    next.add(rowId)
+  }
+
+  checkedRowIds.value = next
+}
+
+function runMergeToolbarCommand(commandId: string): void {
+  switch (commandId) {
+    case 'home':
+      goHomeFromMerge()
+      break
+    case 'expand':
+      expandAllMergePaths()
+      break
+    case 'collapse':
+      collapseAllMergePaths()
+      break
+    case 'select':
+      showMergeSelect.value = !showMergeSelect.value
+      break
+    case 'same':
+      toggleSameOkFilter()
+      break
+    case 'filters':
+      showMergeFilters.value = !showMergeFilters.value
+      break
+    case 'refresh':
+      void buildFolderMergePlan()
+      break
+    case 'peek':
+      togglePeekPanel()
+      break
+    default:
+      break
+  }
+}
 const selectedPlanRow = computed(
   () => planRows.value.find((row) => row.id === selectedPlanRowId.value) ?? null,
 )
@@ -116,6 +234,12 @@ async function buildFolderMergePlan(): Promise<void> {
   })
   execution.value = undefined
   mergeExecutionError.value = undefined
+  collapsedPrefixes.value = new Set()
+  checkedRowIds.value = new Set()
+  lastSelectionAction.value = ''
+  if (plan.value?.rows[0]) {
+    selectedPlanRowId.value = plan.value.rows[0].id
+  }
 }
 
 async function runFolderMerge(): Promise<void> {
@@ -265,6 +389,8 @@ watch(
       case 'export':
       case 'export-settings':
       case 'filters':
+        showMergeFilters.value = !showMergeFilters.value
+        break
       case 'help-contents':
       case 'help-support':
       case 'import-settings':
@@ -294,6 +420,9 @@ watch(
     :eyebrow="$t('ui.merge')"
     :subtitle="$t('status.actionCount', { count: summary.actions })"
     :inspector-label="$t('ui.folderMergeInspector')"
+    :toolbar-commands="mergeSessionToolbar"
+    toolbar-test-id-prefix="folder-merge-session-toolbar"
+    @toolbar-command="runMergeToolbarCommand"
   >
     <section class="folder-merge-view">
       <header class="merge-header">
@@ -426,6 +555,56 @@ watch(
       </section>
 
       <section
+        v-if="showMergeFilters && hasPlan"
+        class="merge-chrome-panel"
+        data-testid="folder-merge-filters-panel"
+      >
+        <strong>{{ $t('ui.filters') }}</strong>
+        <button
+          type="button"
+          data-testid="folder-merge-filter-same-ok"
+          @click="toggleSameOkFilter"
+        >
+          {{ $t('ui.sameOk') }} ({{ sameOkCount }})
+        </button>
+        <span>{{ sameOkOnly ? $t('ui.sameOk') : $t('ui.all') }}</span>
+      </section>
+
+      <section
+        v-if="showMergeSelect && hasPlan"
+        class="merge-chrome-panel"
+        data-testid="folder-merge-select-panel"
+      >
+        <strong>{{ $t('ui.select') }}</strong>
+        <button
+          type="button"
+          data-testid="folder-merge-select-all"
+          @click="selectVisibleMergeRows"
+        >
+          {{ $t('ui.selectAll') }}
+        </button>
+        <button
+          type="button"
+          data-testid="folder-merge-select-invert"
+          @click="invertMergeSelection"
+        >
+          {{ $t('ui.invertSelection') }}
+        </button>
+        <button
+          type="button"
+          data-testid="folder-merge-select-clear"
+          @click="clearMergeSelection"
+        >
+          {{ $t('ui.clearSelection') }}
+        </button>
+        <span
+          v-if="lastSelectionAction"
+          data-testid="folder-merge-selection-status"
+          >{{ lastSelectionAction }}</span
+        >
+      </section>
+
+      <section
         v-if="hasPlan"
         class="merge-plan"
         data-testid="folder-merge-plan"
@@ -436,6 +615,7 @@ watch(
         </header>
         <div class="merge-plan-table">
           <div class="merge-plan-row merge-plan-head">
+            <span>{{ $t('ui.select') }}</span>
             <span>{{ $t('ui.path') }}</span>
             <span>{{ $t('ui.base') }}</span>
             <span>{{ $t('ui.left') }}</span>
@@ -449,11 +629,22 @@ watch(
             class="merge-plan-row"
             :class="{
               conflict: row.action === 'Mark conflict',
-              selected: row.id === selectedPlanRowId,
+              selected: row.id === selectedPlanRowId || checkedRowIds.has(row.id),
             }"
             data-testid="folder-merge-row"
             @click="selectPlanRow(row)"
           >
+            <label
+              class="merge-select-cell"
+              @click.stop
+            >
+              <input
+                type="checkbox"
+                :checked="checkedRowIds.has(row.id)"
+                :data-testid="`folder-merge-check-${row.id}`"
+                @change="toggleMergeRowChecked(row.id)"
+              />
+            </label>
             <strong>{{ row.path }}</strong>
             <span>{{ sideLabel(row.base) }}</span>
             <span>{{ sideLabel(row.left) }}</span>
@@ -733,9 +924,9 @@ h1 {
 .merge-plan-row {
   display: grid;
   grid-template-columns:
-    minmax(150px, 0.75fr) minmax(170px, 1fr) minmax(170px, 1fr) minmax(170px, 1fr)
+    44px minmax(150px, 0.75fr) minmax(170px, 1fr) minmax(170px, 1fr) minmax(170px, 1fr)
     140px minmax(220px, 1fr);
-  min-width: 1080px;
+  min-width: 1124px;
   border-bottom: 1px solid var(--app-border);
   color: var(--app-text);
   font-size: 12px;
@@ -865,5 +1056,31 @@ h1 {
 .merge-plan-row.selected {
   outline: 1px solid var(--app-accent);
   background: color-mix(in srgb, var(--app-accent) 12%, transparent);
+}
+
+.merge-chrome-panel {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-surface);
+}
+
+.merge-chrome-panel button {
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-bg);
+  color: var(--app-text);
+  cursor: pointer;
+}
+
+.merge-select-cell {
+  display: flex;
+  align-items: center;
 }
 </style>

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -163,6 +163,7 @@ function runMergeToolbarCommand(commandId: string): void {
       break
   }
 }
+
 const selectedPlanRow = computed(
   () => planRows.value.find((row) => row.id === selectedPlanRowId.value) ?? null,
 )
@@ -234,7 +235,7 @@ async function buildFolderMergePlan(): Promise<void> {
   collapsedPrefixes.value = new Set()
   checkedRowIds.value = new Set()
   lastSelectionAction.value = ''
-  if (plan.value?.rows[0]) {
+  if (plan.value.rows.length > 0) {
     selectedPlanRowId.value = plan.value.rows[0].id
   }
 }

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -17,10 +17,7 @@ import type {
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import { createFolderSnapshot } from '@/api/diff'
-import {
-  collectExpandablePrefixes,
-  isPathHiddenByCollapse,
-} from '@/app/folderPathGroups'
+import { collectExpandablePrefixes, isPathHiddenByCollapse } from '@/app/folderPathGroups'
 import { buildFolderMergeToolbar, mergeSessionTitle, pathBaseName } from '@/app/sessionToolbars'
 import { useI18n } from '@/i18n'
 import { useViewActionsStore } from '@/stores/viewActions'

--- a/src/views/FolderSyncView.test.ts
+++ b/src/views/FolderSyncView.test.ts
@@ -228,8 +228,12 @@ describe('FolderSyncView', () => {
 
     expect(wrapper.find('[data-testid="folder-sync-session-toolbar-bar"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="folder-sync-session-toolbar-home"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-expand"]').attributes('disabled')).toBeUndefined()
-    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-collapse"]').attributes('disabled')).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="folder-sync-session-toolbar-expand"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="folder-sync-session-toolbar-collapse"]').attributes('disabled'),
+    ).toBeUndefined()
 
     await wrapper.find('[data-testid="folder-sync-session-toolbar-filters"]').trigger('click')
     expect(wrapper.find('[data-testid="folder-sync-filters-panel"]').exists()).toBe(true)

--- a/src/views/FolderSyncView.test.ts
+++ b/src/views/FolderSyncView.test.ts
@@ -2,6 +2,12 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import FolderSyncView from './FolderSyncView.vue'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
 import { executeFolderSync, previewFolderSync } from '@/api/sync'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 
@@ -200,5 +206,42 @@ describe('FolderSyncView', () => {
       rightRoot: 'D:/deploy/prod',
       strategy: 'updateBoth',
     })
+  })
+
+  it('exposes Expand/Collapse/Select/Filters/Home session toolbar chrome', async () => {
+    const wrapper = mount(FolderSyncView, {
+      global: {
+        stubs: {
+          NButton: {
+            props: ['disabled', 'loading'],
+            emits: ['click'],
+            template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+          },
+        },
+      },
+    })
+
+    await wrapper.find('[data-testid="folder-sync-left-path"]').setValue('D:/deploy/package')
+    await wrapper.find('[data-testid="folder-sync-right-path"]').setValue('D:/deploy/prod')
+    await wrapper.find('[data-testid="folder-sync-preview"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-bar"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-home"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-expand"]').attributes('disabled')).toBeUndefined()
+    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-collapse"]').attributes('disabled')).toBeUndefined()
+
+    await wrapper.find('[data-testid="folder-sync-session-toolbar-filters"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-sync-filters-panel"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="folder-sync-session-toolbar-select"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-sync-select-panel"]').exists()).toBe(true)
+    await wrapper.find('[data-testid="folder-sync-select-all"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-sync-selection-status"]').text()).toContain('2')
+
+    await wrapper.find('[data-testid="folder-sync-session-toolbar-collapse"]').trigger('click')
+    expect(wrapper.find('[data-testid="sync-row-copy-app"]').exists()).toBe(false)
+    await wrapper.find('[data-testid="folder-sync-session-toolbar-expand"]').trigger('click')
+    expect(wrapper.find('[data-testid="sync-row-copy-app"]').exists()).toBe(true)
   })
 })

--- a/src/views/FolderSyncView.vue
+++ b/src/views/FolderSyncView.vue
@@ -9,10 +9,15 @@ import type {
   FolderSyncStrategy,
 } from '@/types/sync'
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
-import { pathBaseName, syncPathPairTitle } from '@/app/sessionToolbars'
 import { createFolderSnapshot } from '@/api/diff'
+import {
+  collectExpandablePrefixes,
+  isPathHiddenByCollapse,
+} from '@/app/folderPathGroups'
+import { buildFolderSyncToolbar, pathBaseName, syncPathPairTitle } from '@/app/sessionToolbars'
 import { useI18n } from '@/i18n'
 import { useTabsStore } from '@/stores/tabs'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
@@ -50,6 +55,7 @@ const strategyOptions: SyncStrategyOption[] = [
 ]
 const { t } = useI18n()
 const tabs = useTabsStore()
+const router = useRouter()
 const sessionLaunch = useSessionLaunchStore()
 const viewActions = useViewActionsStore()
 const leftPath = ref('')
@@ -65,6 +71,14 @@ const completedOperations = ref(0)
 const syncLogs = ref<string[]>([])
 const planAccepted = ref(false)
 const syncChromeMessage = ref('')
+const collapsedPrefixes = ref<Set<string>>(new Set())
+const showSyncFilters = ref(false)
+const showSyncSelect = ref(false)
+const checkedRowIds = ref<Set<string>>(new Set())
+const visibleActions = ref<Set<FolderSyncPreviewAction>>(
+  new Set(['Copy', 'Delete', 'Leave', 'Conflict']),
+)
+const lastSelectionAction = ref('')
 
 const selectedStrategyLabel = computed(() =>
   t(
@@ -85,6 +99,134 @@ const syncSessionTitle = computed(() => {
 
   return t('ui.folderSync')
 })
+const filteredPreviewRows = computed(() =>
+  previewRows.value.filter((row) => visibleActions.value.has(row.action)),
+)
+const visiblePreviewRows = computed(() =>
+  filteredPreviewRows.value.filter(
+    (row) => !isPathHiddenByCollapse(row.relativePath, collapsedPrefixes.value),
+  ),
+)
+const syncSessionToolbar = computed(() =>
+  buildFolderSyncToolbar({
+    home: true,
+    expand: previewRows.value.length > 0,
+    collapse: previewRows.value.length > 0,
+    select: previewRows.value.length > 0,
+    filters: previewRows.value.length > 0,
+    refresh: Boolean(leftPath.value && rightPath.value) && !previewLoading.value,
+    swap: Boolean(leftPath.value || rightPath.value),
+    stop: previewLoading.value || syncRunning.value,
+  }),
+)
+
+function goHomeFromSync(): void {
+  tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
+  void router.push('/')
+}
+
+function expandAllSyncPaths(): void {
+  collapsedPrefixes.value = new Set()
+}
+
+function collapseAllSyncPaths(): void {
+  collapsedPrefixes.value = new Set(
+    collectExpandablePrefixes(previewRows.value.map((row) => row.relativePath)),
+  )
+}
+
+function toggleSyncActionFilter(action: FolderSyncPreviewAction): void {
+  const next = new Set(visibleActions.value)
+
+  if (next.has(action)) {
+    next.delete(action)
+  } else {
+    next.add(action)
+  }
+
+  visibleActions.value = next
+}
+
+function selectVisibleSyncRows(): void {
+  checkedRowIds.value = new Set(visiblePreviewRows.value.map((row) => row.id))
+  lastSelectionAction.value = t('status.selectedRowCount', {
+    count: checkedRowIds.value.size,
+    action: t('ui.selectAll'),
+  })
+}
+
+function clearSyncSelection(): void {
+  checkedRowIds.value = new Set()
+  lastSelectionAction.value = t('status.selectedRowCount', {
+    count: 0,
+    action: t('ui.clearSelection'),
+  })
+}
+
+function invertSyncSelection(): void {
+  const next = new Set(checkedRowIds.value)
+
+  for (const row of visiblePreviewRows.value) {
+    if (next.has(row.id)) {
+      next.delete(row.id)
+    } else {
+      next.add(row.id)
+    }
+  }
+
+  checkedRowIds.value = next
+  lastSelectionAction.value = t('status.selectedRowCount', {
+    count: next.size,
+    action: t('ui.invertSelection'),
+  })
+}
+
+function toggleSyncRowChecked(rowId: string): void {
+  const next = new Set(checkedRowIds.value)
+
+  if (next.has(rowId)) {
+    next.delete(rowId)
+  } else {
+    next.add(rowId)
+  }
+
+  checkedRowIds.value = next
+}
+
+function stopSyncWork(): void {
+  syncChromeMessage.value = t('ui.stop')
+}
+
+function runSyncToolbarCommand(commandId: string): void {
+  switch (commandId) {
+    case 'home':
+      goHomeFromSync()
+      break
+    case 'expand':
+      expandAllSyncPaths()
+      break
+    case 'collapse':
+      collapseAllSyncPaths()
+      break
+    case 'select':
+      showSyncSelect.value = !showSyncSelect.value
+      break
+    case 'filters':
+      showSyncFilters.value = !showSyncFilters.value
+      break
+    case 'refresh':
+      void previewSync()
+      break
+    case 'swap':
+      swapSyncPaths()
+      break
+    case 'stop':
+      stopSyncWork()
+      break
+    default:
+      break
+  }
+}
 
 onMounted(() => {
   const launch = sessionLaunch.consumeLaunch('/sync/folder')
@@ -121,6 +263,9 @@ async function previewSync(): Promise<void> {
     syncRunError.value = undefined
     planAccepted.value = false
     syncChromeMessage.value = ''
+    collapsedPrefixes.value = new Set()
+    checkedRowIds.value = new Set()
+    lastSelectionAction.value = ''
   } catch (error) {
     previewError.value = error instanceof Error ? error.message : String(error)
   } finally {
@@ -324,6 +469,8 @@ watch(
       case 'export':
       case 'export-settings':
       case 'filters':
+        showSyncFilters.value = !showSyncFilters.value
+        break
       case 'help-contents':
       case 'help-support':
       case 'import-settings':
@@ -352,6 +499,9 @@ watch(
     :eyebrow="$t('ui.sync')"
     :subtitle="selectedStrategyLabel"
     :inspector-label="$t('ui.folderSyncInspector')"
+    :toolbar-commands="syncSessionToolbar"
+    toolbar-test-id-prefix="folder-sync-session-toolbar"
+    @toolbar-command="runSyncToolbarCommand"
   >
     <section class="folder-sync-view">
       <header class="folder-sync-header">
@@ -461,6 +611,60 @@ watch(
       </section>
 
       <section
+        v-if="showSyncFilters && previewRows.length > 0"
+        class="sync-chrome-panel"
+        data-testid="folder-sync-filters-panel"
+      >
+        <strong>{{ $t('ui.filters') }}</strong>
+        <label
+          v-for="action in (['Copy', 'Delete', 'Leave', 'Conflict'] as const)"
+          :key="action"
+        >
+          <input
+            type="checkbox"
+            :checked="visibleActions.has(action)"
+            :data-testid="`folder-sync-filter-${action}`"
+            @change="toggleSyncActionFilter(action)"
+          />
+          <span>{{ folderSyncActionLabel(action) }}</span>
+        </label>
+      </section>
+
+      <section
+        v-if="showSyncSelect && previewRows.length > 0"
+        class="sync-chrome-panel"
+        data-testid="folder-sync-select-panel"
+      >
+        <strong>{{ $t('ui.select') }}</strong>
+        <button
+          type="button"
+          data-testid="folder-sync-select-all"
+          @click="selectVisibleSyncRows"
+        >
+          {{ $t('ui.selectAll') }}
+        </button>
+        <button
+          type="button"
+          data-testid="folder-sync-select-invert"
+          @click="invertSyncSelection"
+        >
+          {{ $t('ui.invertSelection') }}
+        </button>
+        <button
+          type="button"
+          data-testid="folder-sync-select-clear"
+          @click="clearSyncSelection"
+        >
+          {{ $t('ui.clearSelection') }}
+        </button>
+        <span
+          v-if="lastSelectionAction"
+          data-testid="folder-sync-selection-status"
+          >{{ lastSelectionAction }}</span
+        >
+      </section>
+
+      <section
         v-if="previewRows.length > 0"
         class="sync-preview"
         data-testid="folder-sync-preview-panel"
@@ -474,6 +678,7 @@ watch(
         </header>
         <div class="sync-preview-table">
           <div class="sync-preview-row sync-preview-head">
+            <span>{{ $t('ui.select') }}</span>
             <span>{{ $t('ui.plannedAction') }}</span>
             <span>{{ $t('ui.override') }}</span>
             <span>{{ $t('ui.source') }}</span>
@@ -481,12 +686,23 @@ watch(
             <span>{{ $t('ui.detail') }}</span>
           </div>
           <div
-            v-for="row in previewRows"
+            v-for="row in visiblePreviewRows"
             :key="row.id"
             class="sync-preview-row"
-            :class="{ 'sync-row-overridden': row.overrideAction !== row.plannedAction }"
+            :class="{
+              'sync-row-overridden': row.overrideAction !== row.plannedAction,
+              'sync-row-selected': checkedRowIds.has(row.id),
+            }"
             :data-testid="`sync-row-${row.id}`"
           >
+            <label class="sync-select-cell">
+              <input
+                type="checkbox"
+                :checked="checkedRowIds.has(row.id)"
+                :data-testid="`sync-check-${row.id}`"
+                @change="toggleSyncRowChecked(row.id)"
+              />
+            </label>
             <span :data-testid="`sync-planned-${row.id}`">{{
               $t(
                 overrideOptions.find((option) => option.value === row.plannedAction)?.labelKey ??
@@ -697,7 +913,7 @@ h1 {
 
 .sync-preview-row {
   display: grid;
-  grid-template-columns: 120px minmax(200px, 1fr) minmax(160px, 1.1fr) minmax(160px, 1.1fr) minmax(
+  grid-template-columns: 44px 120px minmax(200px, 1fr) minmax(160px, 1.1fr) minmax(160px, 1.1fr) minmax(
       140px,
       0.9fr
     );
@@ -805,5 +1021,42 @@ h1 {
   .sync-progress {
     text-align: left;
   }
+}
+
+.sync-chrome-panel {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-surface);
+}
+
+.sync-chrome-panel label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.sync-chrome-panel button {
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-bg);
+  color: var(--app-text);
+  cursor: pointer;
+}
+
+.sync-select-cell {
+  display: flex;
+  align-items: center;
+}
+
+.sync-row-selected {
+  background: color-mix(in srgb, var(--app-accent, #4c8bf5) 12%, transparent);
 }
 </style>

--- a/src/views/FolderSyncView.vue
+++ b/src/views/FolderSyncView.vue
@@ -13,10 +13,7 @@ import { useRouter } from 'vue-router'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import { createFolderSnapshot } from '@/api/diff'
-import {
-  collectExpandablePrefixes,
-  isPathHiddenByCollapse,
-} from '@/app/folderPathGroups'
+import { collectExpandablePrefixes, isPathHiddenByCollapse } from '@/app/folderPathGroups'
 import { buildFolderSyncToolbar, pathBaseName, syncPathPairTitle } from '@/app/sessionToolbars'
 import { useI18n } from '@/i18n'
 import { useTabsStore } from '@/stores/tabs'
@@ -617,7 +614,7 @@ watch(
       >
         <strong>{{ $t('ui.filters') }}</strong>
         <label
-          v-for="action in (['Copy', 'Delete', 'Leave', 'Conflict'] as const)"
+          v-for="action in ['Copy', 'Delete', 'Leave', 'Conflict'] as const"
           :key="action"
         >
           <input
@@ -913,10 +910,9 @@ h1 {
 
 .sync-preview-row {
   display: grid;
-  grid-template-columns: 44px 120px minmax(200px, 1fr) minmax(160px, 1.1fr) minmax(160px, 1.1fr) minmax(
-      140px,
-      0.9fr
-    );
+  grid-template-columns:
+    44px 120px minmax(200px, 1fr) minmax(160px, 1.1fr) minmax(160px, 1.1fr)
+    minmax(140px, 0.9fr);
   min-width: 960px;
   border-bottom: 1px solid var(--app-border);
   font-size: 12px;

--- a/src/views/reports/ReportsScriptView.test.ts
+++ b/src/views/reports/ReportsScriptView.test.ts
@@ -138,9 +138,13 @@ describe('ReportsScriptView', () => {
 
     expect(wrapper.find('[data-testid="script-command-lists"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="script-supported-commands"]').text()).toContain('HEX-REPORT')
-    expect(wrapper.find('[data-testid="script-supported-commands"]').text()).toContain('TABLE-REPORT')
+    expect(wrapper.find('[data-testid="script-supported-commands"]').text()).toContain(
+      'TABLE-REPORT',
+    )
     expect(wrapper.find('[data-testid="script-unsupported-commands"]').text()).toContain('ATTRIB')
-    expect(wrapper.find('[data-testid="script-unsupported-commands"]').text()).toContain('MEDIA-REPORT')
+    expect(wrapper.find('[data-testid="script-unsupported-commands"]').text()).toContain(
+      'MEDIA-REPORT',
+    )
     expect(wrapper.text()).not.toMatch(/Beyond Compare|\bBC5?\b|Scooter/i)
   })
 })

--- a/src/views/reports/ReportsScriptView.test.ts
+++ b/src/views/reports/ReportsScriptView.test.ts
@@ -132,4 +132,15 @@ describe('ReportsScriptView', () => {
     expect(wrapper.find('[data-testid="script-result"]').text()).toContain('reports=1')
     expect(wrapper.find('[data-testid="script-result"]').text()).toContain('wrote report.txt')
   })
+
+  it('shows honest supported and unsupported script command lists', () => {
+    const wrapper = mount(ReportsScriptView)
+
+    expect(wrapper.find('[data-testid="script-command-lists"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="script-supported-commands"]').text()).toContain('HEX-REPORT')
+    expect(wrapper.find('[data-testid="script-supported-commands"]').text()).toContain('TABLE-REPORT')
+    expect(wrapper.find('[data-testid="script-unsupported-commands"]').text()).toContain('ATTRIB')
+    expect(wrapper.find('[data-testid="script-unsupported-commands"]').text()).toContain('MEDIA-REPORT')
+    expect(wrapper.text()).not.toMatch(/Beyond Compare|\bBC5?\b|Scooter/i)
+  })
 })

--- a/src/views/reports/ReportsScriptView.vue
+++ b/src/views/reports/ReportsScriptView.vue
@@ -7,6 +7,12 @@ import {
   recordRecentReportExport,
   type RecentReportExport,
 } from '@/app/reportExports'
+import {
+  compareReportExampleScript,
+  formatCommandList,
+  supportedScriptCommands,
+  unsupportedScriptCommands,
+} from '@/app/scriptCommands'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchToolbar from '@/components/workbench/WorkbenchToolbar.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
@@ -32,9 +38,9 @@ const jobs = ref<ReportJob[]>(loadRecentReportExports())
 const running = ref(false)
 const error = ref('')
 const lastExport = ref('')
-const scriptSource = ref(
-  'load "$' + '{left}"\nload "$' + '{right}"\ncompare\ntext-report "$' + '{output}"\n',
-)
+const scriptSource = ref(compareReportExampleScript)
+const supportedCommandsLabel = formatCommandList(supportedScriptCommands)
+const unsupportedCommandsLabel = formatCommandList(unsupportedScriptCommands)
 const scriptPath = ref('')
 const scriptResult = ref('')
 const scriptRunning = ref(false)
@@ -296,8 +302,21 @@ function fillFromLastCompare(): void {
       <section class="script-panel">
         <header class="split-pane-header">
           <strong>{{ $t('ui.scriptCli') }}</strong>
-          <span>{{ $t('ui.scriptingSupported') }}</span>
+          <span>{{ $t('ui.scriptingNotImplemented') }}</span>
         </header>
+        <section
+          class="script-command-lists"
+          data-testid="script-command-lists"
+        >
+          <div>
+            <strong>{{ $t('ui.scriptingSupportedCommands') }}</strong>
+            <p data-testid="script-supported-commands">{{ supportedCommandsLabel }}</p>
+          </div>
+          <div>
+            <strong>{{ $t('ui.scriptingUnsupportedCommands') }}</strong>
+            <p data-testid="script-unsupported-commands">{{ unsupportedCommandsLabel }}</p>
+          </div>
+        </section>
         <label class="script-path">
           <span>{{ $t('ui.scriptPath') }}</span>
           <input
@@ -475,5 +494,28 @@ function fillFromLastCompare(): void {
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 20px;
+}
+
+.script-command-lists {
+  display: grid;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-bg);
+}
+
+.script-command-lists strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 12px;
+}
+
+.script-command-lists p {
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  word-break: break-word;
 }
 </style>

--- a/src/views/reports/ReportsScriptView.vue
+++ b/src/views/reports/ReportsScriptView.vue
@@ -516,6 +516,6 @@ function fillFromLastCompare(): void {
   color: var(--app-text-muted);
   font-size: 12px;
   line-height: 1.45;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 </style>


### PR DESCRIPTION
## Summary
- Deepen Reports/Scripts automation: FILE/HEX/TABLE/PICTURE/VERSION/REGISTRY/REPORT commands, binary/table compare paths, and an honest supported vs unsupported command list in the UI (no trademarked product names).
- Add Folder Sync session toolbar chrome for Home / Expand / Collapse / Select / Filters (plus refresh/swap/stop), with path-prefix collapse and select/filter panels.
- Polish Folder Merge Expand / Collapse / Select (and filters/same/peek) via the same session-toolbar pattern.
- i18n for new script catalog strings; unit tests + typecheck; rebased onto #82 tip.

## Test plan
- [x] `vitest` targeted suites (scriptCommands, folderPathGroups, sessionToolbars, ReportsScriptView, FolderSyncView, FolderMergeView, languageSkeletons)
- [x] `vue-tsc --noEmit`
- [x] `cargo test -p script-core --lib`
- [ ] Manual: open Folder Sync / Folder Merge, toggle Expand/Collapse/Select/Filters from session toolbar
- [ ] Manual: Reports/Scripts shows supported + unsupported lists and runs HEX/TABLE/FILE report scripts