### PR TITLE
Honor follow-symlinks in folder scans and step Hex find matches

### DIFF
--- a/src-tauri/crates/folder-core/src/lib.rs
+++ b/src-tauri/crates/folder-core/src/lib.rs
@@ -1322,22 +1322,14 @@ mod tests {
         let _ = fs::remove_dir_all(root);
     }
 
+    #[cfg(unix)]
     #[test]
     fn skips_directory_symlinks_unless_follow_symlinks_enabled() {
         let root = unique_temp_dir("folder-symlink");
         let real = root.join("real");
         fs::create_dir_all(real.join("nested")).expect("directory should be created");
         fs::write(real.join("nested").join("a.txt"), b"a").expect("file should be written");
-        #[cfg(unix)]
-        {
-            std::os::unix::fs::symlink(&real, root.join("link"))
-                .expect("symlink should be created");
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = fs::remove_dir_all(root);
-            return;
-        }
+        std::os::unix::fs::symlink(&real, root.join("link")).expect("symlink should be created");
 
         let skipped = scan_local_folder(&root, &CancellationToken::default()).expect("scan");
         let link = skipped

--- a/src-tauri/crates/folder-core/src/lib.rs
+++ b/src-tauri/crates/folder-core/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -61,6 +61,9 @@ pub struct FolderCompareOptions {
     /// Additional whole-hour timezone offsets to treat as equal when comparing times.
     #[serde(default)]
     pub ignored_timezone_hour_offsets: Vec<i32>,
+    /// When true, directory/file symbolic links are resolved during folder scans.
+    #[serde(default)]
+    pub follow_symlinks: bool,
 }
 
 impl Default for FolderCompareOptions {
@@ -74,6 +77,7 @@ impl Default for FolderCompareOptions {
             timestamp_tolerance_ms: 0,
             ignore_daylight_saving_hour_offset: false,
             ignored_timezone_hour_offsets: Vec::new(),
+            follow_symlinks: false,
         }
     }
 }
@@ -340,6 +344,11 @@ impl FolderScanNode {
             metadata,
             children: Vec::new(),
         }
+    }
+
+    fn with_children(mut self, children: Vec<FolderScanNode>) -> Self {
+        self.children = children;
+        self
     }
 }
 
@@ -1015,51 +1024,143 @@ pub fn scan_local_folder(
     root: impl AsRef<Path>,
     cancel_token: &job_core::CancellationToken,
 ) -> Result<FolderScanNode, FolderScanError> {
-    let root = root.as_ref();
-    let vfs = LocalVfs::new();
-    let root_path = VfsPath::new(root.display().to_string());
-
-    scan_path(&vfs, root, &root_path, cancel_token)
+    scan_local_folder_with_options(root, cancel_token, &FolderCompareOptions::default())
 }
 
