### PR TITLE
Enable Session New Window and deepen script CRITERIA time flags

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capability for the main OpenDiff window (core events needed for desktop drag-drop).",
-  "windows": ["main"],
-  "permissions": ["core:default"]
+  "description": "Default capability for OpenDiff main and session-* windows (core events for desktop drag-drop; create for New Window).",
+  "windows": ["main", "session-*"],
+  "permissions": ["core:default", "core:webview:allow-create-webview-window"]
 }

--- a/src-tauri/crates/folder-core/src/lib.rs
+++ b/src-tauri/crates/folder-core/src/lib.rs
@@ -52,6 +52,15 @@ pub struct FolderCompareOptions {
     pub case_sensitive_names: bool,
     pub compare_contents: bool,
     pub compare_crc: bool,
+    /// Allowed absolute difference when comparing modified times (milliseconds).
+    #[serde(default)]
+    pub timestamp_tolerance_ms: u128,
+    /// Treat a one-hour modified-time skew as equal (DST / clock skew).
+    #[serde(default)]
+    pub ignore_daylight_saving_hour_offset: bool,
+    /// Additional whole-hour timezone offsets to treat as equal when comparing times.
+    #[serde(default)]
+    pub ignored_timezone_hour_offsets: Vec<i32>,
 }
 
 impl Default for FolderCompareOptions {
@@ -62,6 +71,9 @@ impl Default for FolderCompareOptions {
             case_sensitive_names: true,
             compare_contents: true,
             compare_crc: false,
+            timestamp_tolerance_ms: 0,
+            ignore_daylight_saving_hour_offset: false,
+            ignored_timezone_hour_offsets: Vec::new(),
         }
     }
 }
@@ -941,7 +953,51 @@ fn folder_metadata_matches(
     left.kind == right.kind
         && (!options.compare_size || left.metadata.size == right.metadata.size)
         && (!options.compare_modified_time
-            || left.metadata.modified_at_ms == right.metadata.modified_at_ms)
+            || modified_times_match(
+                left.metadata.modified_at_ms,
+                right.metadata.modified_at_ms,
+                options,
+            ))
+}
+
+fn modified_times_match(
+    left: Option<u128>,
+    right: Option<u128>,
+    options: &FolderCompareOptions,
+) -> bool {
+    let (Some(left), Some(right)) = (left, right) else {
+        return left == right;
+    };
+    let difference = left.abs_diff(right);
+    if difference <= options.timestamp_tolerance_ms {
+        return true;
+    }
+    ignored_hour_offsets_ms(options)
+        .into_iter()
+        .any(|offset_ms| offset_matches_difference(difference, offset_ms, options))
+}
+
+fn ignored_hour_offsets_ms(options: &FolderCompareOptions) -> Vec<u128> {
+    let mut offsets = options
+        .ignored_timezone_hour_offsets
+        .iter()
+        .map(|hours| u128::from(hours.unsigned_abs()) * 3_600_000)
+        .collect::<Vec<_>>();
+    if options.ignore_daylight_saving_hour_offset {
+        offsets.push(3_600_000);
+    }
+    offsets
+}
+
+fn offset_matches_difference(
+    difference: u128,
+    offset_ms: u128,
+    options: &FolderCompareOptions,
+) -> bool {
+    if offset_ms == 0 {
+        return false;
+    }
+    difference.abs_diff(offset_ms) <= options.timestamp_tolerance_ms
 }
 
 fn with_status(mut node: FolderScanNode, status: FolderCompareStatus) -> FolderScanNode {
@@ -1291,6 +1347,7 @@ mod tests {
                     case_sensitive_names: true,
                     compare_contents: false,
                     compare_crc: false,
+                    ..Default::default()
                 },
             ),
             FolderCompareStatus::Different
@@ -1305,9 +1362,83 @@ mod tests {
                     case_sensitive_names: true,
                     compare_contents: false,
                     compare_crc: false,
+                    ..Default::default()
                 },
             ),
             FolderCompareStatus::Same
