### PR TITLE
Save Picture reports to disk and open New Window on the current route

### DIFF
--- a/src/app/pictureReport.test.ts
+++ b/src/app/pictureReport.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPictureReportText,
+  defaultPictureReportOutputPath,
+  formatPictureBoundingRect,
+} from './pictureReport'
+
+describe('pictureReport', () => {
+  it('builds a sibling picture-compare.txt path from the left image', () => {
+    expect(defaultPictureReportOutputPath('C:/images/left.png')).toBe(
+      'C:/images/picture-compare.txt',
+    )
+    expect(defaultPictureReportOutputPath('/tmp/shots/a.webp')).toBe(
+      '/tmp/shots/picture-compare.txt',
+    )
+    expect(defaultPictureReportOutputPath('')).toBe('picture-compare.txt')
+    expect(defaultPictureReportOutputPath('solo.png')).toBe('picture-compare.txt')
+  })
+
+  it('formats bounding rect text and builds the clipboard/file payload', () => {
+    expect(
+      formatPictureBoundingRect({
+        x: 1,
+        y: 0,
+        width: 2,
+        height: 3,
+      }),
+    ).toBe('1, 0, 2 x 3')
+    expect(formatPictureBoundingRect(null)).toBe('--')
+
+    const text = buildPictureReportText({
+      leftPath: 'C:/images/left.png',
+      rightPath: 'C:/images/right.png',
+      statistics: {
+        totalPixels: 10,
+        differentPixels: 2,
+        differenceRatio: 0.2,
+        boundingRect: { x: 1, y: 0, width: 2, height: 3 },
+      },
+      metadataRows: [{ key: 'dimensions', left: '2 x 1', right: '2 x 1', status: 'equal' }],
+    })
+
+    expect(text).toContain('PICTURE-REPORT')
+    expect(text).toContain('left: C:/images/left.png')
+    expect(text).toContain('differentPixels: 2')
+    expect(text).toContain('boundingRect: 1, 0, 2 x 3')
+    expect(text).toContain('dimensions\t2 x 1\t2 x 1\tequal')
+  })
+})

--- a/src/app/pictureReport.ts
+++ b/src/app/pictureReport.ts
@@ -1,0 +1,73 @@
+export interface PictureReportStatistics {
+  totalPixels: number
+  differentPixels: number
+  differenceRatio: number
+  boundingRect?: {
+    x: number
+    y: number
+    width: number
+    height: number
+  } | null
+}
+
+export interface PictureReportMetadataRow {
+  key: string
+  left: string
+  right: string
+  status: string
+}
+
+export interface BuildPictureReportTextInput {
+  leftPath: string
+  rightPath: string
+  statistics: PictureReportStatistics
+  metadataRows: PictureReportMetadataRow[]
+  boundingRectText?: string
+}
+
+export function formatPictureBoundingRect(
+  boundingRect: PictureReportStatistics['boundingRect'],
+): string {
+  if (!boundingRect) {
+    return '--'
+  }
+
+  return `${String(boundingRect.x)}, ${String(boundingRect.y)}, ${String(boundingRect.width)} x ${String(boundingRect.height)}`
+}
+
+/** Sibling text report path next to the left image (matches folder/text export style). */
+export function defaultPictureReportOutputPath(leftPath: string): string {
+  const trimmed = leftPath.trim()
+
+  if (!trimmed) {
+    return 'picture-compare.txt'
+  }
+
+  const slash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+
+  if (slash < 0) {
+    return 'picture-compare.txt'
+  }
+
+  return `${trimmed.slice(0, slash + 1)}picture-compare.txt`
+}
+
+export function buildPictureReportText(input: BuildPictureReportTextInput): string {
+  const boundingRectText =
+    input.boundingRectText ?? formatPictureBoundingRect(input.statistics.boundingRect)
+
+  const lines = [
+    'PICTURE-REPORT',
+    `left: ${input.leftPath}`,
+    `right: ${input.rightPath}`,
+    `totalPixels: ${String(input.statistics.totalPixels)}`,
+    `differentPixels: ${String(input.statistics.differentPixels)}`,
+    `differenceRatio: ${String(input.statistics.differenceRatio)}`,
+    `boundingRect: ${boundingRectText}`,
+    '',
+    'metadata:',
+    ...input.metadataRows.map((row) => `${row.key}\t${row.left}\t${row.right}\t${row.status}`),
+  ]
+
+  return lines.join('\n')
+}

