### PR TITLE
Save Version and Table reports to disk

### DIFF
--- a/src/app/tableReport.test.ts
+++ b/src/app/tableReport.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { buildTableReportText, defaultTableReportOutputPath } from './tableReport'
+
+describe('tableReport', () => {
+  it('builds a sibling table-compare.txt path from the left table', () => {
+    expect(defaultTableReportOutputPath('C:/data/left.csv')).toBe('C:/data/table-compare.txt')
+    expect(defaultTableReportOutputPath('/tmp/sheets/a.xlsx')).toBe('/tmp/sheets/table-compare.txt')
+    expect(defaultTableReportOutputPath('')).toBe('table-compare.txt')
+    expect(defaultTableReportOutputPath('solo.csv')).toBe('table-compare.txt')
+  })
+
+  it('builds the clipboard/file TABLE-REPORT payload', () => {
+    const text = buildTableReportText({
+      leftPath: 'C:/data/left.csv',
+      rightPath: 'C:/data/right.csv',
+      format: 'csv',
+      keyColumns: '0',
+      ignoredColumns: ['notes'],
+      rowCount: 2,
+      differenceCount: 1,
+      differences: [{ key: 'row-1-quantity', text: '12 -> 14' }],
+    })
+
+    expect(text).toContain('TABLE-REPORT')
+    expect(text).toContain('left: C:/data/left.csv')
+    expect(text).toContain('keyColumns: 0')
+    expect(text).toContain('ignoredColumns: notes')
+    expect(text).toContain('differenceCells: 1')
+    expect(text).toContain('row-1-quantity\t12 -> 14')
+  })
+})

--- a/src/app/tableReport.ts
+++ b/src/app/tableReport.ts
@@ -1,0 +1,51 @@
+export interface TableReportDifferenceRow {
+  key: string
+  text: string
+}
+
+export interface BuildTableReportTextInput {
+  leftPath: string
+  rightPath: string
+  format: string
+  keyColumns: string
+  ignoredColumns: string[]
+  rowCount: number
+  differenceCount: number
+  differences: TableReportDifferenceRow[]
+}
+
+/** Sibling text report path next to the left table (matches picture/version export style). */
+export function defaultTableReportOutputPath(leftPath: string): string {
+  const trimmed = leftPath.trim()
+
+  if (!trimmed) {
+    return 'table-compare.txt'
+  }
+
+  const slash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+
+  if (slash < 0) {
+    return 'table-compare.txt'
+  }
+
+  return `${trimmed.slice(0, slash + 1)}table-compare.txt`
+}
+
+export function buildTableReportText(input: BuildTableReportTextInput): string {
+  const ignored = input.ignoredColumns.length > 0 ? input.ignoredColumns.join(',') : '--'
+  const lines = [
+    'TABLE-REPORT',
+    `left: ${input.leftPath || '--'}`,
+    `right: ${input.rightPath || '--'}`,
+    `format: ${input.format}`,
+    `keyColumns: ${input.keyColumns}`,
+    `ignoredColumns: ${ignored}`,
+    `rowCount: ${String(input.rowCount)}`,
+    `differenceCells: ${String(input.differenceCount)}`,
+    '',
+    'differences:',
+    ...input.differences.map((row) => `${row.key}\t${row.text}`),
+  ]
+
+  return lines.join('\n')
+}