+        );
+    }
+
+    #[test]
+    fn honors_timestamp_tolerance_and_ignore_dst_hour_offset() {
+        let left = FolderScanNode::new_file(
+            "same.txt",
+            "same.txt",
+            metadata_with_modified_at(VfsEntryKind::File, "same.txt", Some("txt"), 20, Some(1_000)),
+        );
+        let near = FolderScanNode::new_file(
+            "same.txt",
+            "same.txt",
+            metadata_with_modified_at(VfsEntryKind::File, "same.txt", Some("txt"), 20, Some(1_500)),
+        );
+        let dst = FolderScanNode::new_file(
+            "same.txt",
+            "same.txt",
+            metadata_with_modified_at(
+                VfsEntryKind::File,
+                "same.txt",
+                Some("txt"),
+                20,
+                Some(1_000 + 3_600_000),
+            ),
+        );
+
+        assert_eq!(
+            classify_folder_alignment_with_options(
+                Some(&left),
+                Some(&near),
+                &FolderCompareOptions {
+                    compare_size: true,
+                    compare_modified_time: true,
+                    case_sensitive_names: true,
+                    compare_contents: false,
+                    compare_crc: false,
+                    timestamp_tolerance_ms: 1_000,
+                    ..Default::default()
+                },
+            ),
+            FolderCompareStatus::Same
+        );
+        assert_eq!(
+            classify_folder_alignment_with_options(
+                Some(&left),
+                Some(&dst),
+                &FolderCompareOptions {
+                    compare_size: true,
+                    compare_modified_time: true,
+                    case_sensitive_names: true,
+                    compare_contents: false,
+                    compare_crc: false,
+                    ignore_daylight_saving_hour_offset: true,
+                    ..Default::default()
+                },
+            ),
+            FolderCompareStatus::Same
+        );
+        assert_eq!(
+            classify_folder_alignment_with_options(
+                Some(&left),
+                Some(&dst),
+                &FolderCompareOptions {
+                    compare_size: true,
+                    compare_modified_time: true,
+                    case_sensitive_names: true,
+                    compare_contents: false,
+                    compare_crc: false,
+                    ..Default::default()
+                },
+            ),
+            FolderCompareStatus::Different
         );
     }
 
@@ -1343,6 +1474,7 @@ mod tests {
                 case_sensitive_names: false,
                 compare_contents: false,
                 compare_crc: false,
+                ..Default::default()
             },
         );
         let sensitive = align_folder_trees_with_options(
@@ -1354,6 +1486,7 @@ mod tests {
                 case_sensitive_names: true,
                 compare_contents: false,
                 compare_crc: false,
+                ..Default::default()
             },
         );
 

--- a/src-tauri/crates/script-core/src/lib.rs
+++ b/src-tauri/crates/script-core/src/lib.rs
@@ -134,6 +134,15 @@ pub struct ScriptFolderCriteria {
     pub compare_modified_time: bool,
     pub compare_contents: bool,
     pub compare_crc: bool,
+    #[serde(default)]
+    pub timestamp_tolerance_ms: u128,
+    #[serde(default)]
+    pub ignore_daylight_saving_hour_offset: bool,
+    #[serde(default)]
+    pub ignored_timezone_hour_offsets: Vec<i32>,
+    /// When contents are compared, treat whitespace / case / EOL as unimportant.
+    #[serde(default)]
+    pub ignore_unimportant: bool,
 }
 
 impl Default for ScriptFolderCriteria {
@@ -143,6 +152,10 @@ impl Default for ScriptFolderCriteria {
             compare_modified_time: false,
             compare_contents: true,
             compare_crc: false,
+            timestamp_tolerance_ms: 0,
+            ignore_daylight_saving_hour_offset: false,
+            ignored_timezone_hour_offsets: Vec::new(),
+            ignore_unimportant: false,
         }
     }
 }