-fn scan_path(
-    vfs: &LocalVfs,
-    root: &Path,
-    path: &VfsPath,
+pub fn scan_local_folder_with_options(
+    root: impl AsRef<Path>,
     cancel_token: &job_core::CancellationToken,
+    options: &FolderCompareOptions,
+) -> Result<FolderScanNode, FolderScanError> {
+    let root = root.as_ref();
+    let mut visiting = HashSet::new();
+    if let Ok(canonical) = fs::canonicalize(root) {
+        visiting.insert(canonical);
+    }
+    // Always enter the requested root; follow_symlinks applies to nested entries.
+    scan_resolved_path(
+        root,
+        root,
+        cancel_token,
+        options.follow_symlinks,
+        &mut visiting,
+    )
+}
+
+fn scan_path_entry(
+    root: &Path,
+    path: &Path,
+    cancel_token: &job_core::CancellationToken,
+    follow_symlinks: bool,
+    visiting: &mut HashSet<PathBuf>,
 ) -> Result<FolderScanNode, FolderScanError> {
     if cancel_token.is_cancelled() {
         return Err(FolderScanError::Cancelled);
     }
 
-    let metadata = vfs
-        .metadata(path)
-        .map_err(|error| FolderScanError::Vfs(format!("{error:?}")))?;
-    let relative_path = relative_path(root, Path::new(path.as_str()));
+    let symlink_meta =
+        fs::symlink_metadata(path).map_err(|error| FolderScanError::Vfs(error.to_string()))?;
 
-    if metadata.kind == VfsEntryKind::File {
-        return Ok(FolderScanNode::new_file(
-            relative_path,
-            metadata.name.clone(),
-            metadata,
-        ));
+    if symlink_meta.file_type().is_symlink() {
+        if !follow_symlinks {
+            return Ok(folder_node_from_fs_meta(root, path, &symlink_meta, true));
+        }
+
+        let canonical = match fs::canonicalize(path) {
+            Ok(canonical) => canonical,
+            Err(_) => return Ok(folder_node_from_fs_meta(root, path, &symlink_meta, true)),
+        };
+        if !visiting.insert(canonical.clone()) {
+            return Ok(folder_node_from_fs_meta(root, path, &symlink_meta, true));
+        }
+        let scanned = scan_resolved_path(root, path, cancel_token, follow_symlinks, visiting);
+        visiting.remove(&canonical);
+        return scanned;
     }
 
-    let mut children = vfs
-        .list(path)
-        .map_err(|error| FolderScanError::Vfs(format!("{error:?}")))?
-        .into_iter()
-        .map(|entry| scan_path(vfs, root, &entry.path, cancel_token))
+    scan_resolved_path(root, path, cancel_token, follow_symlinks, visiting)
+}
+
+fn scan_resolved_path(
+    root: &Path,
+    path: &Path,
+    cancel_token: &job_core::CancellationToken,
+    follow_symlinks: bool,
+    visiting: &mut HashSet<PathBuf>,
+) -> Result<FolderScanNode, FolderScanError> {
+    if cancel_token.is_cancelled() {
+        return Err(FolderScanError::Cancelled);
+    }
+
+    let metadata = fs::metadata(path).map_err(|error| FolderScanError::Vfs(error.to_string()))?;
+    if metadata.is_file() || metadata.file_type().is_symlink() {
+        return Ok(folder_node_from_fs_meta(root, path, &metadata, true));
+    }
+
+    let mut children = fs::read_dir(path)
+        .map_err(|error| FolderScanError::Vfs(error.to_string()))?
+        .map(|entry| {
+            let entry = entry.map_err(|error| FolderScanError::Vfs(error.to_string()))?;
+            scan_path_entry(root, &entry.path(), cancel_token, follow_symlinks, visiting)
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     children.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(folder_node_from_fs_meta(root, path, &metadata, false).with_children(children))
+}
 
-    Ok(FolderScanNode::new_directory(
-        relative_path,
-        metadata.name.clone(),
-        metadata,
-        children,
-    ))
+fn folder_node_from_fs_meta(
+    root: &Path,
+    path: &Path,
+    metadata: &fs::Metadata,
+    as_file: bool,
+) -> FolderScanNode {
+    let relative = relative_path(root, path);
+    let name = path
+        .file_name()
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string());
+    let vfs_meta = vfs_metadata_from_fs(path, metadata, as_file);
+    if as_file || metadata.is_file() {
+        FolderScanNode::new_file(relative, name, vfs_meta)
+    } else {
+        FolderScanNode::new_directory(relative, name, vfs_meta, Vec::new())
+    }
+}
+
+fn vfs_metadata_from_fs(path: &Path, metadata: &fs::Metadata, force_file: bool) -> VfsMetadata {
+    let kind = if !force_file && metadata.is_dir() {
+        VfsEntryKind::Directory
+    } else {
+        VfsEntryKind::File
+    };
+    VfsMetadata {
+        kind,
+        name: path
+            .file_name()
+            .map(|value| value.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string()),
+        extension: path
+            .extension()
+            .map(|extension| extension.to_string_lossy().into_owned()),
+        size: metadata.len(),
+        readonly: metadata.permissions().readonly(),
+        created_at_ms: metadata
+            .created()
+            .ok()
+            .and_then(|created| created.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis()),
+        modified_at_ms: metadata
+            .modified()
+            .ok()
+            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis()),
+        accessed_at_ms: metadata
+            .accessed()
+            .ok()
+            .and_then(|accessed| accessed.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis()),
+    }
 }
 
 fn collect_alignment_side(
@@ -1217,6 +1318,53 @@ mod tests {
         assert_eq!(scanned.kind, FolderNodeKind::Directory);
         assert_eq!(scanned.children[0].name, "src");
         assert_eq!(scanned.children[0].children[0].name, "main.rs");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn skips_directory_symlinks_unless_follow_symlinks_enabled() {
+        let root = unique_temp_dir("folder-symlink");
+        let real = root.join("real");
+        fs::create_dir_all(real.join("nested")).expect("directory should be created");
+        fs::write(real.join("nested").join("a.txt"), b"a").expect("file should be written");
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&real, root.join("link"))
+                .expect("symlink should be created");
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = fs::remove_dir_all(root);
+            return;
+        }
+
+        let skipped = scan_local_folder(&root, &CancellationToken::default()).expect("scan");
+        let link = skipped
+            .children
+            .iter()
+            .find(|child| child.name == "link")
+            .expect("link entry");
+        assert_eq!(link.kind, FolderNodeKind::File);
+        assert!(link.children.is_empty());
+
+        let followed = scan_local_folder_with_options(
+            &root,
+            &CancellationToken::default(),
+            &FolderCompareOptions {
+                follow_symlinks: true,
+                ..FolderCompareOptions::default()
+            },
+        )
+        .expect("follow scan");
+        let link = followed
+            .children
+            .iter()
+            .find(|child| child.name == "link")
+            .expect("followed link");
+        assert_eq!(link.kind, FolderNodeKind::Directory);
+        assert_eq!(link.children[0].name, "nested");
+        assert_eq!(link.children[0].children[0].name, "a.txt");
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src-tauri/crates/script-core/src/lib.rs
+++ b/src-tauri/crates/script-core/src/lib.rs
@@ -143,6 +143,9 @@ pub struct ScriptFolderCriteria {
     /// When contents are compared, treat whitespace / case / EOL as unimportant.
     #[serde(default)]
     pub ignore_unimportant: bool,
+    /// Resolve nested symbolic links while scanning folder trees.
+    #[serde(default)]
+    pub follow_symlinks: bool,
 }
 
 impl Default for ScriptFolderCriteria {
@@ -156,6 +159,7 @@ impl Default for ScriptFolderCriteria {
             ignore_daylight_saving_hour_offset: false,
             ignored_timezone_hour_offsets: Vec::new(),
             ignore_unimportant: false,
+            follow_symlinks: false,
         }
     }
 }
@@ -171,6 +175,7 @@ impl ScriptFolderCriteria {
             timestamp_tolerance_ms: self.timestamp_tolerance_ms,
             ignore_daylight_saving_hour_offset: self.ignore_daylight_saving_hour_offset,
             ignored_timezone_hour_offsets: self.ignored_timezone_hour_offsets.clone(),
+            follow_symlinks: self.follow_symlinks,
         }
     }
 }
