### PR TITLE
Round-trip folder snapshots and wire Text Edit wrap

### DIFF
--- a/src-tauri/src/sources.rs
+++ b/src-tauri/src/sources.rs
@@ -39,11 +39,7 @@ pub fn load_compare_source(path: &str) -> Result<CompareSource, String> {
         ));
     }
 
-    if path.to_ascii_lowercase().ends_with(".snapshot.json")
-        || path
-            .to_ascii_lowercase()
-            .ends_with(".opendiff-snapshot.json")
-    {
+    if is_snapshot_compare_path(path) {
         return Ok(CompareSource::Snapshot(
             load_snapshot_file(&path_buf).map_err(|error| format!("{error:?}"))?,
         ));
@@ -304,4 +300,30 @@ fn collect_remote_files(
     }
 
     Ok(())
+}
+
+fn is_snapshot_compare_path(path: &str) -> bool {
+    let lower = path.replace('\\', "/").to_ascii_lowercase();
+    if lower.ends_with(".snapshot.json") || lower.ends_with(".opendiff-snapshot.json") {
+        return true;
+    }
+    let base = lower.rsplit('/').next().unwrap_or("");
+    base == "open-diff-snapshot.json"
+}
+
+#[cfg(test)]
+mod snapshot_path_tests {
+    use super::is_snapshot_compare_path;
+
+    #[test]
+    fn recognizes_reloadable_and_legacy_snapshot_names() {
+        assert!(is_snapshot_compare_path("/tmp/tree.snapshot.json"));
+        assert!(is_snapshot_compare_path(
+            r"C:\data\workspace.opendiff-snapshot.json"
+        ));
+        assert!(is_snapshot_compare_path("/tmp/open-diff-snapshot.json"));
+        assert!(is_snapshot_compare_path("/tmp/OPEN-DIFF-SNAPSHOT.JSON"));
+        assert!(!is_snapshot_compare_path("/tmp/folder"));
+        assert!(!is_snapshot_compare_path("/tmp/notes.json"));
+    }
 }

--- a/src/app/snapshotPath.test.ts
+++ b/src/app/snapshotPath.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { folderSnapshotOutputPath, isSnapshotPath } from './snapshotPath'
+
+describe('snapshotPath', () => {
+  it('detects snapshot compare paths including legacy save names', () => {
+    expect(isSnapshotPath('/tmp/tree.snapshot.json')).toBe(true)
+    expect(isSnapshotPath('C:\\data\\workspace.opendiff-snapshot.json')).toBe(true)
+    expect(isSnapshotPath('/tmp/open-diff-snapshot.json')).toBe(true)
+    expect(isSnapshotPath('/tmp/OPEN-DIFF-SNAPSHOT.JSON')).toBe(true)
+    expect(isSnapshotPath('/tmp/folder')).toBe(false)
+    expect(isSnapshotPath('/tmp/notes.json')).toBe(false)
+    expect(isSnapshotPath('')).toBe(false)
+  })
+
+  it('builds a reloadable snapshot output path from the folder basename', () => {
+    expect(folderSnapshotOutputPath('/tmp/docs/')).toBe('/tmp/docs/docs.snapshot.json')
+    expect(folderSnapshotOutputPath('C:\\work\\release')).toBe(
+      'C:\\work\\release/release.snapshot.json',
+    )
+  })
+})

--- a/src/app/snapshotPath.ts
+++ b/src/app/snapshotPath.ts
@@ -1,0 +1,27 @@
+/** Match sources.rs snapshot compare-side detection for Folder Compare chips. */
+
+import { pathBaseName } from './sessionToolbars'
+
+export function isSnapshotPath(path: string): boolean {
+  const lower = path.trim().replaceAll('\\', '/').toLowerCase()
+
+  if (!lower) {
+    return false
+  }
+
+  if (lower.endsWith('.snapshot.json') || lower.endsWith('.opendiff-snapshot.json')) {
+    return true
+  }
+
+  const base = lower.split('/').pop() ?? ''
+
+  return base === 'open-diff-snapshot.json'
+}
+
+/** Prefer `{folder}.snapshot.json` so saved snapshots reload as compare sides. */
+export function folderSnapshotOutputPath(sourceRoot: string): string {
+  const normalizedRoot = sourceRoot.replace(/[/\\]+$/u, '')
+  const base = pathBaseName(normalizedRoot) || 'folder'
+
+  return `${normalizedRoot}/${base}.snapshot.json`
+}

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -824,6 +824,7 @@ export const deDE: LanguagePack = {
     'status.conflictPosition': 'Conflict {index} of {total}',
     'ui.browseArchive': 'Archive…',
     'ui.archiveSide': 'Archive',
+    'ui.snapshotSide': 'Snapshot',
     'status.notAnArchivePath': 'Not a ZIP/TAR archive: {path}',
     'status.attributesChangedBulk': 'Attributes changed on {count} items -> {state}',
     'status.renamedBulkPaths': 'Renamed {count} items -> {path}',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -803,6 +803,7 @@ export const enUS: LanguagePack = {
     'status.conflictPosition': 'Conflict {index} of {total}',
     'ui.browseArchive': 'Archive…',
     'ui.archiveSide': 'Archive',
+    'ui.snapshotSide': 'Snapshot',
     'status.notAnArchivePath': 'Not a ZIP/TAR archive: {path}',
     'status.attributesChangedBulk': 'Attributes changed on {count} items -> {state}',
     'status.renamedBulkPaths': 'Renamed {count} items -> {path}',

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -819,6 +819,7 @@ export const esES: LanguagePack = {
     'status.conflictPosition': 'Conflict {index} of {total}',
     'ui.browseArchive': 'Archive…',
     'ui.archiveSide': 'Archive',
+    'ui.snapshotSide': 'Instantánea',
     'status.notAnArchivePath': 'Not a ZIP/TAR archive: {path}',
     'status.attributesChangedBulk': 'Attributes changed on {count} items -> {state}',
     'status.renamedBulkPaths': 'Renamed {count} items -> {path}',

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -819,6 +819,7 @@ export const frFR: LanguagePack = {
     'status.conflictPosition': 'Conflict {index} of {total}',
     'ui.browseArchive': 'Archive…',
     'ui.archiveSide': 'Archive',
+    'ui.snapshotSide': 'Instantané',
     'status.notAnArchivePath': 'Not a ZIP/TAR archive: {path}',
     'status.attributesChangedBulk': 'Attributes changed on {count} items -> {state}',
     'status.renamedBulkPaths': 'Renamed {count} items -> {path}',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -803,6 +803,7 @@ export const jaJP: LanguagePack = {
     'status.conflictPosition': 'Conflict {index} of {total}',
     'ui.browseArchive': 'Archive…',
     'ui.archiveSide': 'Archive',
+    'ui.snapshotSide': 'スナップショット',
     'status.notAnArchivePath': 'Not a ZIP/TAR archive: {path}',
     'status.attributesChangedBulk': 'Attributes changed on {count} items -> {state}',
     'status.renamedBulkPaths': 'Renamed {count} items -> {path}',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -798,6 +798,7 @@ export const koKR: LanguagePack = {
     'status.conflictPosition': 'Conflict {index} of {total}',
     'ui.browseArchive': 'Archive…',
     'ui.archiveSide': 'Archive',
+    'ui.snapshotSide': '스냅샷',
     'status.notAnArchivePath': 'Not a ZIP/TAR archive: {path}',
     'status.attributesChangedBulk': 'Attributes changed on {count} items -> {state}',
     'status.renamedBulkPaths': 'Renamed {count} items -> {path}',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -779,6 +779,7 @@ export const zhCN: LanguagePack = {
     'status.conflictPosition': '冲突 {index}/{total}',
     'ui.browseArchive': '压缩包…',
     'ui.archiveSide': '压缩包',
+    'ui.snapshotSide': '快照',
     'status.notAnArchivePath': '不是 ZIP/TAR 压缩包：{path}',
     'status.attributesChangedBulk': '已更改 {count} 项属性 -> {state}',
     'status.renamedBulkPaths': '已重命名 {count} 项 -> {path}',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -780,6 +780,7 @@ export const zhTW: LanguagePack = {
     'status.conflictPosition': '衝突 {index}/{total}',
     'ui.browseArchive': '壓縮檔…',
     'ui.archiveSide': '壓縮檔',
+    'ui.snapshotSide': '快照',
     'status.notAnArchivePath': '不是 ZIP/TAR 壓縮檔：{path}',
     'status.attributesChangedBulk': '已變更 {count} 項屬性 -> {state}',
     'status.renamedBulkPaths': '已重新命名 {count} 項 -> {path}',

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -49,6 +49,7 @@ import { useViewActionsStore } from '@/stores/viewActions'
 import { useLastCompareStore } from '@/stores/lastCompare'
 import { useWorkspacesStore } from '@/stores/workspaces'
 import { createFolderSnapshot } from '@/api/diff'
+import { folderSnapshotOutputPath } from '@/app/snapshotPath'
 import { openPathExternal, takeShellCompareLaunch } from '@/api/integration'
 import { pickNativePath } from '@/app/filePicker'
 import { pathBaseName } from '@/app/sessionToolbars'
@@ -461,7 +462,7 @@ async function saveSnapshotFromMenu(): Promise<void> {
   }
 
   const normalizedRoot = sourceRoot.replace(/[/\\]+$/u, '')
-  const outputPath = `${normalizedRoot}/open-diff-snapshot.json`
+  const outputPath = folderSnapshotOutputPath(normalizedRoot)
 
   try {
     const written = await createFolderSnapshot({

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -731,6 +731,18 @@ describe('FolderCompareView', () => {
     expect(wrapper.find('[data-testid="folder-browse-archive-left"]').exists()).toBe(true)
   })
 
+  it('shows snapshot side chips when roots are snapshot JSON paths', async () => {
+    const wrapper = mountFolderCompareView()
+
+    await wrapper.find('[data-testid="folder-left-root"]').setValue('/tmp/docs/docs.snapshot.json')
+    await wrapper.find('[data-testid="folder-right-root"]').setValue('/tmp/open-diff-snapshot.json')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="folder-left-snapshot-chip"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-right-snapshot-chip"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-left-archive-chip"]').exists()).toBe(false)
+  })
+
   it('applies readonly attributes across the checked set', async () => {
     vi.mocked(changeFolderEntryAttributes).mockClear()
     const wrapper = mountFolderCompareView()

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -13,6 +13,7 @@ import {
 } from '@/app/fileOperationConfirmation'
 import { createChildCompareLaunch } from '@/app/childSession'
 import { isArchivePath } from '@/app/archivePath'
+import { folderSnapshotOutputPath, isSnapshotPath } from '@/app/snapshotPath'
 import { pickNativePath } from '@/app/filePicker'
 import { formatCompareError } from '@/app/compareError'
 import { loadFolderDisplayFilters, saveFolderDisplayFilters } from '@/app/folderDisplayFilters'
@@ -509,7 +510,7 @@ async function saveFolderSnapshot(): Promise<void> {
   }
 
   const normalizedRoot = sourceRoot.replace(/[/\\]+$/u, '')
-  const outputPath = `${normalizedRoot}/open-diff-snapshot.json`
+  const outputPath = folderSnapshotOutputPath(normalizedRoot)
 
   try {
     await createFolderSnapshot({
@@ -1147,6 +1148,8 @@ function operationEntryPaths(): string[] {
 
 const leftSideIsArchive = computed(() => isArchivePath(leftRoot.value))
 const rightSideIsArchive = computed(() => isArchivePath(rightRoot.value))
+const leftSideIsSnapshot = computed(() => isSnapshotPath(leftRoot.value))
+const rightSideIsSnapshot = computed(() => isSnapshotPath(rightRoot.value))
 
 async function browseArchive(side: 'left' | 'right'): Promise<void> {
   const selected = await pickNativePath({ directory: false })
@@ -1854,6 +1857,12 @@ onUnmounted(() => {
                 data-testid="folder-left-archive-chip"
                 >{{ $t('ui.archiveSide') }}</span
               >
+              <span
+                v-if="leftSideIsSnapshot"
+                class="archive-side-chip"
+                data-testid="folder-left-snapshot-chip"
+                >{{ $t('ui.snapshotSide') }}</span
+              >
             </div>
           </label>
           <label>
@@ -1890,6 +1899,12 @@ onUnmounted(() => {
                 class="archive-side-chip"
                 data-testid="folder-right-archive-chip"
                 >{{ $t('ui.archiveSide') }}</span
+              >
+              <span
+                v-if="rightSideIsSnapshot"
+                class="archive-side-chip"
+                data-testid="folder-right-snapshot-chip"
+                >{{ $t('ui.snapshotSide') }}</span
               >
             </div>
           </label>

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -17,6 +17,7 @@ import type {
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import { createFolderSnapshot } from '@/api/diff'
+import { folderSnapshotOutputPath } from '@/app/snapshotPath'
 import { collectExpandablePrefixes, isPathHiddenByCollapse } from '@/app/folderPathGroups'
 import { buildFolderMergeToolbar, mergeSessionTitle, pathBaseName } from '@/app/sessionToolbars'
 import { useI18n } from '@/i18n'
@@ -210,7 +211,7 @@ async function saveMergeFolderSnapshot(): Promise<void> {
   }
 
   const normalizedRoot = sourceRoot.replace(/[/\\]+$/u, '')
-  const outputPath = `${normalizedRoot}/open-diff-snapshot.json`
+  const outputPath = folderSnapshotOutputPath(normalizedRoot)
 
   try {
     await createFolderSnapshot({

--- a/src/views/FolderSyncView.vue
+++ b/src/views/FolderSyncView.vue
@@ -13,6 +13,7 @@ import { useRouter } from 'vue-router'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
 import { createFolderSnapshot } from '@/api/diff'
+import { folderSnapshotOutputPath } from '@/app/snapshotPath'
 import { collectExpandablePrefixes, isPathHiddenByCollapse } from '@/app/folderPathGroups'
 import { buildFolderSyncToolbar, pathBaseName, syncPathPairTitle } from '@/app/sessionToolbars'
 import { useI18n } from '@/i18n'
@@ -419,7 +420,7 @@ async function saveSyncFolderSnapshot(): Promise<void> {
   }
 
   const normalizedRoot = sourceRoot.replace(/[/\\]+$/u, '')
-  const outputPath = `${normalizedRoot}/open-diff-snapshot.json`
+  const outputPath = folderSnapshotOutputPath(normalizedRoot)
 
   try {
     await createFolderSnapshot({

--- a/src/views/TextEditView.test.ts
+++ b/src/views/TextEditView.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import TextEditView from './TextEditView.vue'
 import { readTextFile, saveTextFile } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useSettingsStore } from '@/stores/settings'
 
 vi.mock('@/api/diff', () => ({
   readTextFile: vi.fn().mockResolvedValue({
@@ -44,9 +45,7 @@ function mountTextEditView(): VueWrapper {
           emits: ['click'],
           template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
         },
-        NInput: {
-          ...NInputStub,
-        },
+        NInput: NInputStub,
         NAlert: { template: '<div><slot /></div>' },
       },
     },
@@ -55,6 +54,7 @@ function mountTextEditView(): VueWrapper {
 
 describe('TextEditView', () => {
   beforeEach(() => {
+    localStorage.clear()
     setActivePinia(createPinia())
     vi.mocked(readTextFile).mockClear()
     vi.mocked(saveTextFile).mockClear()
@@ -222,5 +222,22 @@ describe('TextEditView', () => {
     expect(wrapper.find('[data-testid="text-edit-syntax-preview"]').html()).toContain(
       'syntax-keyword',
     )
+  })
+
+  it('starts wrap from Options default and toggles from the toolbar', async () => {
+    localStorage.setItem('open-diff-wrap-text-default', '1')
+    setActivePinia(createPinia())
+    expect(useSettingsStore().wrapTextDefault).toBe(true)
+
+    const wrapper = mountTextEditView()
+    const wrapButton = wrapper.find('[data-testid="text-edit-toolbar-wrap"]')
+
+    expect(wrapButton.exists()).toBe(true)
+    expect(wrapButton.attributes('aria-pressed')).toBe('true')
+
+    await wrapButton.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapButton.attributes('aria-pressed')).toBe('false')
   })
 })

--- a/src/views/TextEditView.vue
+++ b/src/views/TextEditView.vue
@@ -47,6 +47,7 @@ const replaceQuery = ref('')
 const currentFindIndex = ref(0)
 const syntaxMenuOpen = ref(false)
 const syntaxLanguageId = ref('auto')
+const wordWrap = ref(settings.wrapTextDefault)
 
 const fileTitle = computed(() => {
   if (!document.value) {
@@ -313,6 +314,12 @@ function runTextEditCommand(commandId: string): void {
 
   if (commandId === 'syntax') {
     syntaxMenuOpen.value = !syntaxMenuOpen.value
+
+    return
+  }
+
+  if (commandId === 'wrap') {
+    wordWrap.value = !wordWrap.value
   }
 }
 
@@ -440,6 +447,7 @@ const textEditToolbarCommands = computed(() => [
   },
   { id: 'delete', glyph: 'D', labelKey: 'ui.delete', enabled: hasEditorContent.value },
   { id: 'syntax', glyph: 'S', labelKey: 'ui.syntax', enabled: true },
+  { id: 'wrap', glyph: 'W', labelKey: 'ui.wrap', enabled: true },
 ])
 </script>
 
@@ -450,7 +458,9 @@ const textEditToolbarCommands = computed(() => [
       :key="command.id"
       class="bc-toolbar-command"
       type="button"
+      :class="{ 'bc-toolbar-command-active': command.id === 'wrap' && wordWrap }"
       :disabled="!command.enabled"
+      :aria-pressed="command.id === 'wrap' ? wordWrap : undefined"
       :data-testid="`text-edit-toolbar-${command.id}`"
       @click="runTextEditCommand(command.id)"
     >
@@ -590,6 +600,7 @@ const textEditToolbarCommands = computed(() => [
       :value="editorText"
       type="textarea"
       class="editor-input"
+      :class="{ 'editor-input-wrap': wordWrap, 'editor-input-nowrap': !wordWrap }"
       :placeholder="$t('ui.openATextFileToBeginEditing')"
       @update:value="updateEditorText"
     />
@@ -756,6 +767,22 @@ h1 {
 
 .editor-input {
   min-height: 0;
+}
+
+.bc-toolbar-command-active {
+  background: color-mix(in srgb, var(--od-accent, #3b82f6) 28%, transparent);
+}
+
+:deep(.editor-input-wrap textarea),
+.editor-input-wrap :deep(textarea) {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+:deep(.editor-input-nowrap textarea),
+.editor-input-nowrap :deep(textarea) {
+  overflow-x: auto;
+  white-space: pre;
 }
 
 :deep(textarea) {


### PR DESCRIPTION
## Summary
- Save Snapshot now writes `{folder}.snapshot.json`, which Folder Compare already treats as a snapshot side (legacy `open-diff-snapshot.json` names still load).
- Folder Compare shows Snapshot side chips when a root is a snapshot JSON path.
- Text Edit honors Options “wrap text by default” and adds a Wrap toolbar toggle.

Based on `origin/master` (`0a171f9`). PR #94 is still open, so this avoids Media Compare / CLI `/fv` files.

## Test plan
- [x] `vitest run` for `snapshotPath`, `TextEditView`, `FolderCompareView` (36 passed)
- [x] `cargo test --lib sources::snapshot_path_tests`
- [x] eslint / stylelint / `vue-tsc` / rustfmt / clippy on touched scope
- [ ] Do not merge until reviewed; leave open