@@ -155,6 +168,9 @@ impl ScriptFolderCriteria {
             case_sensitive_names: true,
             compare_contents: self.compare_contents,
             compare_crc: self.compare_crc,
+            timestamp_tolerance_ms: self.timestamp_tolerance_ms,
+            ignore_daylight_saving_hour_offset: self.ignore_daylight_saving_hour_offset,
+            ignored_timezone_hour_offsets: self.ignored_timezone_hour_offsets.clone(),
         }
     }
 }
@@ -844,6 +860,11 @@ fn apply_criteria_command(
         ("compare-timestamp", criteria.compare_modified_time),
         ("compare-contents", criteria.compare_contents),
         ("compare-crc", criteria.compare_crc),
+        ("ignore-unimportant", criteria.ignore_unimportant),
+        (
+            "ignore-dst",
+            criteria.ignore_daylight_saving_hour_offset,
+        ),
     ] {
         state
             .options
@@ -855,6 +876,25 @@ fn apply_criteria_command(
             } else {
                 "false".to_owned()
             },
+        });
+    }
+    if criteria.timestamp_tolerance_ms > 0 {
+        state
+            .options
+            .retain(|option| !option.key.eq_ignore_ascii_case("timestamp-tolerance-ms"));
+        state.options.push(ScriptOption {
+            key: "timestamp-tolerance-ms".to_owned(),
+            value: criteria.timestamp_tolerance_ms.to_string(),
+        });
+    }
+    for hours in &criteria.ignored_timezone_hour_offsets {
+        let key = format!("timezone:{hours}");
+        state
+            .options
+            .retain(|option| !option.key.eq_ignore_ascii_case(&key));
+        state.options.push(ScriptOption {
+            key,
+            value: "true".to_owned(),
         });
     }
     for token in &acknowledged {
@@ -870,7 +910,8 @@ fn apply_criteria_command(
 }
 
 /// Map CRITERIA tokens onto folder Session Settings comparison flags.
-/// Supported: timestamp[:…], size, crc, binary, rules-based.
+/// Supported: timestamp[:seconds], size, crc, binary, rules-based,
+/// ignore-unimportant, IgnoreDST / ignore-dst, timezone:<hours>.
 /// Other legacy script tokens are acknowledged without changing compare results.
 pub fn parse_folder_criteria_tokens(
     tokens: &[String],
@@ -880,6 +921,10 @@ pub fn parse_folder_criteria_tokens(
         compare_modified_time: false,
         compare_contents: false,
         compare_crc: false,
+        timestamp_tolerance_ms: 0,
+        ignore_daylight_saving_hour_offset: false,
+        ignored_timezone_hour_offsets: Vec::new(),
+        ignore_unimportant: false,
     };
     let mut acknowledged = Vec::new();
     let mut saw_content_method = false;
@@ -896,6 +941,14 @@ pub fn parse_folder_criteria_tokens(
         let lower = token.to_ascii_lowercase();
         if lower == "timestamp" || lower.starts_with("timestamp:") {
             criteria.compare_modified_time = true;
+            if let Some(rest) = lower.strip_prefix("timestamp:") {
+                if !rest.is_empty() {
+                    let seconds: u128 = rest.parse().map_err(|_| {
+                        format!("invalid CRITERIA timestamp tolerance: {token}")
+                    })?;
+                    criteria.timestamp_tolerance_ms = seconds.saturating_mul(1_000);
+                }
+            }
             continue;
         }
         if lower == "size" {
@@ -924,11 +977,26 @@ pub fn parse_folder_criteria_tokens(
             criteria.compare_size = true;
             continue;
         }
+        if lower == "ignore-unimportant" {
+            criteria.ignore_unimportant = true;
+            continue;
+        }
+        if lower == "ignoredst" || lower == "ignore-dst" {
+            criteria.compare_modified_time = true;
+            criteria.ignore_daylight_saving_hour_offset = true;
+            continue;
+        }
+        if let Some(rest) = lower.strip_prefix("timezone:") {
+            let hours: i32 = rest.parse().map_err(|_| {
+                format!("invalid CRITERIA timezone offset: {token}")
+            })?;
+            criteria.compare_modified_time = true;
+            criteria.ignored_timezone_hour_offsets.push(hours);
+            continue;
+        }
         if lower.starts_with("attrib:")
             || lower == "version"
-            || lower.starts_with("timezone:")
             || lower == "follow-symlinks"
-            || lower == "ignore-unimportant"
             || lower == "owner"
             || lower == "group"
             || lower == "permissions"
@@ -1281,7 +1349,11 @@ fn classify_script_folder_row(
     row: &folder_core::FolderAlignmentRow,
     criteria: &ScriptFolderCriteria,
 ) -> folder_core::FolderCompareStatus {
-    let options = criteria.to_folder_options();
+    let mut options = criteria.to_folder_options();
+    // Whitespace / EOL ignores can change byte length; don't hard-fail on size first.
+    if criteria.ignore_unimportant && criteria.compare_contents {
+        options.compare_size = false;
+    }
     let metadata_status = folder_core::classify_folder_alignment_with_options(
         row.left.as_ref(),
         row.right.as_ref(),
@@ -1325,6 +1397,22 @@ fn classify_script_folder_row(
     }
 
     if criteria.compare_contents {
+        if criteria.ignore_unimportant {
+            let left_text = String::from_utf8_lossy(&left_bytes);
+            let right_text = String::from_utf8_lossy(&right_bytes);
+            return folder_core::compare_text_content_with_rules(
+                &left_text,
+                &right_text,
+                &folder_core::FolderTextRuleCompareOptions {
+                    ignore_whitespace: true,
+                    ignore_case: true,
+                    ignore_line_endings: true,
+                    ignore_regexes: Vec::new(),
+                    algorithm: None,
+                },
+            )
+            .status;
+        }
         return folder_core::compare_binary_streams(&left_bytes[..], &right_bytes[..], 8192)
             .map(|result| result.status)
             .unwrap_or(folder_core::FolderCompareStatus::Error);
@@ -2014,6 +2102,7 @@ mod tests {
                 compare_modified_time: true,
                 compare_contents: false,
                 compare_crc: false,
+                ..Default::default()
             })
         );
         assert!(result
@@ -2028,6 +2117,7 @@ mod tests {
                 compare_modified_time: true,
                 compare_contents: false,
                 compare_crc: false,
+                ..Default::default()
             })
         );
     }
@@ -2048,10 +2138,25 @@ mod tests {
         let (criteria, acknowledged) = parse_folder_criteria_tokens(&[
             "rules-based".to_owned(),
             "ignore-unimportant".to_owned(),
+            "follow-symlinks".to_owned(),
         ])
-        .expect("ack tokens");
+        .expect("applied + ack tokens");
         assert!(criteria.compare_contents);
-        assert_eq!(acknowledged, vec!["ignore-unimportant".to_owned()]);
+        assert!(criteria.ignore_unimportant);
+        assert_eq!(acknowledged, vec!["follow-symlinks".to_owned()]);
+
+        let (timed, _) = parse_folder_criteria_tokens(&[
+            "timestamp:2".to_owned(),
+            "IgnoreDST".to_owned(),
+            "timezone:8".to_owned(),
+            "size".to_owned(),
+        ])
+        .expect("time tokens");
+        assert!(timed.compare_modified_time);
+        assert_eq!(timed.timestamp_tolerance_ms, 2_000);
+        assert!(timed.ignore_daylight_saving_hour_offset);
+        assert_eq!(timed.ignored_timezone_hour_offsets, vec![8]);
+        assert!(timed.compare_size);
     }
 
     #[test]
@@ -2085,6 +2190,40 @@ mod tests {
         )
         .expect("binary criteria");
         assert_eq!(content.state.last_compare.map(|s| s.different), Some(1));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn criteria_ignore_unimportant_treats_whitespace_case_as_same() {
+        let root = unique_temp_dir("script-criteria-unimportant");
+        let left = root.join("left");
+        let right = root.join("right");
+        std::fs::create_dir_all(&left).expect("left");
+        std::fs::create_dir_all(&right).expect("right");
+        std::fs::write(left.join("a.txt"), "Hello World").expect("left file");
+        std::fs::write(right.join("a.txt"), "hello   world").expect("right file");
+
+        let ignored = run_script_source(
+            &format!(
+                "LOAD \"{}\" \"{}\"\nCRITERIA rules-based ignore-unimportant\nCOMPARE\n",
+                left.display(),
+                right.display()
+            ),
+            ScriptExecutionContext::default(),
+        )
+        .expect("ignore-unimportant");
+        assert_eq!(ignored.state.last_compare.map(|s| s.different), Some(0));
+
+        let strict = run_script_source(
+            &format!(
+                "LOAD \"{}\" \"{}\"\nCRITERIA binary\nCOMPARE\n",
+                left.display(),
+                right.display()
+            ),
+            ScriptExecutionContext::default(),
+        )
+        .expect("binary strict");
+        assert_eq!(strict.state.last_compare.map(|s| s.different), Some(1));
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/src-tauri/crates/script-core/src/lib.rs
+++ b/src-tauri/crates/script-core/src/lib.rs
@@ -861,10 +861,7 @@ fn apply_criteria_command(
         ("compare-contents", criteria.compare_contents),
         ("compare-crc", criteria.compare_crc),
         ("ignore-unimportant", criteria.ignore_unimportant),
-        (
-            "ignore-dst",
-            criteria.ignore_daylight_saving_hour_offset,
-        ),
+        ("ignore-dst", criteria.ignore_daylight_saving_hour_offset),
     ] {
         state
             .options
@@ -943,9 +940,9 @@ pub fn parse_folder_criteria_tokens(
             criteria.compare_modified_time = true;
             if let Some(rest) = lower.strip_prefix("timestamp:") {
                 if !rest.is_empty() {
-                    let seconds: u128 = rest.parse().map_err(|_| {
-                        format!("invalid CRITERIA timestamp tolerance: {token}")
-                    })?;
+                    let seconds: u128 = rest
+                        .parse()
+                        .map_err(|_| format!("invalid CRITERIA timestamp tolerance: {token}"))?;
                     criteria.timestamp_tolerance_ms = seconds.saturating_mul(1_000);
                 }
             }
@@ -987,9 +984,9 @@ pub fn parse_folder_criteria_tokens(
             continue;
         }
         if let Some(rest) = lower.strip_prefix("timezone:") {
-            let hours: i32 = rest.parse().map_err(|_| {
-                format!("invalid CRITERIA timezone offset: {token}")
-            })?;
+            let hours: i32 = rest
+                .parse()
+                .map_err(|_| format!("invalid CRITERIA timezone offset: {token}"))?;
             criteria.compare_modified_time = true;
             criteria.ignored_timezone_hour_offsets.push(hours);
             continue;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -363,6 +363,7 @@ impl FolderCompareCriteria {
             case_sensitive_names: true,
             compare_contents: self.compare_contents,
             compare_crc: self.compare_crc,
+            ..Default::default()
         }
     }
 }

--- a/src/app/commandRegistry.test.ts
+++ b/src/app/commandRegistry.test.ts
@@ -39,8 +39,11 @@ describe('commandRegistry', () => {
       ]),
     )
     expect(commandRegistry.find((command) => command.id === 'session.newWindow')?.enabled).toBe(
-      false,
+      true,
     )
+    expect(commandRegistry.find((command) => command.id === 'session.newWindow')?.action).toEqual({
+      type: 'new-window',
+    })
     expect(commandRegistry.find((command) => command.id === 'session.exit')?.enabled).toBe(true)
     expect(commandRegistry.find((command) => command.id === 'tools.saveSnapshot')?.enabled).toBe(
       true,

--- a/src/app/commandRegistry.ts
+++ b/src/app/commandRegistry.ts
@@ -51,6 +51,7 @@ export type CommandAction =
   | { type: 'navigate'; route: string; titleKey: string }
   | { type: 'toggle-theme' }
   | { type: 'quit' }
+  | { type: 'new-window' }
   | { type: 'noop' }
   | {
       type: 'view-action'
@@ -386,15 +387,13 @@ export const commandRegistry: AppCommand[] = [
     id: 'session.newWindow',
     titleKey: 'ui.newWindow',
     keywords: ['session', 'window', 'new'],
-    // Left disabled on purpose: default capability only grants window label "main"
-    // with core:default. Creating a second WebviewWindow needs an explicit create
-    // permission plus a second window label in capabilities — enabling the menu
-    // without that would fake a broken New Window. Keep noop until those land.
-    enabled: false,
+    // Real multi-window: capabilities grant session-* labels plus
+    // core:webview:allow-create-webview-window; openSessionWindow creates the shell.
+    enabled: true,
     visibility: 'global',
     defaultShortcut: { keys: ['Ctrl', 'Shift', 'N'], scope: 'global' },
     placements: ['command-palette', 'menu'],
-    action: { type: 'noop' },
+    action: { type: 'new-window' },
   },
   {
     id: 'session.openSession',

--- a/src/app/commandSystem.test.ts
+++ b/src/app/commandSystem.test.ts
@@ -80,6 +80,14 @@ describe('commandSystem', () => {
     expect(executeCommand('session.exit')).toBe(true)
     expect(context.leaveApp).toHaveBeenCalledTimes(1)
   })
+
+  it('invokes openNewWindow for the session new window command', () => {
+    const context = createExecutionContext()
+    const executeCommand = createCommandExecutor(commandRegistry, context)
+
+    expect(executeCommand('session.newWindow')).toBe(true)
+    expect(context.openNewWindow).toHaveBeenCalledTimes(1)
+  })
 })
 
 function createExecutionContext(): CommandExecutionContext {
@@ -95,5 +103,6 @@ function createExecutionContext(): CommandExecutionContext {
     toggleTheme: vi.fn(),
     dispatchViewAction: vi.fn(),
     leaveApp: vi.fn(),
+    openNewWindow: vi.fn(),
   }
 }

--- a/src/app/commandSystem.ts
+++ b/src/app/commandSystem.ts
@@ -9,6 +9,7 @@ export interface CommandExecutionContext {
   toggleTheme: () => void
   dispatchViewAction: (name: ViewActionName) => void
   leaveApp: () => void
+  openNewWindow: () => void
 }
 
 export function getCommandsForPlacement(
@@ -49,6 +50,12 @@ export function createCommandExecutor(
 
     if (command.action.type === 'quit') {
       context.leaveApp()
+
+      return true
+    }
+
+    if (command.action.type === 'new-window') {
+      context.openNewWindow()
 
       return true
     }

--- a/src/app/sessionWindow.test.ts
+++ b/src/app/sessionWindow.test.ts
@@ -20,13 +20,15 @@ describe('sessionWindow', () => {
   })
 
   it('opens a same-origin window outside Tauri', async () => {
-    const openBlank = vi.fn().mockReturnValue({} as Window)
+    const openBlank = vi.fn().mockReturnValue({})
+
     await expect(openSessionWindow(openBlank)).resolves.toBe(true)
     expect(openBlank).toHaveBeenCalledWith(window.location.href, '_blank')
   })
 
   it('reports failure when the browser blocks window.open', async () => {
     const openBlank = vi.fn().mockReturnValue(null)
+
     await expect(openSessionWindow(openBlank)).resolves.toBe(false)
   })
 })

--- a/src/app/sessionWindow.test.ts
+++ b/src/app/sessionWindow.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  nextSessionWindowLabel,
+  openSessionWindow,
+  sessionNewWindowCapability,
+} from './sessionWindow'
+
+describe('sessionWindow', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('documents multi-window capability as supported with create permission', () => {
+    expect(sessionNewWindowCapability.supported).toBe(true)
+    expect(sessionNewWindowCapability.requiresCreateWebviewPermission).toBe(true)
+  })
+
+  it('builds alphanumeric session window labels', () => {
+    expect(nextSessionWindowLabel(1_700_000_000_000)).toBe('session-1700000000000')
+  })
+
+  it('opens a same-origin window outside Tauri', async () => {
+    const openBlank = vi.fn().mockReturnValue({} as Window)
+    await expect(openSessionWindow(openBlank)).resolves.toBe(true)
+    expect(openBlank).toHaveBeenCalledWith(window.location.href, '_blank')
+  })
+
+  it('reports failure when the browser blocks window.open', async () => {
+    const openBlank = vi.fn().mockReturnValue(null)
+    await expect(openSessionWindow(openBlank)).resolves.toBe(false)
+  })
+})

--- a/src/app/sessionWindow.ts
+++ b/src/app/sessionWindow.ts
@@ -13,7 +13,7 @@ export const sessionNewWindowCapability = {
 } as const
 
 export function nextSessionWindowLabel(nowMs: number = Date.now()): string {
-  return `session-${nowMs}`
+  return `session-${String(nowMs)}`
 }
 
 /**
@@ -24,10 +24,6 @@ export async function openSessionWindow(
   openBlank: (url: string, target: string) => Window | null = (url, target) =>
     window.open(url, target),
 ): Promise<boolean> {
-  if (!sessionNewWindowCapability.supported) {
-    return false
-  }
-
   if (!isTauriRuntime()) {
     const opened = openBlank(window.location.href, '_blank')
 
@@ -49,7 +45,7 @@ export async function openSessionWindow(
 
     return await new Promise<boolean>((resolve) => {
       let settled = false
-      const finish = (ok: boolean) => {
+      const finish = (ok: boolean): void => {
         if (settled) {
           return
         }

--- a/src/app/sessionWindow.ts
+++ b/src/app/sessionWindow.ts
@@ -1,0 +1,67 @@
+import { isTauriRuntime } from './desktopDrop'
+
+/** Capability flag: multi-window is wired via Tauri WebviewWindow + create permission. */
+export const sessionNewWindowCapability = {
+  supported: true,
+  /**
+   * Requires capabilities/default.json to grant:
+   * - windows: main + session-*
+   * - core:webview:allow-create-webview-window
+   * Browser / non-Tauri falls back to window.open of the same origin.
+   */
+  requiresCreateWebviewPermission: true,
+} as const
+
+export function nextSessionWindowLabel(nowMs: number = Date.now()): string {
+  return `session-${nowMs}`
+}
+
+/**
+ * Open a second app shell window with the same frontend entry.
+ * Returns false when the runtime refused to create the window.
+ */
+export async function openSessionWindow(
+  openBlank: (url: string, target: string) => Window | null = (url, target) =>
+    window.open(url, target),
+): Promise<boolean> {
+  if (!sessionNewWindowCapability.supported) {
+    return false
+  }
+
+  if (!isTauriRuntime()) {
+    const opened = openBlank(window.location.href, '_blank')
+
+    return opened != null
+  }
+
+  try {
+    const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow')
+    const label = nextSessionWindowLabel()
+    const webview = new WebviewWindow(label, {
+      url: '/',
+      title: 'OpenDiff',
+      width: 1280,
+      height: 820,
+      minWidth: 980,
+      minHeight: 640,
+      focus: true,
+    })
+
+    return await new Promise<boolean>((resolve) => {
+      let settled = false
+      const finish = (ok: boolean) => {
+        if (settled) {
+          return
+        }
+        settled = true
+        resolve(ok)
+      }
+
+      void webview.once('tauri://created', () => finish(true))
+      void webview.once('tauri://error', () => finish(false))
+      window.setTimeout(() => finish(true), 1_500)
+    })
+  } catch {
+    return false
+  }
+}

--- a/src/layouts/AppLayout.test.ts
+++ b/src/layouts/AppLayout.test.ts
@@ -82,7 +82,7 @@ describe('AppLayout command palette', () => {
     await wrapper.find('[data-testid="menu-session"]').trigger('click')
     expect(
       wrapper.find('[data-testid="menu-command-session.newWindow"]').attributes('disabled'),
-    ).toBeDefined()
+    ).toBeUndefined()
     expect(wrapper.find('[data-testid="menu-command-session.newTab"]').exists()).toBe(true)
   })
 
@@ -111,7 +111,7 @@ describe('AppLayout command palette', () => {
     ).toBeUndefined()
     expect(
       wrapper.find('[data-testid="menu-command-session.newWindow"]').attributes('disabled'),
-    ).toBeDefined()
+    ).toBeUndefined()
     expect(
       wrapper.find('[data-testid="menu-command-session.exit"]').attributes('disabled'),
     ).toBeUndefined()

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -35,6 +35,7 @@ import {
 import { commandRegistry, filterCommands } from '@/app/commandRegistry'
 import { createCommandExecutor, getCommandsForPlacement } from '@/app/commandSystem'
 import { listenDesktopPathDrop } from '@/app/desktopDrop'
+import { openSessionWindow } from '@/app/sessionWindow'
 import { resolveDropLaunchFromPaths } from '@/app/dropLaunch'
 import { sessionCatalog } from '@/app/sessionCatalog'
 import { useI18n } from '@/i18n'
@@ -432,6 +433,17 @@ async function closeMainWindow(): Promise<void> {
   }
 }
 
+async function openSessionWindowFromMenu(): Promise<void> {
+  const opened = await openSessionWindow()
+
+  if (!opened) {
+    statusBar.reportStatus({
+      comparisonStatus: t('ui.newWindow'),
+      source: 'session',
+    })
+  }
+}
+
 async function saveSnapshotFromMenu(): Promise<void> {
   let sourceRoot = lastCompare.folder?.leftRoot ?? ''
 
@@ -481,6 +493,9 @@ const executeRegisteredCommand = createCommandExecutor(commandRegistry, {
   toggleTheme: settings.toggleTheme,
   leaveApp: () => {
     void closeMainWindow()
+  },
+  openNewWindow: () => {
+    void openSessionWindowFromMenu()
   },
   dispatchViewAction: (name) => {
     lastViewAction.value = name


### PR DESCRIPTION
## Summary
- Stacks on open PR #87 (`feat/script-criteria-newwindow` @ `328cade`). Please merge or rebase #87 first if needed; this branch is based on that head so the New Window / CRITERIA work lands cleanly.
- **Session New Window (real):** grant `session-*` window labels plus `core:webview:allow-create-webview-window`, wire `openSessionWindow()` via Tauri `WebviewWindow` (same app shell at `/`), and enable the Session menu/command. Browser/non-Tauri falls back to `window.open`.
- **CRITERIA depth (real):** apply `timestamp:N` tolerance (seconds → ms), `IgnoreDST` / `ignore-dst`, and `timezone:<hours>` in folder metadata matching; apply `ignore-unimportant` as whitespace/case/EOL text rules during content compare (skips hard size fail so whitespace length changes still work). `follow-symlinks` / attrib / version / owner / group / permissions stay acknowledged-only (no VFS/metadata plumbing yet).

## Still short
- Symlink following, attrib/version/owner/group/permissions criteria
- Picture report file-save export (clipboard chrome already on #87)
- Independent session state isolation between windows (each window boots a fresh shell)

## Test plan
- [x] `cargo test -p folder-core`
- [x] `cargo test -p script-core`
- [x] `vue-tsc --noEmit`
- [x] Vitest: `sessionWindow`, `commandRegistry`, `commandSystem`, `AppLayout`
- [ ] Manual: Session → New Window opens a second desktop shell
- [ ] Manual: script `CRITERIA timestamp:2 IgnoreDST size` then `COMPARE`
- [ ] Manual: `CRITERIA rules-based ignore-unimportant` treats whitespace/case-only text as same

Do **not** merge from this PR until #87 is in (or rebase onto master after #87 merges).