### PR TITLE
Wire Media tag filters/rules and accept open /fv aliases

### DIFF
--- a/src-tauri/crates/cli-core/src/lib.rs
+++ b/src-tauri/crates/cli-core/src/lib.rs
@@ -272,6 +272,7 @@ pub fn cli_help_text() -> String {
         "                         text-compare, text-merge, text-edit, text-patch,".to_owned(),
         "                         table-compare, hex-compare, picture-compare,".to_owned(),
         "                         registry-compare, media-compare, version-compare".to_owned(),
+        "      --fv <type>        alias for --session (accepts spaced names)".to_owned(),
         "      --left <path>      left side path (or positional)".to_owned(),
         "      --right <path>     right side path (or positional)".to_owned(),
         "      --center <path>    center/base path for merge sessions".to_owned(),
@@ -921,14 +922,18 @@ fn parse_open_compare(args: Vec<String>) -> Result<CliInvocation, CliParseError>
     while index < args.len() {
         let arg = &args[index];
         match normalized_switch(arg).as_deref() {
-            Some("session") | Some("type") => {
+            Some("session") | Some("type") | Some("fv") => {
                 index += 1;
                 let value = args
                     .get(index)
-                    .ok_or_else(|| usage_error("open --session requires a session type"))?;
+                    .ok_or_else(|| usage_error("open --session/--fv requires a session type"))?;
                 session_type = Some(value.clone());
             }
-            Some(switch) if switch.starts_with("session=") || switch.starts_with("type=") => {
+            Some(switch)
+                if switch.starts_with("session=")
+                    || switch.starts_with("type=")
+                    || switch.starts_with("fv=") =>
+            {
                 let value = switch.split_once('=').map(|(_, value)| value).unwrap_or("");
                 session_type = Some(value.to_owned());
             }
@@ -1065,7 +1070,7 @@ fn resolve_open_session_type(
     right: &str,
     edit: bool,
 ) -> Result<(&'static str, &'static str), CliParseError> {
-    let key = explicit.map(str::to_ascii_lowercase).unwrap_or_else(|| {
+    let key = explicit.map(normalize_session_type_key).unwrap_or_else(|| {
         if edit {
             "text-edit".to_owned()
         } else {
@@ -1089,6 +1094,34 @@ fn resolve_open_session_type(
         "version" | "version-compare" => Ok(("version-compare", "/compare/version")),
         other => Err(usage_error(format!("unknown session type: {other}"))),
     }
+}
+
+fn normalize_session_type_key(value: &str) -> String {
+    let mut trimmed = value.trim();
+    if trimmed.len() >= 2 {
+        let bytes = trimmed.as_bytes();
+        let first = bytes[0];
+        let last = bytes[trimmed.len() - 1];
+        let double_quoted = first == b'"' && last == b'"';
+        let single_quoted = first == 39 && last == 39;
+        if double_quoted || single_quoted {
+            trimmed = trimmed[1..trimmed.len() - 1].trim();
+        }
+    }
+    trimmed
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_whitespace() || ch == '_' {
+                '-'
+            } else {
+                ch.to_ascii_lowercase()
+            }
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 fn infer_open_session_type(left: &str, right: &str) -> String {
@@ -1549,6 +1582,52 @@ mod tests {
                 left: "a.bin".to_owned(),
                 right: "b.bin".to_owned(),
                 route: "/compare/hex".to_owned(),
+                options: CliOpenOptions::default(),
+            }
+        );
+
+        assert!(help.contains("--fv <type>"));
+    }
+
+    #[test]
+    fn parses_open_fv_alias_with_spaced_session_names() {
+        let fv = parse_cli_args([
+            "open-diff-cli",
+            "open",
+            "/fv",
+            "Text Compare",
+            "left.txt",
+            "right.txt",
+        ])
+        .expect("fv open should parse");
+        assert_eq!(
+            fv.command,
+            CliCommand::OpenCompare {
+                session_type: "text-compare".to_owned(),
+                left: "left.txt".to_owned(),
+                right: "right.txt".to_owned(),
+                route: "/compare/text".to_owned(),
+                options: CliOpenOptions::default(),
+            }
+        );
+
+        let inline = parse_cli_args([
+            "open-diff-cli",
+            "open",
+            r#"/fv=Media Compare"#,
+            "--left",
+            "a.mp3",
+            "--right",
+            "b.mp3",
+        ])
+        .expect("inline fv open should parse");
+        assert_eq!(
+            inline.command,
+            CliCommand::OpenCompare {
+                session_type: "media-compare".to_owned(),
+                left: "a.mp3".to_owned(),
+                right: "b.mp3".to_owned(),
+                route: "/compare/media".to_owned(),
                 options: CliOpenOptions::default(),
             }
         );

--- a/src/app/mediaCompareOptions.test.ts
+++ b/src/app/mediaCompareOptions.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  buildMediaRulesCatalog,
+  defaultMediaCompareOptions,
+  isMediaFieldImportant,
+  loadMediaCompareOptions,
+  mediaCompareOptionsStorageKey,
+  resetMediaCompareOptions,
+  saveMediaCompareOptions,
+  toggleMediaFieldImportance,
+} from './mediaCompareOptions'
+
+describe('mediaCompareOptions', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('loads defaults and persists unimportant fields', () => {
+    expect(loadMediaCompareOptions().unimportantFields).toContain('Comment')
+
+    saveMediaCompareOptions({ unimportantFields: ['Comment', 'Title'] })
+
+    expect(localStorage.getItem(mediaCompareOptionsStorageKey)).toContain('Title')
+    expect(loadMediaCompareOptions().unimportantFields).toEqual(['Comment', 'Title'])
+  })
+
+  it('toggles field importance', () => {
+    const base = defaultMediaCompareOptions()
+
+    expect(isMediaFieldImportant('Title', base)).toBe(true)
+    expect(isMediaFieldImportant('Comment', base)).toBe(false)
+
+    const demoted = toggleMediaFieldImportance('Title', base)
+
+    expect(isMediaFieldImportant('Title', demoted)).toBe(false)
+
+    const promoted = toggleMediaFieldImportance('Comment', demoted)
+
+    expect(isMediaFieldImportant('Comment', promoted)).toBe(true)
+  })
+})
+
+it('builds a rules catalog with known fields and extras', () => {
+  const catalog = buildMediaRulesCatalog(['CustomTag'])
+
+  expect(catalog.some((row) => row.field === 'Title')).toBe(true)
+  expect(catalog.some((row) => row.field === 'Comment')).toBe(true)
+  expect(catalog.some((row) => row.field === 'CustomTag')).toBe(true)
+})
+
+it('resets importance rules to defaults', () => {
+  saveMediaCompareOptions({ unimportantFields: ['Title'] })
+  const reset = resetMediaCompareOptions()
+
+  saveMediaCompareOptions(reset)
+
+  expect(loadMediaCompareOptions().unimportantFields).toEqual(
+    defaultMediaCompareOptions().unimportantFields,
+  )
+})

--- a/src/app/mediaCompareOptions.ts
+++ b/src/app/mediaCompareOptions.ts
@@ -1,0 +1,155 @@
+export const mediaCompareOptionsStorageKey = 'open-diff-media-compare-options'
+
+/** Default tag fields treated as unimportant (minor) when comparing media metadata. */
+export const defaultUnimportantMediaFields = [
+  'Comment',
+  'Comments',
+  'Copyright',
+  'EncodedBy',
+  'Encoder',
+  'EncodingSettings',
+  'Software',
+] as const
+
+/** Catalog of common media tag fields shown in Importance Rules before/without a compare. */
+export const knownMediaRuleFields = [
+  'Title',
+  'Artist',
+  'Album',
+  'AlbumArtist',
+  'Track',
+  'TrackNumber',
+  'Disc',
+  'Genre',
+  'Year',
+  'Date',
+  'Composer',
+  'Comment',
+  'Comments',
+  'Copyright',
+  'EncodedBy',
+  'Encoder',
+  'EncodingSettings',
+  'Software',
+] as const
+
+export function mediaRuleFieldGroup(field: string): string {
+  const normalized = field.trim().toLowerCase()
+
+  if (
+    normalized === 'comment' ||
+    normalized === 'comments' ||
+    normalized === 'copyright' ||
+    normalized === 'encodedby' ||
+    normalized === 'encoder' ||
+    normalized === 'encodingsettings' ||
+    normalized === 'software'
+  ) {
+    return 'Extra'
+  }
+
+  return 'Tags'
+}
+
+export function buildMediaRulesCatalog(
+  extraFields: string[] = [],
+): { field: string; group: string }[] {
+  const names = [
+    ...new Set([
+      ...knownMediaRuleFields,
+      ...extraFields.map((field) => field.trim()).filter(Boolean),
+    ]),
+  ]
+
+  return names.map((field) => ({
+    field,
+    group: mediaRuleFieldGroup(field),
+  }))
+}
+
+export interface MediaCompareOptionsState {
+  unimportantFields: string[]
+}
+
+export function defaultMediaCompareOptions(): MediaCompareOptionsState {
+  return {
+    unimportantFields: [...defaultUnimportantMediaFields],
+  }
+}
+
+function normalizeFieldList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [...defaultUnimportantMediaFields]
+  }
+
+  const fields = value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+  return [...new Set(fields)]
+}
+
+export function loadMediaCompareOptions(
+  storage: Pick<Storage, 'getItem'> = localStorage,
+): MediaCompareOptionsState {
+  try {
+    const raw = storage.getItem(mediaCompareOptionsStorageKey)
+
+    if (!raw) {
+      return defaultMediaCompareOptions()
+    }
+
+    const parsed = JSON.parse(raw) as Partial<MediaCompareOptionsState>
+
+    return {
+      unimportantFields: normalizeFieldList(parsed.unimportantFields),
+    }
+  } catch {
+    return defaultMediaCompareOptions()
+  }
+}
+
+export function saveMediaCompareOptions(
+  state: MediaCompareOptionsState,
+  storage: Pick<Storage, 'setItem'> = localStorage,
+): void {
+  storage.setItem(
+    mediaCompareOptionsStorageKey,
+    JSON.stringify({
+      unimportantFields: normalizeFieldList(state.unimportantFields),
+    }),
+  )
+}
+
+export function isMediaFieldImportant(
+  field: string,
+  options: Pick<MediaCompareOptionsState, 'unimportantFields'>,
+): boolean {
+  const normalized = field.trim().toLowerCase()
+
+  return !options.unimportantFields.some((entry) => entry.trim().toLowerCase() === normalized)
+}
+
+export function toggleMediaFieldImportance(
+  field: string,
+  options: MediaCompareOptionsState,
+): MediaCompareOptionsState {
+  const important = isMediaFieldImportant(field, options)
+
+  if (important) {
+    return {
+      unimportantFields: [...options.unimportantFields, field],
+    }
+  }
+
+  return {
+    unimportantFields: options.unimportantFields.filter(
+      (entry) => entry.trim().toLowerCase() !== field.trim().toLowerCase(),
+    ),
+  }
+}
+
+export function resetMediaCompareOptions(): MediaCompareOptionsState {
+  return defaultMediaCompareOptions()
+}

--- a/src/views/MediaCompareView.test.ts
+++ b/src/views/MediaCompareView.test.ts
@@ -47,11 +47,17 @@ vi.mock('@/api/diff', () => ({
         right: 'Aster',
         status: 'unchanged',
       },
+      {
+        field: 'Comment',
+        left: 'demo',
+        right: 'demo-b',
+        status: 'modified',
+      },
     ],
     summary: {
       added: 0,
       removed: 0,
-      modified: 1,
+      modified: 2,
       unchanged: 1,
     },
   }),
@@ -60,6 +66,7 @@ vi.mock('@/api/diff', () => ({
 describe('MediaCompareView', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    localStorage.clear()
     vi.mocked(compareMediaFiles).mockClear()
   })
 
@@ -77,7 +84,8 @@ describe('MediaCompareView', () => {
     })
     expect(wrapper.text()).toContain('fixture-left.mp3')
     expect(wrapper.text()).toContain('fixture-right.mp3')
-    expect(wrapper.find('[data-testid="media-summary-modified"]').text()).toContain('1')
+    expect(wrapper.find('[data-testid="media-summary-modified"]').text()).toContain('2')
+    expect(wrapper.find('[data-testid="media-summary-minor"]').text()).toContain('1')
     expect(wrapper.find('[data-testid="media-field-Title"]').text()).toContain('Left Song')
     expect(wrapper.find('[data-testid="media-field-Title"]').text()).toContain('Right Song')
   })
@@ -144,5 +152,67 @@ describe('MediaCompareView', () => {
     await wrapper.vm.$nextTick()
 
     expect(tabs.activeTab.title).toBe('fixture-left.mp3 <--> fixture-right.mp3')
+  })
+
+  it('enables filter and rules toolbar actions', () => {
+    const wrapper = mount(MediaCompareView)
+
+    expect(
+      wrapper.find('[data-testid="media-session-toolbar-all"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="media-session-toolbar-diffs"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="media-session-toolbar-same"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="media-session-toolbar-minor"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="media-session-toolbar-rules"]').attributes('disabled'),
+    ).toBeUndefined()
+  })
+
+  it('filters minor differences and toggles importance rules', async () => {
+    const wrapper = mount(MediaCompareView)
+
+    await wrapper.find('[data-testid="media-left-path"]').setValue('C:/music/fixture-left.mp3')
+    await wrapper.find('[data-testid="media-right-path"]').setValue('C:/music/fixture-right.mp3')
+    await wrapper.find('[data-testid="run-media-compare"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="media-session-toolbar-minor"]').trigger('click')
+    expect(wrapper.find('[data-testid="media-field-Comment"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="media-field-Title"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="media-session-toolbar-rules"]').trigger('click')
+    expect(wrapper.find('[data-testid="media-rules-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="media-rule-Title"]').exists()).toBe(true)
+    await wrapper.find('[data-testid="media-rule-Comment"] input').setValue(true)
+    await wrapper.find('[data-testid="media-session-toolbar-diffs"]').trigger('click')
+    expect(wrapper.find('[data-testid="media-field-Comment"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="media-rules-reset"]').trigger('click')
+    await wrapper.find('[data-testid="media-session-toolbar-minor"]').trigger('click')
+    expect(wrapper.find('[data-testid="media-field-Comment"]').exists()).toBe(true)
+  })
+
+  it('filters diffs and same tag rows from the toolbar', async () => {
+    const wrapper = mount(MediaCompareView)
+
+    await wrapper.find('[data-testid="media-left-path"]').setValue('C:/music/fixture-left.mp3')
+    await wrapper.find('[data-testid="media-right-path"]').setValue('C:/music/fixture-right.mp3')
+    await wrapper.find('[data-testid="run-media-compare"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="media-session-toolbar-diffs"]').trigger('click')
+    expect(wrapper.find('[data-testid="media-field-Title"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="media-field-Comment"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="media-field-Artist"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="media-session-toolbar-same"]').trigger('click')
+    expect(wrapper.find('[data-testid="media-field-Artist"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="media-field-Title"]').exists()).toBe(false)
   })
 })

--- a/src/views/MediaCompareView.vue
+++ b/src/views/MediaCompareView.vue
@@ -13,11 +13,23 @@ import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import { localFileSrc } from '@/app/localFileSrc'
 import { prefersVideoElement } from '@/app/mediaPlayback'
 import { buildMediaCompareToolbar, pathPairTitle } from '@/app/sessionToolbars'
+import {
+  buildMediaRulesCatalog,
+  isMediaFieldImportant,
+  loadMediaCompareOptions,
+  resetMediaCompareOptions,
+  saveMediaCompareOptions,
+  toggleMediaFieldImportance,
+  type MediaCompareOptionsState,
+} from '@/app/mediaCompareOptions'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
 import { useI18n } from '@/i18n'
 
 const mediaStatuses: MediaFieldStatus[] = ['added', 'removed', 'modified', 'unchanged']
+
+type MediaFieldFilter = 'all' | 'diffs' | 'same' | 'minor'
+
 const { t } = useI18n()
 const emptyMediaSide: MediaSideSummary = {
   name: '',
@@ -42,8 +54,11 @@ const rightMedia = ref<MediaSideSummary>({
 })
 const mediaFields = ref<MediaFieldRow[]>([])
 const mediaSummaryOverride = ref<Record<MediaFieldStatus, number> | null>(null)
+const fieldFilter = ref<MediaFieldFilter>('all')
 const loading = ref(false)
 const error = ref('')
+const showMediaRules = ref(false)
+const mediaOptions = ref<MediaCompareOptionsState>(loadMediaCompareOptions())
 const leftPlayer = ref<HTMLMediaElement | null>(null)
 const rightPlayer = ref<HTMLMediaElement | null>(null)
 const syncPlayback = ref(true)
@@ -124,18 +139,67 @@ async function runMediaCompare(): Promise<void> {
   }
 }
 
+function fieldIsImportant(field: string): boolean {
+  return isMediaFieldImportant(field, mediaOptions.value)
+}
+
+const visibleMediaFields = computed(() => {
+  if (fieldFilter.value === 'diffs') {
+    return mediaFields.value.filter(
+      (field) => field.status !== 'unchanged' && fieldIsImportant(field.field),
+    )
+  }
+
+  if (fieldFilter.value === 'same') {
+    return mediaFields.value.filter((field) => field.status === 'unchanged')
+  }
+
+  if (fieldFilter.value === 'minor') {
+    return mediaFields.value.filter(
+      (field) => field.status !== 'unchanged' && !fieldIsImportant(field.field),
+    )
+  }
+
+  return mediaFields.value
+})
+
+const mediaRulesCatalog = computed(() =>
+  buildMediaRulesCatalog(mediaFields.value.map((row) => row.field)),
+)
+
+const minorDifferenceCount = computed(
+  () =>
+    mediaFields.value.filter(
+      (field) => field.status !== 'unchanged' && !fieldIsImportant(field.field),
+    ).length,
+)
+
 const mediaSessionToolbar = computed(() =>
   buildMediaCompareToolbar({
     home: true,
-    all: false,
-    diffs: false,
-    same: false,
-    minor: false,
-    rules: false,
+    all: true,
+    diffs: true,
+    same: true,
+    minor: true,
+    rules: true,
     swap: Boolean(leftPath.value || rightPath.value),
     reload: Boolean(leftPath.value && rightPath.value),
   }),
 )
+
+function persistMediaOptions(): void {
+  saveMediaCompareOptions(mediaOptions.value)
+}
+
+function toggleFieldImportance(field: string): void {
+  mediaOptions.value = toggleMediaFieldImportance(field, mediaOptions.value)
+  persistMediaOptions()
+}
+
+function resetMediaRules(): void {
+  mediaOptions.value = resetMediaCompareOptions()
+  persistMediaOptions()
+}
 
 const leftMediaSrc = computed(() => (leftPath.value ? localFileSrc(leftPath.value) : ''))
 const rightMediaSrc = computed(() => (rightPath.value ? localFileSrc(rightPath.value) : ''))
@@ -246,6 +310,23 @@ function runMediaToolbarCommand(commandId: string): void {
   if (commandId === 'home') {
     tabs.openTab({ title: 'Home', titleKey: 'ui.home', route: '/', dirty: false })
     void router.push('/')
+
+    return
+  }
+
+  if (
+    commandId === 'all' ||
+    commandId === 'diffs' ||
+    commandId === 'same' ||
+    commandId === 'minor'
+  ) {
+    fieldFilter.value = commandId
+
+    return
+  }
+
+  if (commandId === 'rules') {
+    showMediaRules.value = !showMediaRules.value
 
     return
   }
@@ -442,6 +523,10 @@ function runMediaToolbarCommand(commandId: string): void {
           <strong :data-testid="`media-summary-${status}`">{{ mediaSummary[status] }}</strong>
           <span>{{ statusLabel(status) }}</span>
         </article>
+        <article class="media-summary-item status-minor">
+          <strong data-testid="media-summary-minor">{{ minorDifferenceCount }}</strong>
+          <span>{{ $t('ui.minor') }}</span>
+        </article>
       </section>
 
       <section class="media-side-grid">
@@ -518,19 +603,58 @@ function runMediaToolbarCommand(commandId: string): void {
             <span>{{ $t('ui.left') }}</span>
             <span>{{ $t('ui.right') }}</span>
             <span>{{ $t('ui.status') }}</span>
+            <span>{{ $t('ui.importance') }}</span>
           </div>
           <div
-            v-for="row in mediaFields"
+            v-for="row in visibleMediaFields"
             :key="row.field"
             class="media-field-row"
-            :class="`status-${row.status}`"
+            :class="[`status-${row.status}`, { 'media-field-minor': !fieldIsImportant(row.field) }]"
             :data-testid="`media-field-${row.field}`"
+            :data-important="fieldIsImportant(row.field) ? 'true' : 'false'"
           >
             <strong>{{ row.field }}</strong>
             <code>{{ valueText(row.left) }}</code>
             <code>{{ valueText(row.right) }}</code>
             <em>{{ statusLabel(row.status) }}</em>
+            <span>{{
+              fieldIsImportant(row.field) ? $t('ui.important') : $t('ui.unimportant')
+            }}</span>
           </div>
+        </div>
+      </section>
+
+      <section
+        v-if="showMediaRules"
+        class="media-rules-panel"
+        data-testid="media-rules-panel"
+      >
+        <header>
+          <strong>{{ $t('ui.importanceRules') }}</strong>
+          <span>{{ $t('ui.versionRulesHint') }}</span>
+          <button
+            type="button"
+            data-testid="media-rules-reset"
+            @click="resetMediaRules"
+          >
+            {{ $t('ui.reset') }}
+          </button>
+        </header>
+        <div class="media-rules-list">
+          <label
+            v-for="row in mediaRulesCatalog"
+            :key="`rule-${row.field}`"
+            class="media-rule-row"
+            :data-testid="`media-rule-${row.field}`"
+          >
+            <input
+              type="checkbox"
+              :checked="fieldIsImportant(row.field)"
+              @change="toggleFieldImportance(row.field)"
+            />
+            <span>{{ row.field }}</span>
+            <em>{{ row.group }}</em>
+          </label>
         </div>
       </section>
     </section>
@@ -697,10 +821,59 @@ h1 {
 
 .media-field-row {
   display: grid;
-  grid-template-columns: 140px minmax(180px, 1fr) minmax(180px, 1fr) 98px;
-  min-width: 640px;
+  grid-template-columns: 140px minmax(160px, 1fr) minmax(160px, 1fr) 98px 98px;
+  min-width: 760px;
   border-bottom: 1px solid var(--app-border);
   font-size: 12px;
+}
+
+.media-field-minor {
+  opacity: 0.78;
+}
+
+.media-rules-panel {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-surface);
+}
+
+.media-rules-panel header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.media-rules-panel header button {
+  margin-left: auto;
+}
+
+.media-rules-panel header span {
+  color: var(--app-text-muted);
+  font-size: 12px;
+}
+
+.media-rules-list {
+  display: grid;
+  gap: 6px;
+  max-height: 220px;
+  overflow: auto;
+}
+
+.media-rule-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+}
+
+.media-rule-row em {
+  color: var(--app-text-muted);
+  font-style: normal;
 }
 
 .media-field-row:last-child {
@@ -761,6 +934,14 @@ h1 {
 .status-modified em,
 .status-modified.media-summary-item {
   color: var(--diff-modified-fg);
+}
+
+.status-minor.media-summary-item {
+  border-color: color-mix(in srgb, var(--bc-warning, #c9a227) 55%, var(--bc-border));
+}
+
+.status-minor.media-summary-item strong {
+  color: var(--bc-warning, #c9a227);
 }
 
 .status-unchanged em {


### PR DESCRIPTION
## Summary
- Enable Media Compare All/Diffs/Same/Minor/Rules with persisted tag importance settings and a minor-difference summary.
- Accept CLI `open --fv` / `/fv` as a session-type alias, including spaced names such as `Text Compare` and `Media Compare`.

## Test plan
- [x] `vitest run src/app/mediaCompareOptions.test.ts src/views/MediaCompareView.test.ts` (12 passed)
- [x] `cargo test -p cli-core parses_open_fv` and `parses_open_session_flags`
- [x] prettier/eslint/stylelint on touched frontend files; `cargo fmt` + clippy on `cli-core`
- [ ] Manual: open Media Compare, run a compare, toggle Diffs/Same/Minor/Rules and confirm the field table filters
- [ ] Manual: `open-diff-cli open /fv "Text Compare" a.txt b.txt` reports text-compare route