### PR TITLE
Deepen HEX-REPORT and wire Hex byte copy/export

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3391,6 +3391,7 @@ dependencies = [
  "diff-core",
  "file-core",
  "folder-core",
+ "hex-core",
  "image-core",
  "job-core",
  "logging-core",

--- a/src-tauri/crates/script-core/Cargo.toml
+++ b/src-tauri/crates/script-core/Cargo.toml
@@ -12,6 +12,7 @@ folder-core = { path = "../folder-core" }
 job-core = { path = "../job-core" }
 logging-core = { path = "../logging-core" }
 media-core = { path = "../media-core" }
+hex-core = { path = "../hex-core" }
 image-core = { path = "../image-core" }
 report-core = { path = "../report-core" }
 serde.workspace = true

--- a/src-tauri/crates/script-core/src/lib.rs
+++ b/src-tauri/crates/script-core/src/lib.rs
@@ -455,11 +455,10 @@ where
                 )?;
             }
             ScriptCommandKind::HexReport { output } => {
-                run_report_command(
+                run_hex_report_command(
                     command,
                     &mut state,
                     report_engine,
-                    ScriptReportType::Hex,
                     output,
                     &execution.variables,
                 )?;
@@ -1658,6 +1657,92 @@ fn delete_path(path: &str) -> Result<(), String> {
     } else {
         std::fs::remove_file(path).map_err(|error| error.to_string())
     }
+}
+
+fn run_hex_report_command<R>(
+    command: &ScriptCommand,
+    state: &mut ScriptRuntimeState,
+    report_engine: &mut R,
+    output: &str,
+    variables: &ScriptVariables,
+) -> Result<(), ScriptExecutionError>
+where
+    R: ScriptReportEngine,
+{
+    let output = expand_script_variables(output, variables).map_err(|error| {
+        execution_error(command, format!("{} at line {}", error.message, error.line))
+    })?;
+
+    if state.load_paths.len() >= 2 {
+        let left = &state.load_paths[0];
+        let right = &state.load_paths[1];
+        let left_path = std::path::Path::new(left);
+        let right_path = std::path::Path::new(right);
+        if left_path.is_file() && right_path.is_file() {
+            if let Ok((summary, report_text)) = compare_hex_script_paths(left, right) {
+                state.last_compare = Some(summary.clone());
+                write_script_report_file(&output, &report_text)
+                    .map_err(|reason| execution_error(command, reason))?;
+                state.reports_written += 1;
+                return Ok(());
+            }
+        }
+    }
+
+    let Some(compare_summary) = state.last_compare.clone() else {
+        return Err(execution_error(
+            command,
+            "HEX-REPORT requires binary LOAD paths or COMPARE first",
+        ));
+    };
+
+    report_engine
+        .write_report(ScriptReportRequest {
+            report_type: ScriptReportType::Hex,
+            output,
+            compare_summary,
+        })
+        .map_err(|reason| execution_error(command, reason))?;
+    state.reports_written += 1;
+    Ok(())
+}
+
+fn compare_hex_script_paths(
+    left: &str,
+    right: &str,
+) -> Result<(ScriptCompareSummary, String), String> {
+    let left_bytes = std::fs::read(left).map_err(|error| error.to_string())?;
+    let right_bytes = std::fs::read(right).map_err(|error| error.to_string())?;
+    let report = hex_core::build_hex_report(&left_bytes, &right_bytes);
+    let row_lines = report
+        .rows
+        .iter()
+        .map(|row| {
+            format!(
+                "{:08X}\t{}\t{}",
+                row.offset,
+                row.original_hex.as_deref().unwrap_or("--"),
+                row.modified_hex.as_deref().unwrap_or("--"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let report_text = format!(
+        "HEX-REPORT\nleft: {left}\nright: {right}\noriginalLen: {}\nmodifiedLen: {}\nchangedRows: {}\n\nrows:\n{}\n",
+        report.summary.original_len,
+        report.summary.modified_len,
+        report.summary.changed_rows,
+        row_lines.join("\n"),
+    );
+    let summary = ScriptCompareSummary {
+        compared: report
+            .summary
+            .original_len
+            .max(report.summary.modified_len)
+            .max(1) as usize,
+        different: report.summary.changed_rows as usize,
+    };
+
+    Ok((summary, report_text))
 }
 
 fn run_picture_report_command<R>(
@@ -3096,6 +3181,73 @@ mod tests {
         let content = std::fs::read_to_string(&report).expect("report");
         assert!(content.contains("MEDIA-REPORT"));
         assert!(content.contains("different: 1"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn hex_report_compares_binaries_when_load_paths_are_files() {
+        let root = unique_temp_dir("script-hex-report");
+        let left = root.join("left.bin");
+        let right = root.join("right.bin");
+        let report = root.join("out.txt");
+
+        std::fs::write(&left, b"ABCD").expect("left binary");
+        std::fs::write(&right, b"AxCD").expect("right binary");
+
+        let result = run_script_source(
+            &format!(
+                "LOAD \"{}\" \"{}\"\nHEX-REPORT \"{}\"\n",
+                left.display(),
+                right.display(),
+                report.display()
+            ),
+            ScriptExecutionContext::default(),
+        )
+        .expect("hex report runs");
+
+        assert_eq!(result.state.reports_written, 1);
+        assert_eq!(
+            result.state.last_compare,
+            Some(ScriptCompareSummary {
+                compared: 4,
+                different: 1,
+            })
+        );
+        let content = std::fs::read_to_string(&report).expect("report");
+        assert!(content.contains("HEX-REPORT"));
+        assert!(content.contains("changedRows: 1"));
+        assert!(content.contains("00000001\t42\t78"));
+        assert!(content.contains(&format!("left: {}", left.display())));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn hex_report_falls_back_to_compare_summary_after_folder_compare() {
+        let root = unique_temp_dir("script-hex-fallback");
+        let left_dir = root.join("left");
+        let right_dir = root.join("right");
+        let report = root.join("hex.txt");
+        std::fs::create_dir_all(&left_dir).expect("left dir");
+        std::fs::create_dir_all(&right_dir).expect("right dir");
+        std::fs::write(left_dir.join("a.txt"), "a").expect("left file");
+        std::fs::write(right_dir.join("a.txt"), "b").expect("right file");
+
+        let result = run_script_source(
+            &format!(
+                "LOAD \"{}\" \"{}\"\nCOMPARE\nHEX-REPORT \"{}\"\n",
+                left_dir.display(),
+                right_dir.display(),
+                report.display()
+            ),
+            ScriptExecutionContext::default(),
+        )
+        .expect("hex report after folder compare");
+
+        assert_eq!(result.state.reports_written, 1);
+        let content = std::fs::read_to_string(&report).expect("report");
+        assert!(content.contains("HEX-REPORT"));
+        assert!(content.contains("compared:"));
+        assert!(!content.contains("rows:"));
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/src/app/hexReport.test.ts
+++ b/src/app/hexReport.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildHexReportText,
+  defaultHexReportOutputPath,
+  formatHexReportOffset,
+  hexReportRowsFromDiffRanges,
+} from './hexReport'
+
+describe('hexReport', () => {
+  it('builds a sibling hex-compare.txt path from the left binary', () => {
+    expect(defaultHexReportOutputPath('C:/bin/left.bin')).toBe('C:/bin/hex-compare.txt')
+    expect(defaultHexReportOutputPath('/tmp/data/a.dat')).toBe('/tmp/data/hex-compare.txt')
+    expect(defaultHexReportOutputPath('')).toBe('hex-compare.txt')
+    expect(defaultHexReportOutputPath('solo.bin')).toBe('hex-compare.txt')
+  })
+
+  it('formats offsets and builds the clipboard/file payload', () => {
+    expect(formatHexReportOffset(1)).toBe('00000001')
+    expect(formatHexReportOffset(0x80000000)).toBe('80000000')
+
+    const text = buildHexReportText({
+      leftPath: 'C:/bin/left.bin',
+      rightPath: 'C:/bin/right.bin',
+      originalLen: 4,
+      modifiedLen: 4,
+      rows: [
+        { offset: 1, originalHex: '42', modifiedHex: '58' },
+        { offset: 3, originalHex: '44', modifiedHex: null },
+      ],
+    })
+
+    expect(text).toContain('HEX-REPORT')
+    expect(text).toContain('left: C:/bin/left.bin')
+    expect(text).toContain('changedRows: 2')
+    expect(text).toContain('00000001\t42\t58')
+    expect(text).toContain('00000003\t44\t--')
+  })
+
+  it('expands binary diff ranges into per-byte report rows', () => {
+    expect(
+      hexReportRowsFromDiffRanges([{ offset: 1, leftBytes: [0x42, 0x43], rightBytes: [0x58] }]),
+    ).toEqual([
+      { offset: 1, originalHex: '42', modifiedHex: '58' },
+      { offset: 2, originalHex: '43', modifiedHex: null },
+    ])
+  })
+})

--- a/src/app/hexReport.ts
+++ b/src/app/hexReport.ts
@@ -1,0 +1,89 @@
+export interface HexReportRowInput {
+  offset: number | string
+  originalHex?: string | null
+  modifiedHex?: string | null
+}
+
+export interface BuildHexReportTextInput {
+  leftPath: string
+  rightPath: string
+  originalLen: number
+  modifiedLen: number
+  rows: HexReportRowInput[]
+}
+
+/** Sibling text report path next to the left binary (matches picture export style). */
+export function defaultHexReportOutputPath(leftPath: string): string {
+  const trimmed = leftPath.trim()
+
+  if (!trimmed) {
+    return 'hex-compare.txt'
+  }
+
+  const slash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+
+  if (slash < 0) {
+    return 'hex-compare.txt'
+  }
+
+  return `${trimmed.slice(0, slash + 1)}hex-compare.txt`
+}
+
+export function formatHexReportOffset(offset: number | string): string {
+  const asNumber = typeof offset === 'number' ? offset : Number(offset)
+
+  if (!Number.isFinite(asNumber) || asNumber < 0) {
+    return String(offset)
+  }
+
+  return asNumber.toString(16).toUpperCase().padStart(8, '0')
+}
+
+export function buildHexReportText(input: BuildHexReportTextInput): string {
+  const lines = [
+    'HEX-REPORT',
+    `left: ${input.leftPath}`,
+    `right: ${input.rightPath}`,
+    `originalLen: ${String(input.originalLen)}`,
+    `modifiedLen: ${String(input.modifiedLen)}`,
+    `changedRows: ${String(input.rows.length)}`,
+    '',
+    'rows:',
+    ...input.rows.map((row) => {
+      const original = row.originalHex ?? '--'
+      const modified = row.modifiedHex ?? '--'
+
+      return `${formatHexReportOffset(row.offset)}\t${original}\t${modified}`
+    }),
+  ]
+
+  return `${lines.join('\n')}\n`
+}
+
+export function hexReportRowsFromDiffRanges(
+  ranges: { offset: number | string; leftBytes: number[]; rightBytes: number[] }[],
+): HexReportRowInput[] {
+  const rows: HexReportRowInput[] = []
+
+  for (const range of ranges) {
+    const base = typeof range.offset === 'number' ? range.offset : Number(range.offset)
+    const length = Math.max(range.leftBytes.length, range.rightBytes.length)
+
+    for (let index = 0; index < length; index += 1) {
+      const hasLeft = index < range.leftBytes.length
+      const hasRight = index < range.rightBytes.length
+
+      rows.push({
+        offset: (Number.isFinite(base) ? base : 0) + index,
+        originalHex: hasLeft
+          ? range.leftBytes[index].toString(16).toUpperCase().padStart(2, '0')
+          : null,
+        modifiedHex: hasRight
+          ? range.rightBytes[index].toString(16).toUpperCase().padStart(2, '0')
+          : null,
+      })
+    }
+  }
+
+  return rows
+}

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -284,6 +284,7 @@ export const deDE: LanguagePack = {
     'ui.picture': 'Bild',
     'ui.pictureCompare': 'Bildvergleich',
     'ui.pictureReport': 'Bildbericht',
+    'ui.hexReport': 'Hex-Bericht',
     'ui.port': 'Hafen',
     'ui.preview': 'Vorschau',
     'ui.previewSync': 'Vorschau-Synchronisierung',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -329,6 +329,7 @@ export const enUS: LanguagePack = {
     'ui.picture': 'Picture',
     'ui.pictureCompare': 'Picture Compare',
     'ui.pictureReport': 'Picture Report',
+    'ui.hexReport': 'Hex Report',
     'ui.pictureCompareInspector': 'Picture compare inspector',
     'ui.policy': 'Policy',
     'ui.port': 'Port',

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -280,6 +280,7 @@ export const esES: LanguagePack = {
     'ui.picture': 'Imagen',
     'ui.pictureCompare': 'Comparar imágenes',
     'ui.pictureReport': 'Informe de imagen',
+    'ui.hexReport': 'Informe hexadecimal',
     'ui.port': 'Puerto',
     'ui.preview': 'Avance',
     'ui.previewSync': 'Vista previa de sincronización',

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -280,6 +280,7 @@ export const frFR: LanguagePack = {
     'ui.picture': 'Image',
     'ui.pictureCompare': "Comparaison d'images",
     'ui.pictureReport': 'Rapport image',
+    'ui.hexReport': 'Rapport hexadécimal',
     'ui.port': 'Port',
     'ui.preview': 'Aperçu',
     'ui.previewSync': "Synchronisation de l'aperçu",

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -328,6 +328,7 @@ export const jaJP: LanguagePack = {
     'ui.picture': 'Picture',
     'ui.pictureCompare': 'Picture Compare',
     'ui.pictureReport': 'ピクチャレポート',
+    'ui.hexReport': 'Hex レポート',
     'ui.pictureCompareInspector': 'Picture compare inspector',
     'ui.policy': 'Policy',
     'ui.port': 'Port',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -271,6 +271,7 @@ export const koKR: LanguagePack = {
     'ui.picture': '그림',
     'ui.pictureCompare': '사진 비교',
     'ui.pictureReport': '그림 보고서',
+    'ui.hexReport': 'Hex 보고서',
     'ui.port': '포트',
     'ui.preview': '시사',
     'ui.previewSync': '미리보기 동기화',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -262,6 +262,7 @@ export const zhCN: LanguagePack = {
     'ui.picture': '图片',
     'ui.pictureCompare': '图片比较',
     'ui.pictureReport': '图片报告',
+    'ui.hexReport': '十六进制报告',
     'ui.port': '端口',
     'ui.preview': '预览',
     'ui.previewSync': '预览同步',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -263,6 +263,7 @@ export const zhTW: LanguagePack = {
     'ui.picture': '圖片',
     'ui.pictureCompare': '圖片比較',
     'ui.pictureReport': '圖片報告',
+    'ui.hexReport': '十六進位報告',
     'ui.port': '連接埠',
     'ui.preview': '預覽',
     'ui.previewSync': '預覽同步',

--- a/src/views/HexCompareView.test.ts
+++ b/src/views/HexCompareView.test.ts
@@ -2,10 +2,11 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import HexCompareView from './HexCompareView.vue'
-import { compareHexFiles, findHexInFile, saveHexEdits } from '@/api/diff'
+import { compareHexFiles, findHexInFile, saveHexEdits, saveTextFile } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 
 const push = vi.fn()
+const clipboardWriteText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push }),
@@ -45,6 +46,7 @@ vi.mock('@/api/diff', () => ({
     { offset: 512, length: 2 },
   ]),
   saveHexEdits: vi.fn().mockResolvedValue({ bytesWritten: 1 }),
+  saveTextFile: vi.fn().mockResolvedValue({ bytesWritten: 12 }),
 }))
 
 async function runCompare(wrapper: ReturnType<typeof mount>): Promise<void> {
@@ -60,6 +62,14 @@ describe('HexCompareView', () => {
     vi.mocked(compareHexFiles).mockClear()
     vi.mocked(findHexInFile).mockClear()
     vi.mocked(saveHexEdits).mockClear()
+    vi.mocked(saveTextFile).mockClear()
+    clipboardWriteText.mockClear()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteText,
+      },
+    })
   })
 
   it('starts empty without a demo hex dump', () => {
@@ -287,5 +297,55 @@ describe('HexCompareView', () => {
 
     expect(wrapper.findAll('[data-testid="hex-row"]')).toHaveLength(1)
     expect(wrapper.find('[data-testid="left-hex-byte-diff-00000001"]').text()).toBe('42')
+  })
+
+  it('selects a byte and copies it from the session toolbar', async () => {
+    const wrapper = mount(HexCompareView)
+
+    await runCompare(wrapper)
+    expect(
+      wrapper.find('[data-testid="hex-session-toolbar-copy"]').attributes('disabled'),
+    ).toBeDefined()
+
+    await wrapper.find('[data-testid="left-hex-byte-diff-00000001"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(
+      (wrapper.find('[data-testid="hex-edit-offset"]').element as HTMLInputElement).value,
+    ).toBe('1')
+    expect((wrapper.find('[data-testid="hex-edit-value"]').element as HTMLInputElement).value).toBe(
+      '42',
+    )
+    expect(
+      wrapper.find('[data-testid="hex-session-toolbar-copy"]').attributes('disabled'),
+    ).toBeUndefined()
+
+    await wrapper.find('[data-testid="hex-session-toolbar-copy"]').trigger('click')
+    await flushPromises()
+
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('42'))
+    expect(wrapper.find('[data-testid="hex-copy-status"]').exists()).toBe(true)
+  })
+
+  it('exports a hex report to clipboard and disk', async () => {
+    const wrapper = mount(HexCompareView)
+
+    await runCompare(wrapper)
+    expect(wrapper.find('[data-testid="hex-report-panel"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="export-hex-report"]').trigger('click')
+    await flushPromises()
+
+    expect(clipboardWriteText).toHaveBeenCalled()
+    const payload = clipboardWriteText.mock.calls[0]?.[0] ?? ''
+
+    expect(payload).toContain('HEX-REPORT')
+    expect(payload).toContain('00000001\t42\t58')
+    expect(saveTextFile).toHaveBeenCalledWith({
+      path: 'C:/bin/hex-compare.txt',
+      text: payload,
+      createBackup: false,
+    })
+    expect(wrapper.find('[data-testid="hex-report-status"]').text()).toBe('C:/bin/hex-compare.txt')
   })
 })

--- a/src/views/HexCompareView.vue
+++ b/src/views/HexCompareView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { compareHexFiles, findHexInFile, saveHexEdits } from '@/api/diff'
+import { compareHexFiles, findHexInFile, saveHexEdits, saveTextFile } from '@/api/diff'
 import type {
   HexByteEdit,
   HexCompareResponse,
@@ -30,6 +30,12 @@ import {
   saveHexCompareSessionOptions,
   type HexCompareSessionOptions,
 } from '@/app/hexCompareSessionOptions'
+import {
+  buildHexReportText,
+  defaultHexReportOutputPath,
+  hexReportRowsFromDiffRanges,
+} from '@/app/hexReport'
+import { useI18n } from '@/i18n'
 
 interface HexRow {
   offset: string
@@ -75,6 +81,10 @@ const findStatus = ref('')
 const pendingEdits = ref<HexByteEdit[]>([])
 const editOffset = ref(0)
 const editValue = ref('00')
+const selectedByteOffset = ref<number | null>(null)
+const selectedByteSide = ref<'left' | 'right'>('left')
+const copyStatus = ref('')
+const reportStatus = ref('')
 const saveStatus = ref('')
 const loading = ref(false)
 const error = ref('')
@@ -82,6 +92,7 @@ const sessionLaunch = useSessionLaunchStore()
 const tabs = useTabsStore()
 const settings = useSettingsStore()
 const router = useRouter()
+const { t } = useI18n()
 const bytesPerRow = computed(() => (viewportWidth.value < 480 ? 8 : 16))
 
 const leftHex = computed<HexSideRows>(() =>
@@ -181,15 +192,19 @@ watch(
       case 'save':
         void runHexSave()
         break
+      case 'copy':
+        void copySelectedHexByte()
+        break
+      case 'export':
+        void exportHexReport()
+        break
       case 'about':
       case 'check-for-updates':
       case 'close-tab':
-      case 'copy':
       case 'copy-left':
       case 'copy-right':
       case 'cut':
       case 'delete':
-      case 'export':
       case 'export-settings':
       case 'help-contents':
       case 'help-support':
@@ -341,7 +356,7 @@ const hexSessionToolbar = computed(() =>
     diffs: true,
     same: false,
     rules: true,
-    copy: false,
+    copy: selectedByteOffset.value !== null,
     'next-diff': navigationRanges.value.length > 0,
     'prev-diff': navigationRanges.value.length > 0,
     swap: Boolean(leftPath.value || rightPath.value),
@@ -362,6 +377,9 @@ function runHexToolbarCommand(commandId: string): void {
       break
     case 'rules':
       openHexSessionSettings()
+      break
+    case 'copy':
+      void copySelectedHexByte()
       break
     case 'next-diff':
       goToHexDiffRange(activeDiffRangeIndex.value + 1)
@@ -513,6 +531,80 @@ function goToFindMatch(delta: number): void {
   const next = (current + delta + findMatches.value.length) % findMatches.value.length
 
   void jumpToFindMatch(next)
+}
+
+function selectHexByte(side: 'left' | 'right', cell: HexViewCell): void {
+  const offset = numericOffset(cell.offset)
+
+  selectedByteOffset.value = offset
+  selectedByteSide.value = side
+  editOffset.value = offset
+  editValue.value = cell.hex
+  copyStatus.value = ''
+}
+
+function selectedHexCell(): HexViewCell | undefined {
+  if (selectedByteOffset.value === null) {
+    return undefined
+  }
+
+  const cells = selectedByteSide.value === 'left' ? leftCells.value : rightCells.value
+
+  return cells.find((cell) => numericOffset(cell.offset) === selectedByteOffset.value)
+}
+
+function formatSelectedHexClipboardPayload(cell: HexViewCell): string {
+  return `${formatOffset(cell.offset)}\t${cell.hex}\t${cell.ascii}`
+}
+
+async function copySelectedHexByte(): Promise<void> {
+  const cell = selectedHexCell()
+
+  if (!cell) {
+    return
+  }
+
+  const payload = formatSelectedHexClipboardPayload(cell)
+
+  try {
+    await navigator.clipboard.writeText(payload)
+    copyStatus.value = t('status.copiedPath', { path: payload })
+  } catch (event) {
+    error.value = String(event)
+  }
+}
+
+async function exportHexReport(): Promise<void> {
+  if (!leftPath.value || !rightPath.value) {
+    return
+  }
+
+  const rows = hexReportRowsFromDiffRanges(diffRanges.value)
+  const payload = buildHexReportText({
+    leftPath: leftPath.value,
+    rightPath: rightPath.value,
+    originalLen: leftTotalLen.value,
+    modifiedLen: rightTotalLen.value,
+    rows,
+  })
+  const outputPath = defaultHexReportOutputPath(leftPath.value)
+
+  try {
+    await navigator.clipboard.writeText(payload)
+  } catch {
+    // Clipboard may be unavailable in headless tests; still try file export.
+  }
+
+  try {
+    await saveTextFile({
+      path: outputPath,
+      text: payload,
+      createBackup: false,
+    })
+    reportStatus.value = outputPath
+  } catch (event) {
+    error.value = String(event)
+  }
 }
 
 function queueHexEdit(): void {
@@ -789,6 +881,35 @@ async function runHexSave(): Promise<void> {
         {{ $t('ui.emptyCompareHint') }}
       </p>
 
+      <section
+        v-if="leftPath && rightPath"
+        class="hex-report-panel"
+        data-testid="hex-report-panel"
+      >
+        <header>
+          <strong>{{ $t('ui.hexReport') }}</strong>
+          <span>{{ $t('status.fieldCount', { count: diffRanges.length }) }}</span>
+          <button
+            type="button"
+            data-testid="export-hex-report"
+            :disabled="!leftPath || !rightPath"
+            @click="exportHexReport"
+          >
+            {{ $t('ui.export') }}
+          </button>
+          <span
+            v-if="reportStatus"
+            data-testid="hex-report-status"
+            >{{ reportStatus }}</span
+          >
+          <span
+            v-if="copyStatus"
+            data-testid="hex-copy-status"
+            >{{ copyStatus }}</span
+          >
+        </header>
+      </section>
+
       <section class="hex-pane-grid">
         <section class="hex-side">
           <h2>{{ $t('ui.left') }} · {{ leftHex.path }}</h2>
@@ -814,17 +935,26 @@ async function runHexSave(): Promise<void> {
                 class="hex-bytes"
                 data-testid="hex-byte-pane"
               >
-                <span
+                <button
                   v-for="cell in pair.left?.cells ?? []"
                   :key="cell.offset"
+                  type="button"
                   class="hex-byte"
-                  :class="{ 'hex-byte-different': cell.different }"
+                  :class="{
+                    'hex-byte-different': cell.different,
+                    'hex-byte-selected':
+                      selectedByteOffset === numericOffset(cell.offset) &&
+                      selectedByteSide === 'left',
+                  }"
                   :data-testid="
-                    cell.different ? `left-hex-byte-diff-${formatOffset(cell.offset)}` : undefined
+                    cell.different
+                      ? `left-hex-byte-diff-${formatOffset(cell.offset)}`
+                      : `left-hex-byte-${formatOffset(cell.offset)}`
                   "
+                  @click="selectHexByte('left', cell)"
                 >
                   {{ cell.hex }}
-                </span>
+                </button>
               </span>
               <span
                 class="hex-ascii"
@@ -851,17 +981,26 @@ async function runHexSave(): Promise<void> {
             >
               <span class="hex-offset">{{ pair.right?.offset ?? pair.left?.offset }}</span>
               <span class="hex-bytes">
-                <span
+                <button
                   v-for="cell in pair.right?.cells ?? []"
                   :key="cell.offset"
+                  type="button"
                   class="hex-byte"
-                  :class="{ 'hex-byte-different': cell.different }"
+                  :class="{
+                    'hex-byte-different': cell.different,
+                    'hex-byte-selected':
+                      selectedByteOffset === numericOffset(cell.offset) &&
+                      selectedByteSide === 'right',
+                  }"
                   :data-testid="
-                    cell.different ? `right-hex-byte-diff-${formatOffset(cell.offset)}` : undefined
+                    cell.different
+                      ? `right-hex-byte-diff-${formatOffset(cell.offset)}`
+                      : `right-hex-byte-${formatOffset(cell.offset)}`
                   "
+                  @click="selectHexByte('right', cell)"
                 >
                   {{ cell.hex }}
-                </span>
+                </button>
               </span>
               <span class="hex-ascii">{{ pair.right?.ascii ?? '' }}</span>
             </div>
@@ -1146,8 +1285,35 @@ h2 {
   display: inline-flex;
   justify-content: center;
   width: 22px;
-  margin-right: 6px;
+  padding: 0 0.15rem;
+  border: 1px solid transparent;
   border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  margin-right: 6px;
+}
+
+.hex-byte-selected {
+  border-color: var(--accent, #3b82f6);
+  background: color-mix(in srgb, var(--accent, #3b82f6) 22%, transparent);
+}
+
+.hex-report-panel {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0.75rem 0;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border, #d0d7de);
+  border-radius: 0.4rem;
+}
+
+.hex-report-panel header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .hex-byte-different {


### PR DESCRIPTION
## Summary
- Script `HEX-REPORT` writes real per-byte rows through `hex-core::build_hex_report` when LOAD paths are files (folder COMPARE still falls back to the summary stub).
- Hex Compare: click a byte to select it, enable toolbar Copy to clipboard (`offset\thex\tascii`), and export a session Hex Report to clipboard plus sibling `hex-compare.txt`.

Based on `origin/master` (`057048c`, #94). Avoids snapshot / Text Edit wrap / FolderCompare snapshot-chip files still open in #95.

## Test plan
- [x] `vitest run src/app/hexReport.test.ts src/views/HexCompareView.test.ts` (17 passed)
- [x] `vitest run src/i18n/locales/languageSkeletons.test.ts` (with the above)
- [x] `cargo test -p script-core --lib hex_report` (2 passed)
- [x] pre-commit quality (prettier/eslint/stylelint/typecheck/clippy)
- [ ] Manual: Hex Compare a pair with diffs, click a byte, Copy, then Export and open `hex-compare.txt`
- [ ] Manual: script `LOAD a.bin b.bin` / `HEX-REPORT out.txt` lists changed offsets