@@ -861,6 +866,7 @@ fn apply_criteria_command(
         ("compare-crc", criteria.compare_crc),
         ("ignore-unimportant", criteria.ignore_unimportant),
         ("ignore-dst", criteria.ignore_daylight_saving_hour_offset),
+        ("follow-symlinks", criteria.follow_symlinks),
     ] {
         state
             .options
@@ -907,7 +913,7 @@ fn apply_criteria_command(
 
 /// Map CRITERIA tokens onto folder Session Settings comparison flags.
 /// Supported: timestamp[:seconds], size, crc, binary, rules-based,
-/// ignore-unimportant, IgnoreDST / ignore-dst, timezone:<hours>.
+/// ignore-unimportant, IgnoreDST / ignore-dst, timezone:<hours>, follow-symlinks.
 /// Other legacy script tokens are acknowledged without changing compare results.
 pub fn parse_folder_criteria_tokens(
     tokens: &[String],
@@ -921,6 +927,7 @@ pub fn parse_folder_criteria_tokens(
         ignore_daylight_saving_hour_offset: false,
         ignored_timezone_hour_offsets: Vec::new(),
         ignore_unimportant: false,
+        follow_symlinks: false,
     };
     let mut acknowledged = Vec::new();
     let mut saw_content_method = false;
@@ -990,9 +997,12 @@ pub fn parse_folder_criteria_tokens(
             criteria.ignored_timezone_hour_offsets.push(hours);
             continue;
         }
+        if lower == "follow-symlinks" {
+            criteria.follow_symlinks = true;
+            continue;
+        }
         if lower.starts_with("attrib:")
             || lower == "version"
-            || lower == "follow-symlinks"
             || lower == "owner"
             || lower == "group"
             || lower == "permissions"
@@ -1294,11 +1304,19 @@ fn compare_script_paths(
 
     if left_path.is_dir() && right_path.is_dir() {
         let cancellation = job_core::CancellationToken::default();
-        let left_tree = folder_core::scan_local_folder(left, &cancellation)
-            .map_err(|error| format!("{error:?}"))?;
-        let right_tree = folder_core::scan_local_folder(right, &cancellation)
-            .map_err(|error| format!("{error:?}"))?;
-        let rows = folder_core::align_folder_trees(&left_tree, &right_tree);
+        let follow = criteria.map(|value| value.follow_symlinks).unwrap_or(false);
+        let scan_options = folder_core::FolderCompareOptions {
+            follow_symlinks: follow,
+            ..folder_core::FolderCompareOptions::default()
+        };
+        let left_tree =
+            folder_core::scan_local_folder_with_options(left, &cancellation, &scan_options)
+                .map_err(|error| format!("{error:?}"))?;
+        let right_tree =
+            folder_core::scan_local_folder_with_options(right, &cancellation, &scan_options)
+                .map_err(|error| format!("{error:?}"))?;
+        let rows =
+            folder_core::align_folder_trees_with_options(&left_tree, &right_tree, &scan_options);
         let filtered = if filters.is_empty() {
             rows
         } else {
@@ -2264,7 +2282,8 @@ mod tests {
         .expect("applied + ack tokens");
         assert!(criteria.compare_contents);
         assert!(criteria.ignore_unimportant);
-        assert_eq!(acknowledged, vec!["follow-symlinks".to_owned()]);
+        assert!(criteria.follow_symlinks);
+        assert!(acknowledged.is_empty());
 
         let (timed, _) = parse_folder_criteria_tokens(&[
             "timestamp:2".to_owned(),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -342,6 +342,8 @@ pub struct FolderCompareCriteria {
     pub compare_modified_time: bool,
     pub compare_contents: bool,
     pub compare_crc: bool,
+    #[serde(default)]
+    pub follow_symlinks: bool,
 }
 
 impl Default for FolderCompareCriteria {
@@ -351,6 +353,7 @@ impl Default for FolderCompareCriteria {
             compare_modified_time: false,
             compare_contents: true,
             compare_crc: false,
+            follow_symlinks: false,
         }
     }
 }
@@ -363,6 +366,7 @@ impl FolderCompareCriteria {
             case_sensitive_names: true,
             compare_contents: self.compare_contents,
             compare_crc: self.compare_crc,
+            follow_symlinks: self.follow_symlinks,
             ..Default::default()
         }
     }
@@ -766,10 +770,12 @@ pub fn compare_folder_paths(
         .map_err(|error| compare_source_error(&left_root, error))?;
     let right_source = crate::sources::load_compare_source(&right_root)
         .map_err(|error| compare_source_error(&right_root, error))?;
-    let left_tree = crate::sources::scan_compare_source(&left_source)
-        .map_err(|error| compare_source_error(&left_root, error))?;
-    let right_tree = crate::sources::scan_compare_source(&right_source)
-        .map_err(|error| compare_source_error(&right_root, error))?;
+    let left_tree =
+        crate::sources::scan_compare_source_with_options(&left_source, options.follow_symlinks)
+            .map_err(|error| compare_source_error(&left_root, error))?;
+    let right_tree =
+        crate::sources::scan_compare_source_with_options(&right_source, options.follow_symlinks)
+            .map_err(|error| compare_source_error(&right_root, error))?;
     let alignment_rows =
         folder_core::align_folder_trees_with_options(&left_tree, &right_tree, &options);
     let alignment_rows = if name_filters.is_active() {
@@ -4562,6 +4568,7 @@ mod tests {
                 compare_modified_time: false,
                 compare_contents: false,
                 compare_crc: false,
+                follow_symlinks: false,
             }),
             None,
         )
@@ -4574,6 +4581,7 @@ mod tests {
                 compare_modified_time: false,
                 compare_contents: true,
                 compare_crc: false,
+                follow_symlinks: false,
             }),
             None,
         )
@@ -4586,6 +4594,7 @@ mod tests {
                 compare_modified_time: false,
                 compare_contents: false,
                 compare_crc: true,
+                follow_symlinks: false,
             }),
             None,
         )

--- a/src-tauri/src/sources.rs
+++ b/src-tauri/src/sources.rs
@@ -52,11 +52,22 @@ pub fn load_compare_source(path: &str) -> Result<CompareSource, String> {
     Ok(CompareSource::Local(path_buf))
 }
 
-pub fn scan_compare_source(source: &CompareSource) -> Result<FolderScanNode, String> {
+pub fn scan_compare_source_with_options(
+    source: &CompareSource,
+    follow_symlinks: bool,
+) -> Result<FolderScanNode, String> {
     match source {
         CompareSource::Local(path) => {
-            folder_core::scan_local_folder(path, &job_core::CancellationToken::default())
-                .map_err(|error| format!("{error:?}"))
+            let options = folder_core::FolderCompareOptions {
+                follow_symlinks,
+                ..folder_core::FolderCompareOptions::default()
+            };
+            folder_core::scan_local_folder_with_options(
+                path,
+                &job_core::CancellationToken::default(),
+                &options,
+            )
+            .map_err(|error| format!("{error:?}"))
         }
         CompareSource::Archive(document) => Ok(folder_tree_from_archive(document)),
         CompareSource::Snapshot(snapshot) => Ok(folder_tree_from_snapshot(snapshot)),

--- a/src/app/folderCompareCriteria.test.ts
+++ b/src/app/folderCompareCriteria.test.ts
@@ -21,14 +21,16 @@ describe('folderCompareCriteria', () => {
       compareModifiedTime: true,
       compareContents: false,
       compareCrc: true,
+      followSymlinks: true,
     })
 
-    expect(localStorage.getItem(folderCompareCriteriaStorageKey)).toContain('compareCrc')
+    expect(localStorage.getItem(folderCompareCriteriaStorageKey)).toContain('followSymlinks')
     expect(loadFolderCompareCriteria()).toEqual({
       compareSize: false,
       compareModifiedTime: true,
       compareContents: false,
       compareCrc: true,
+      followSymlinks: true,
     })
   })
 })

--- a/src/app/folderCompareCriteria.ts
+++ b/src/app/folderCompareCriteria.ts
@@ -8,6 +8,7 @@ export function defaultFolderCompareCriteria(): FolderCompareCriteria {
     compareModifiedTime: false,
     compareContents: true,
     compareCrc: false,
+    followSymlinks: false,
   }
 }
 
@@ -28,6 +29,7 @@ export function loadFolderCompareCriteria(
       compareModifiedTime: Boolean(parsed.compareModifiedTime),
       compareContents: parsed.compareContents !== false,
       compareCrc: Boolean(parsed.compareCrc),
+      followSymlinks: Boolean(parsed.followSymlinks),
     }
   } catch {
     return defaultFolderCompareCriteria()
@@ -45,6 +47,7 @@ export function saveFolderCompareCriteria(
       compareModifiedTime: state.compareModifiedTime,
       compareContents: state.compareContents,
       compareCrc: state.compareCrc,
+      followSymlinks: Boolean(state.followSymlinks),
     }),
   )
 }

