### PR TITLE
Fix stale unsupported-script test after ATTRIB landed

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5788,8 +5788,8 @@ mod tests {
 
     #[test]
     fn run_script_unsupported_command_fails_clearly() {
-        let error = run_script("ATTRIB readme.txt\n".to_owned(), None)
-            .expect_err("ATTRIB should stay unsupported");
+        let error = run_script("CRITERIA name\n".to_owned(), None)
+            .expect_err("CRITERIA should stay unsupported");
 
         assert!(error
             .debug_message


### PR DESCRIPTION
## Summary
- After #85, ATTRIB is supported; the commands regression still expected it to stay unsupported.
- Point run_script_unsupported_command_fails_clearly at remaining legacy gap CRITERIA.

## Test plan
- [x] cargo test -p open-diff-app --lib commands::tests::run_script_unsupported_command_fails_clearly
- [x] cargo test --workspace (345 passed)