--- a/src/app/versionReport.test.ts
+++ b/src/app/versionReport.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { buildVersionReportText, defaultVersionReportOutputPath } from './versionReport'
+
+describe('versionReport', () => {
+  it('builds a sibling version-compare.txt path from the left binary', () => {
+    expect(defaultVersionReportOutputPath('C:/apps/left.exe')).toBe('C:/apps/version-compare.txt')
+    expect(defaultVersionReportOutputPath('/opt/bin/a.so')).toBe('/opt/bin/version-compare.txt')
+    expect(defaultVersionReportOutputPath('')).toBe('version-compare.txt')
+    expect(defaultVersionReportOutputPath('solo.exe')).toBe('version-compare.txt')
+  })
+
+  it('builds the clipboard/file VERSION-REPORT payload', () => {
+    const text = buildVersionReportText({
+      leftPath: 'C:/apps/left.exe',
+      rightPath: 'C:/apps/right.exe',
+      summary: { added: 0, removed: 0, modified: 1, unchanged: 1 },
+      fields: [
+        {
+          group: 'Fixed Info',
+          field: 'FileVersion',
+          left: '1.0.0.0',
+          right: '1.1.0.0',
+          status: 'modified',
+          important: true,
+        },
+        {
+          group: 'String Info',
+          field: 'Comments',
+          left: 'alpha',
+          right: 'beta',
+          status: 'modified',
+          important: false,
+        },
+      ],
+    })
+
+    expect(text).toContain('VERSION-REPORT')
+    expect(text).toContain('left: C:/apps/left.exe')
+    expect(text).toContain('modified: 1')
+    expect(text).toContain('Fixed Info\tFileVersion\t1.0.0.0\t1.1.0.0\tmodified\timportant')
+    expect(text).toContain('String Info\tComments\talpha\tbeta\tmodified\tunimportant')
+  })
+})

--- a/src/app/versionReport.ts
+++ b/src/app/versionReport.ts
@@ -1,0 +1,59 @@
+export interface VersionReportFieldRow {
+  group: string
+  field: string
+  left: string
+  right: string
+  status: string
+  important: boolean
+}
+
+export interface VersionReportSummary {
+  added: number
+  removed: number
+  modified: number
+  unchanged: number
+}
+
+export interface BuildVersionReportTextInput {
+  leftPath: string
+  rightPath: string
+  summary: VersionReportSummary
+  fields: VersionReportFieldRow[]
+}
+
+/** Sibling text report path next to the left binary (matches picture export style). */
+export function defaultVersionReportOutputPath(leftPath: string): string {
+  const trimmed = leftPath.trim()
+
+  if (!trimmed) {
+    return 'version-compare.txt'
+  }
+
+  const slash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+
+  if (slash < 0) {
+    return 'version-compare.txt'
+  }
+
+  return `${trimmed.slice(0, slash + 1)}version-compare.txt`
+}
+
+export function buildVersionReportText(input: BuildVersionReportTextInput): string {
+  const lines = [
+    'VERSION-REPORT',
+    `left: ${input.leftPath}`,
+    `right: ${input.rightPath}`,
+    `added: ${String(input.summary.added)}`,
+    `removed: ${String(input.summary.removed)}`,
+    `modified: ${String(input.summary.modified)}`,
+    `unchanged: ${String(input.summary.unchanged)}`,
+    '',
+    'fields:',
+    ...input.fields.map(
+      (row) =>
+        `${row.group}\t${row.field}\t${row.left}\t${row.right}\t${row.status}\t${row.important ? 'important' : 'unimportant'}`,
+    ),
+  ]
+
+  return lines.join('\n')
+}

--- a/src/views/TableCompareView.test.ts
+++ b/src/views/TableCompareView.test.ts
@@ -2,7 +2,7 @@ import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import TableCompareView from './TableCompareView.vue'
-import { compareTable, readTextFile } from '@/api/diff'
+import { compareTable, readTextFile, saveTextFile } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import type { TableCompareRequest } from '@/types/diff'
 