--- a/src/components/session/SessionSettingsDialog.vue
+++ b/src/components/session/SessionSettingsDialog.vue
@@ -34,6 +34,7 @@ const props = withDefaults(
       compareModifiedTime: false,
       compareContents: true,
       compareCrc: false,
+      followSymlinks: false,
     }),
     folderFilters: () => ({
       include: [],
@@ -310,6 +311,14 @@ function applySettings(): void {
             data-testid="session-settings-compare-crc"
           />
           <span>{{ $t('ui.compareCrc') }}</span>
+        </label>
+        <label>
+          <input
+            v-model="draftFolder.followSymlinks"
+            type="checkbox"
+            data-testid="session-settings-follow-symlinks"
+          />
+          <span>{{ $t('ui.followSymlinks') }}</span>
         </label>
       </div>
 

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -766,6 +766,7 @@ export const deDE: LanguagePack = {
     'ui.compareByTimestamp': 'Zeitstempel vergleichen',
     'ui.compareBinaryContents': 'Binärinhalt vergleichen',
     'ui.compareCrc': 'CRC vergleichen',
+    'ui.followSymlinks': 'Symbolische Verknüpfungen folgen',
     'ui.folderCriteria': 'Vergleichskriterien',
     'ui.windowsShell': 'Windows-Shell',
     'ui.unixShell': 'macOS- / Linux-Shell',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -748,6 +748,7 @@ export const enUS: LanguagePack = {
     'ui.compareByTimestamp': 'Compare timestamp',
     'ui.compareBinaryContents': 'Compare binary contents',
     'ui.compareCrc': 'Compare CRC',
+    'ui.followSymlinks': 'Follow symbolic links',
     'ui.folderCriteria': 'Compare criteria',
     'ui.windowsShell': 'Windows shell',
     'ui.unixShell': 'macOS / Linux shell',

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -761,6 +761,7 @@ export const esES: LanguagePack = {
     'ui.compareByTimestamp': 'Comparar marca de tiempo',
     'ui.compareBinaryContents': 'Comparar contenido binario',
     'ui.compareCrc': 'Comparar CRC',
+    'ui.followSymlinks': 'Seguir enlaces simbólicos',
     'ui.folderCriteria': 'Criterios de comparación',
     'ui.windowsShell': 'Shell de Windows',
     'ui.unixShell': 'Shell de macOS / Linux',

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -761,6 +761,7 @@ export const frFR: LanguagePack = {
     'ui.compareByTimestamp': 'Comparer l’horodatage',
     'ui.compareBinaryContents': 'Comparer le contenu binaire',
     'ui.compareCrc': 'Comparer le CRC',
+    'ui.followSymlinks': 'Suivre les liens symboliques',
     'ui.folderCriteria': 'Critères de comparaison',
     'ui.windowsShell': 'Shell Windows',
     'ui.unixShell': 'Shell macOS / Linux',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -747,6 +747,7 @@ export const jaJP: LanguagePack = {
     'ui.compareByTimestamp': 'タイムスタンプを比較',
     'ui.compareBinaryContents': 'バイナリ内容を比較',
     'ui.compareCrc': 'CRC を比較',
+    'ui.followSymlinks': 'シンボリックリンクをたどる',
     'ui.folderCriteria': '比較条件',
     'ui.windowsShell': 'Windows シェル',
     'ui.unixShell': 'macOS / Linux シェル',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -744,6 +744,7 @@ export const koKR: LanguagePack = {
     'ui.compareByTimestamp': '타임스탬프 비교',
     'ui.compareBinaryContents': '바이너리 내용 비교',
     'ui.compareCrc': 'CRC 비교',
+    'ui.followSymlinks': '심볼릭 링크 따라가기',
     'ui.folderCriteria': '비교 조건',
     'ui.windowsShell': 'Windows 셸',
     'ui.unixShell': 'macOS / Linux 셸',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -728,6 +728,7 @@ export const zhCN: LanguagePack = {
     'ui.compareByTimestamp': '比较时间戳',
     'ui.compareBinaryContents': '比较二进制内容',
     'ui.compareCrc': '比较 CRC',
+    'ui.followSymlinks': '跟随符号链接',
     'ui.folderCriteria': '比较条件',
     'ui.windowsShell': 'Windows 外壳扩展',
     'ui.unixShell': 'macOS / Linux 外壳集成',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -729,6 +729,7 @@ export const zhTW: LanguagePack = {
     'ui.compareByTimestamp': '比較時間戳',
     'ui.compareBinaryContents': '比較二進位內容',
     'ui.compareCrc': '比較 CRC',
+    'ui.followSymlinks': '跟隨符號連結',
     'ui.folderCriteria': '比較條件',
     'ui.windowsShell': 'Windows 殼層延伸',
     'ui.unixShell': 'macOS / Linux 殼層整合',

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -163,6 +163,7 @@ export interface FolderCompareCriteria {
   compareModifiedTime: boolean
   compareContents: boolean
   compareCrc: boolean
+  followSymlinks?: boolean
 }
 
 export interface FolderNameFilters {

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -374,6 +374,7 @@ describe('FolderCompareView', () => {
         compareModifiedTime: false,
         compareContents: true,
         compareCrc: false,
+        followSymlinks: false,
       },
       filters: {
         include: [],

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -1979,6 +1979,14 @@ onUnmounted(() => {
             />
             <span>{{ $t('ui.compareCrc') }}</span>
           </label>
+          <label>
+            <input
+              v-model="folderCriteria.followSymlinks"
+              data-testid="folder-criteria-follow-symlinks"
+              type="checkbox"
+            />
+            <span>{{ $t('ui.followSymlinks') }}</span>
+          </label>
         </fieldset>
         <button
           type="button"

--- a/src/views/HexCompareView.test.ts
+++ b/src/views/HexCompareView.test.ts
@@ -40,7 +40,10 @@ vi.mock('@/api/diff', () => ({
       differentRanges: 1,
     },
   }),
-  findHexInFile: vi.fn().mockResolvedValue([{ offset: 256, length: 2 }]),
+  findHexInFile: vi.fn().mockResolvedValue([
+    { offset: 256, length: 2 },
+    { offset: 512, length: 2 },
+  ]),
   saveHexEdits: vi.fn().mockResolvedValue({ bytesWritten: 1 }),
 }))
 
@@ -198,7 +201,15 @@ describe('HexCompareView', () => {
       queryKind: 'hex',
       query: '4142',
     })
-    expect(wrapper.find('[data-testid="hex-find-status"]').text()).toContain('1')
+    expect(wrapper.find('[data-testid="hex-find-status"]').text()).toBe('1/2')
+
+    await wrapper.find('[data-testid="hex-find-next"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="hex-find-status"]').text()).toBe('2/2')
+
+    await wrapper.find('[data-testid="hex-find-prev"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="hex-find-status"]').text()).toBe('1/2')
 
     await wrapper.find('[data-testid="hex-edit-offset"]').setValue(1)
     await wrapper.find('[data-testid="hex-edit-value"]').setValue('58')

--- a/src/views/HexCompareView.vue
+++ b/src/views/HexCompareView.vue
@@ -70,6 +70,7 @@ const goToError = ref('')
 const findQuery = ref('')
 const findKind = ref<'text' | 'hex'>('hex')
 const findMatches = ref<HexFindMatch[]>([])
+const activeFindIndex = ref(-1)
 const findStatus = ref('')
 const pendingEdits = ref<HexByteEdit[]>([])
 const editOffset = ref(0)
@@ -477,16 +478,41 @@ async function runHexFind(): Promise<void> {
       query: findQuery.value.trim(),
     })
     findStatus.value = String(findMatches.value.length)
-    const firstMatch = findMatches.value.at(0)
+    if (findMatches.value.length === 0) {
+      activeFindIndex.value = -1
 
-    if (firstMatch) {
-      hexOffset.value = numericOffset(firstMatch.offset)
-      jumpOffsetInput.value = hexOffsetInputValue(firstMatch.offset)
-      await runHexCompare()
+      return
     }
+
+    await jumpToFindMatch(0)
   } catch (event) {
     error.value = String(event)
   }
+}
+
+async function jumpToFindMatch(index: number): Promise<void> {
+  if (index < 0 || index >= findMatches.value.length) {
+    return
+  }
+
+  const match = findMatches.value[index]
+
+  activeFindIndex.value = index
+  hexOffset.value = numericOffset(match.offset)
+  jumpOffsetInput.value = hexOffsetInputValue(match.offset)
+  findStatus.value = `${String(index + 1)}/${String(findMatches.value.length)}`
+  await runHexCompare()
+}
+
+function goToFindMatch(delta: number): void {
+  if (findMatches.value.length === 0) {
+    return
+  }
+
+  const current = activeFindIndex.value < 0 ? 0 : activeFindIndex.value
+  const next = (current + delta + findMatches.value.length) % findMatches.value.length
+
+  void jumpToFindMatch(next)
 }
 
 function queueHexEdit(): void {
@@ -694,6 +720,22 @@ async function runHexSave(): Promise<void> {
           @click="runHexFind"
         >
           {{ $t('ui.find') }}
+        </button>
+        <button
+          type="button"
+          data-testid="hex-find-prev"
+          :disabled="findMatches.length === 0"
+          @click="goToFindMatch(-1)"
+        >
+          {{ $t('ui.previous') }}
+        </button>
+        <button
+          type="button"
+          data-testid="hex-find-next"
+          :disabled="findMatches.length === 0"
+          @click="goToFindMatch(1)"
+        >
+          {{ $t('ui.next') }}
         </button>
         <strong data-testid="hex-find-status">{{ findStatus }}</strong>
         <label>


### PR DESCRIPTION
## Summary
- Folder compare now applies a real `followSymlinks` / CRITERIA `follow-symlinks` option in `folder-core` scans (default off; cycle-safe when on), wired through session settings, persisted criteria, and script COMPARE.
- Hex Compare Find gains Previous/Next match stepping over the existing hit list, with `n/total` status text.

## Test plan
- [x] `cargo test -p folder-core --lib` (incl. symlink follow test)
- [x] `cargo test -p script-core --lib criteria`
- [x] `cargo test -p open-diff-app --lib compare_folder`
- [x] `vitest` folderCompareCriteria + HexCompareView + language skeletons
- [x] pre-commit quality (format/lint/stylelint/typecheck/clippy)
- [ ] Manual: Folder Compare with a directory symlink — off shows link leaf, on expands nested files
- [ ] Manual: Hex Find with multiple hits, step Next/Previous