--- a/src/app/sessionWindow.test.ts
+++ b/src/app/sessionWindow.test.ts
@@ -3,6 +3,7 @@ import {
   nextSessionWindowLabel,
   openSessionWindow,
   sessionNewWindowCapability,
+  sessionWindowEntryUrl,
 } from './sessionWindow'
 
 describe('sessionWindow', () => {
@@ -19,11 +20,24 @@ describe('sessionWindow', () => {
     expect(nextSessionWindowLabel(1_700_000_000_000)).toBe('session-1700000000000')
   })
 
-  it('opens a same-origin window outside Tauri', async () => {
+  it('builds same-origin entry URLs for named session routes', () => {
+    expect(sessionWindowEntryUrl('/compare/picture', 'https://app.local')).toBe(
+      'https://app.local/compare/picture',
+    )
+    expect(sessionWindowEntryUrl('compare/folder', 'https://app.local')).toBe(
+      'https://app.local/compare/folder',
+    )
+    expect(sessionWindowEntryUrl('', 'https://app.local')).toBe('https://app.local/')
+  })
+
+  it('opens a same-origin window outside Tauri on the requested route', async () => {
     const openBlank = vi.fn().mockReturnValue({})
 
-    await expect(openSessionWindow(openBlank)).resolves.toBe(true)
-    expect(openBlank).toHaveBeenCalledWith(window.location.href, '_blank')
+    await expect(openSessionWindow(openBlank, '/compare/picture')).resolves.toBe(true)
+    expect(openBlank).toHaveBeenCalledWith(
+      sessionWindowEntryUrl('/compare/picture', window.location.origin),
+      '_blank',
+    )
   })
 
   it('reports failure when the browser blocks window.open', async () => {

--- a/src/app/sessionWindow.ts
+++ b/src/app/sessionWindow.ts
@@ -16,16 +16,32 @@ export function nextSessionWindowLabel(nowMs: number = Date.now()): string {
   return `session-${String(nowMs)}`
 }
 
+/** Normalize a router path/hash into a same-origin entry URL for a new window. */
+export function sessionWindowEntryUrl(
+  entryPath = '/',
+  origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost',
+): string {
+  const trimmed = entryPath.trim() || '/'
+  const path = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+
+  return new URL(path, origin).href
+}
+
 /**
  * Open a second app shell window with the same frontend entry.
+ * Pass entryPath (e.g. route.fullPath) so the new window opens that session route.
  * Returns false when the runtime refused to create the window.
+ * Windows do not share live session state — only the starting route.
  */
 export async function openSessionWindow(
   openBlank: (url: string, target: string) => Window | null = (url, target) =>
     window.open(url, target),
+  entryPath = '/',
 ): Promise<boolean> {
+  const href = sessionWindowEntryUrl(entryPath)
+
   if (!isTauriRuntime()) {
-    const opened = openBlank(window.location.href, '_blank')
+    const opened = openBlank(href, '_blank')
 
     return opened != null
   }
@@ -33,8 +49,9 @@ export async function openSessionWindow(
   try {
     const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow')
     const label = nextSessionWindowLabel()
+    const path = new URL(href).pathname + new URL(href).search + new URL(href).hash
     const webview = new WebviewWindow(label, {
-      url: '/',
+      url: path || '/',
       title: 'OpenDiff',
       width: 1280,
       height: 820,

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -434,7 +434,7 @@ async function closeMainWindow(): Promise<void> {
 }
 
 async function openSessionWindowFromMenu(): Promise<void> {
-  const opened = await openSessionWindow()
+  const opened = await openSessionWindow(undefined, route.fullPath || '/')
 
   if (!opened) {
     statusBar.reportStatus({

--- a/src/views/PictureCompareView.test.ts
+++ b/src/views/PictureCompareView.test.ts
@@ -2,14 +2,20 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import PictureCompareView from './PictureCompareView.vue'
-import { comparePictureFiles } from '@/api/diff'
+import { comparePictureFiles, saveTextFile } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+
+const clipboardWriteText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 
 vi.mock('@/api/diff', () => ({
+  saveTextFile: vi.fn().mockResolvedValue({
+    path: 'C:/images/picture-compare.txt',
+    bytesWritten: 32,
+  }),
   comparePictureFiles: vi.fn().mockResolvedValue({
     left: {
       name: 'left-fixture.png',
@@ -58,6 +64,14 @@ describe('PictureCompareView', () => {
     setActivePinia(createPinia())
     localStorage.clear()
     vi.mocked(comparePictureFiles).mockClear()
+    vi.mocked(saveTextFile).mockClear()
+    clipboardWriteText.mockClear()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteText,
+      },
+    })
   })
 
   it('runs a real picture comparison request and renders returned pixel statistics', async () => {
@@ -347,5 +361,32 @@ describe('PictureCompareView', () => {
 
     await wrapper.find('[data-testid="picture-session-toolbar-minor"]').trigger('click')
     expect(wrapper.find('[data-testid="picture-metadata-dimensions"]').exists()).toBe(false)
+  })
+
+  it('exports the picture report to clipboard and a sibling text file', async () => {
+    const wrapper = mount(PictureCompareView)
+
+    await wrapper.find('[data-testid="picture-left-path"]').setValue('C:/images/left-fixture.png')
+    await wrapper.find('[data-testid="picture-right-path"]').setValue('C:/images/right-fixture.png')
+    await wrapper.find('[data-testid="run-picture-compare"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="export-picture-report"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await Promise.resolve()
+
+    expect(clipboardWriteText).toHaveBeenCalled()
+    const payload = clipboardWriteText.mock.calls[0]?.[0] ?? ''
+
+    expect(payload).toContain('PICTURE-REPORT')
+    expect(payload).toContain('left: C:/images/left-fixture.png')
+    expect(saveTextFile).toHaveBeenCalledWith({
+      path: 'C:/images/picture-compare.txt',
+      text: payload,
+      createBackup: false,
+    })
+    expect(wrapper.find('[data-testid="picture-report-status"]').text()).toBe(
+      'C:/images/picture-compare.txt',
+    )
   })
 })

--- a/src/views/PictureCompareView.vue
+++ b/src/views/PictureCompareView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { comparePictureFiles } from '@/api/diff'
+import { comparePictureFiles, saveTextFile } from '@/api/diff'
+import { buildPictureReportText, defaultPictureReportOutputPath } from '@/app/pictureReport'
 import { localFileSrc } from '@/app/localFileSrc'
 import type { PictureCompareResponse, PictureMetadataRow } from '@/types/diff'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
@@ -66,6 +67,7 @@ const pictureStatistics = ref<PictureCompareResponse['statistics']>({
   differenceRatio: 0,
 })
 const compared = ref(false)
+const reportStatus = ref('')
 const leftImageSrc = computed(() => (compared.value ? localFileSrc(leftPath.value) : ''))
 const rightImageSrc = computed(() => (compared.value ? localFileSrc(rightPath.value) : ''))
 const overlayStyle = computed(() => {
@@ -143,6 +145,8 @@ watch(
         swapPicturePaths()
         break
       case 'export':
+      case 'save':
+      case 'save-as':
         void exportPictureReport()
         break
       case 'about':
@@ -164,8 +168,6 @@ watch(
       case 'redo':
       case 'save-snapshot':
       case 'restore-factory-defaults':
-      case 'save':
-      case 'save-as':
       case 'show-all':
       case 'show-differences':
       case 'undo':
@@ -454,26 +456,30 @@ async function exportPictureReport(): Promise<void> {
     return
   }
 
-  const lines = [
-    'PICTURE-REPORT',
-    `left: ${leftPath.value}`,
-    `right: ${rightPath.value}`,
-    `totalPixels: ${String(pictureStatistics.value.totalPixels)}`,
-    `differentPixels: ${String(pictureStatistics.value.differentPixels)}`,
-    `differenceRatio: ${String(pictureStatistics.value.differenceRatio)}`,
-    `boundingRect: ${pictureBoundingRectText.value}`,
-    '',
-    'metadata:',
-    ...visibleMetadataRows.value.map(
-      (row) => `${row.key}\t${row.left}\t${row.right}\t${row.status}`,
-    ),
-  ]
-  const payload = lines.join('\n')
+  const payload = buildPictureReportText({
+    leftPath: leftPath.value,
+    rightPath: rightPath.value,
+    statistics: pictureStatistics.value,
+    metadataRows: visibleMetadataRows.value,
+    boundingRectText: pictureBoundingRectText.value,
+  })
+  const outputPath = defaultPictureReportOutputPath(leftPath.value)
 
   try {
     await navigator.clipboard.writeText(payload)
   } catch {
-    // Clipboard may be unavailable in headless tests; still mark compared report ready.
+    // Clipboard may be unavailable in headless tests; still try file export.
+  }
+
+  try {
+    await saveTextFile({
+      path: outputPath,
+      text: payload,
+      createBackup: false,
+    })
+    reportStatus.value = outputPath
+  } catch (event) {
+    error.value = String(event)
   }
 }
 
@@ -975,6 +981,18 @@ async function runPictureCompare(): Promise<void> {
         <header>
           <strong>{{ $t('ui.pictureReport') }}</strong>
           <span>{{ $t('status.fieldCount', { count: visibleMetadataRows.length }) }}</span>
+          <button
+            type="button"
+            data-testid="export-picture-report"
+            @click="exportPictureReport"
+          >
+            {{ $t('ui.export') }}
+          </button>
+          <span
+            v-if="reportStatus"
+            data-testid="picture-report-status"
+            >{{ reportStatus }}</span
+          >
         </header>
         <div
           class="picture-report-table"
@@ -1403,9 +1421,13 @@ h2 {
 
 .picture-report-panel header {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 12px;
+}
+
+.picture-report-panel header button {
+  margin-left: auto;
 }
 
 .picture-report-table {


### PR DESCRIPTION
## Summary
- Picture Compare export now writes a sibling `picture-compare.txt` next to the left image (via `save_text_file`) and still copies the same payload to the clipboard. Export / Save / Save As all use that path; the report panel shows the saved path.
- Session New Window opens on the active route (`route.fullPath`) instead of always landing on `/`. Browser fallback uses the same-origin URL.
- Skipped CRITERIA `follow-symlinks` (no real symlink plumbing in folder/file compare yet).

## Known remaining gaps
- CRITERIA `follow-symlinks` / `attrib:` / bare `version` stay acknowledge-only until folder compare grows real options.
- New windows do not share live session state (paths, options, compare results) — only the starting route.
- No native Save As dialog for picture reports yet (derived sibling path, same pattern as folder/text report export).

## Test plan
- [x] `vitest run src/app/pictureReport.test.ts src/app/sessionWindow.test.ts src/views/PictureCompareView.test.ts` (23 passed)
- [x] ESLint on touched files
- [ ] Manual: compare two images → Export → confirm clipboard + `picture-compare.txt` beside left image
- [ ] Manual: from Picture Compare, Session → New Window → lands on `/compare/picture`