@@ -10,7 +10,13 @@ vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 
+const clipboardWriteText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+
 vi.mock('@/api/diff', () => ({
+  saveTextFile: vi.fn().mockResolvedValue({
+    path: 'C:/data/table-compare.txt',
+    bytesWritten: 48,
+  }),
   compareTable: vi.fn().mockResolvedValue({
     leftColumns: [
       { side: 'left', name: 'SKU' },
@@ -131,6 +137,14 @@ describe('TableCompareView', () => {
         fileStamp: { size: 20, modifiedAtMs: 1 },
       }),
     )
+    vi.mocked(saveTextFile).mockClear()
+    clipboardWriteText.mockClear()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteText,
+      },
+    })
   })
 
   it('starts empty without a demo grid or sample CSV', () => {
@@ -512,5 +526,31 @@ describe('TableCompareView', () => {
 
     expect(request?.keyColumnIndices).toEqual([0, 1])
     expect(request?.ignoredColumns).toContain('Quantity')
+  })
+
+  it('exports the table report to clipboard and a sibling text file', async () => {
+    const wrapper = mountTableCompareView()
+
+    await wrapper.find('[data-testid="table-left-path"]').setValue('C:/data/left.csv')
+    await wrapper.find('[data-testid="table-right-path"]').setValue('C:/data/right.csv')
+    await wrapper.find('[data-testid="run-table-compare"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('[data-testid="export-table-report"]').trigger('click')
+    await flushPromises()
+
+    expect(clipboardWriteText).toHaveBeenCalled()
+    const payload = clipboardWriteText.mock.calls[0]?.[0] ?? ''
+
+    expect(payload).toContain('TABLE-REPORT')
+    expect(payload).toContain('left: C:/data/left.csv')
+    expect(saveTextFile).toHaveBeenCalledWith({
+      path: 'C:/data/table-compare.txt',
+      text: payload,
+      createBackup: false,
+    })
+    expect(wrapper.find('[data-testid="table-report-status"]').text()).toBe(
+      'C:/data/table-compare.txt',
+    )
   })
 })

--- a/src/views/TableCompareView.vue
+++ b/src/views/TableCompareView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { compareTable, readTextFile } from '@/api/diff'
+import { compareTable, readTextFile, saveTextFile } from '@/api/diff'
+import { buildTableReportText, defaultTableReportOutputPath } from '@/app/tableReport'
 import type {
   TableCompareChangedCell,
   TableCompareRequest,
@@ -95,6 +96,7 @@ const tableSearchQuery = ref('')
 const activeDifferenceIndex = ref(0)
 const loading = ref(false)
 const error = ref('')
+const reportStatus = ref('')
 const tableDifferenceCells = ref<TableCellLocation[]>([])
 
 function currentTableSessionOptions(): TableCompareSessionOptions {
@@ -185,6 +187,8 @@ watch(
       case 'cut':
       case 'delete':
       case 'export':
+        void exportTableReport()
+        break
       case 'export-settings':
       case 'filters':
       case 'help-contents':
@@ -539,6 +543,7 @@ async function runTableCompare(): Promise<void> {
     virtualGridColumns.value = columns
     comparedRows.value = rowsFromResult(result, columns)
     tableDifferenceCells.value = changedCellsFromResult(result.changedCells, columns)
+    reportStatus.value = ''
     activeDifferenceIndex.value = 0
     manualLeftColumn.value = result.leftColumns[0]?.name ?? ''
     manualRightColumn.value = result.rightColumns[0]?.name ?? ''
@@ -634,6 +639,44 @@ function syncTableTabTitle(): void {
   }
 
   tabs.setTabTitle('/compare/table', pathPairTitle(leftPath.value, rightPath.value))
+}
+
+async function exportTableReport(): Promise<void> {
+  if (comparedRows.value === null) {
+    return
+  }
+
+  const payload = buildTableReportText({
+    leftPath: leftPath.value,
+    rightPath: rightPath.value,
+    format: tableFormat.value,
+    keyColumns: keyColumnsInput.value,
+    ignoredColumns: [...ignoredColumnKeys.value],
+    rowCount: comparedRows.value.length,
+    differenceCount: tableDifferenceCells.value.length,
+    differences: tableDifferenceCells.value.map((cell) => ({
+      key: cell.key,
+      text: cell.text,
+    })),
+  })
+  const outputPath = defaultTableReportOutputPath(leftPath.value)
+
+  try {
+    await navigator.clipboard.writeText(payload)
+  } catch {
+    // Clipboard may be unavailable in headless tests; still try file export.
+  }
+
+  try {
+    await saveTextFile({
+      path: outputPath,
+      text: payload,
+      createBackup: false,
+    })
+    reportStatus.value = outputPath
+  } catch (event) {
+    error.value = String(event)
+  }
 }
 
 function goHomeFromTable(): void {
@@ -732,6 +775,21 @@ watch([leftPath, rightPath], () => {
         <div class="table-summary">
           <strong>{{ columnMappings.length }}</strong>
           <span>{{ $t('ui.columnMappings') }}</span>
+        </div>
+        <div class="table-summary table-report-actions">
+          <NButton
+            size="small"
+            data-testid="export-table-report"
+            :disabled="comparedRows === null"
+            @click="exportTableReport"
+          >
+            {{ $t('ui.export') }}
+          </NButton>
+          <span
+            v-if="reportStatus"
+            data-testid="table-report-status"
+            >{{ reportStatus }}</span
+          >
         </div>
         <div
           v-if="showSheetSelectors"
@@ -1167,6 +1225,12 @@ h2 {
   border-radius: 8px;
   background: var(--app-surface);
   text-align: right;
+}
+
+.table-report-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .table-summary strong {

--- a/src/views/VersionCompareView.test.ts
+++ b/src/views/VersionCompareView.test.ts
@@ -2,15 +2,21 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import VersionCompareView from './VersionCompareView.vue'
-import { compareVersionFiles } from '@/api/diff'
+import { compareVersionFiles, saveTextFile } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
+
+const clipboardWriteText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 
 vi.mock('@/api/diff', () => ({
+  saveTextFile: vi.fn().mockResolvedValue({
+    path: 'C:/apps/version-compare.txt',
+    bytesWritten: 64,
+  }),
   compareVersionFiles: vi.fn().mockResolvedValue({
     left: {
       name: 'fixture-left.exe',
@@ -63,6 +69,14 @@ describe('VersionCompareView', () => {
     setActivePinia(createPinia())
     localStorage.clear()
     vi.mocked(compareVersionFiles).mockClear()
+    vi.mocked(saveTextFile).mockClear()
+    clipboardWriteText.mockClear()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteText,
+      },
+    })
   })
 
   it('runs a real version comparison request and renders returned fields', async () => {
@@ -215,4 +229,32 @@ it('opens rules catalog before compare', async () => {
   expect(wrapper.find('[data-testid="version-rules-panel"]').exists()).toBe(true)
   expect(wrapper.find('[data-testid="version-rule-FileVersion"]').exists()).toBe(true)
   expect(wrapper.find('[data-testid="version-rule-Comments"]').exists()).toBe(true)
+})
+
+it('exports the version report to clipboard and a sibling text file', async () => {
+  const wrapper = mount(VersionCompareView)
+
+  await wrapper.find('[data-testid="version-left-path"]').setValue('C:/apps/fixture-left.exe')
+  await wrapper.find('[data-testid="version-right-path"]').setValue('C:/apps/fixture-right.exe')
+  await wrapper.find('[data-testid="run-version-compare"]').trigger('click')
+  await wrapper.vm.$nextTick()
+
+  await wrapper.find('[data-testid="export-version-report"]').trigger('click')
+  await wrapper.vm.$nextTick()
+  await Promise.resolve()
+
+  expect(clipboardWriteText).toHaveBeenCalled()
+  const payload = clipboardWriteText.mock.calls[0]?.[0] ?? ''
+
+  expect(payload).toContain('VERSION-REPORT')
+  expect(payload).toContain('left: C:/apps/fixture-left.exe')
+  expect(payload).toContain('FileVersion')
+  expect(saveTextFile).toHaveBeenCalledWith({
+    path: 'C:/apps/version-compare.txt',
+    text: payload,
+    createBackup: false,
+  })
+  expect(wrapper.find('[data-testid="version-report-status"]').text()).toBe(
+    'C:/apps/version-compare.txt',
+  )
 })

--- a/src/views/VersionCompareView.vue
+++ b/src/views/VersionCompareView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { compareVersionFiles } from '@/api/diff'
+import { compareVersionFiles, saveTextFile } from '@/api/diff'
+import { buildVersionReportText, defaultVersionReportOutputPath } from '@/app/versionReport'
 import { useI18n } from '@/i18n'
 import type {
   VersionCompareResponse,
@@ -47,6 +48,7 @@ const fieldFilter = ref<VersionFieldFilter>('all')
 const activeFieldIndex = ref(0)
 const loading = ref(false)
 const error = ref('')
+const reportStatus = ref('')
 const showVersionRules = ref(false)
 const versionOptions = ref<VersionCompareOptionsState>(loadVersionCompareOptions())
 
@@ -242,6 +244,7 @@ function applyVersionResult(result: VersionCompareResponse): void {
   versionFields.value = result.fields
   versionSummaryOverride.value = result.summary
   activeFieldIndex.value = 0
+  reportStatus.value = ''
   syncVersionTabTitle()
 }
 
@@ -257,6 +260,44 @@ function toggleFieldImportance(field: string): void {
 function resetVersionRules(): void {
   versionOptions.value = resetVersionCompareOptions()
   persistVersionOptions()
+}
+
+async function exportVersionReport(): Promise<void> {
+  if (versionFields.value.length === 0) {
+    return
+  }
+
+  const payload = buildVersionReportText({
+    leftPath: leftPath.value,
+    rightPath: rightPath.value,
+    summary: versionSummary.value,
+    fields: versionFields.value.map((row) => ({
+      group: row.group,
+      field: row.field,
+      left: valueText(row.left),
+      right: valueText(row.right),
+      status: row.status,
+      important: fieldIsImportant(row.field),
+    })),
+  })
+  const outputPath = defaultVersionReportOutputPath(leftPath.value)
+
+  try {
+    await navigator.clipboard.writeText(payload)
+  } catch {
+    // Clipboard may be unavailable in headless tests; still try file export.
+  }
+
+  try {
+    await saveTextFile({
+      path: outputPath,
+      text: payload,
+      createBackup: false,
+    })
+    reportStatus.value = outputPath
+  } catch (event) {
+    error.value = String(event)
+  }
 }
 
 async function runVersionCompare(): Promise<void> {
@@ -402,6 +443,19 @@ async function runVersionCompare(): Promise<void> {
       <header>
         <strong>{{ $t('ui.versionFieldReport') }}</strong>
         <span>{{ $t('status.fieldCount', { count: versionFields.length }) }}</span>
+        <button
+          type="button"
+          data-testid="export-version-report"
+          :disabled="versionFields.length === 0"
+          @click="exportVersionReport"
+        >
+          {{ $t('ui.export') }}
+        </button>
+        <span
+          v-if="reportStatus"
+          data-testid="version-report-status"
+          >{{ reportStatus }}</span
+        >
       </header>
       <div
         class="version-report-table"
@@ -621,6 +675,10 @@ h1 {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+.version-report-panel header button {
+  margin-left: auto;
 }
 
 .version-side dl {


### PR DESCRIPTION
## Summary
- Version Compare builds a VERSION-REPORT text payload, copies it to the clipboard, and writes a sibling `version-compare.txt` next to the left path (same pattern as Picture export).
- Table Compare wires the previously no-op Session Export action the same way for TABLE-REPORT, with an Export control on the session header.
- Shared helpers live in `versionReport` / `tableReport` with unit coverage; views cover the save path.

Based on `origin/master` (`4714369`, #95). PR #96 is still open, so this avoids HexCompareView / hexReport / script HEX-REPORT files.

## Test plan
- [x] `vitest run` versionReport + tableReport + VersionCompareView + TableCompareView (26 passed)
- [x] Full unit suite via pre-commit (`544` passed earlier in session)
- [x] eslint / stylelint / prettier / `vue-tsc` / rustfmt / clippy (pre-commit hook)
- [ ] Do not merge until reviewed; leave open