### PR TITLE
Save Registry reports and add Folder Sync Peek chrome

### DIFF
--- a/src/app/registryReport.test.ts
+++ b/src/app/registryReport.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { buildRegistryReportText, defaultRegistryReportOutputPath } from './registryReport'
+
+describe('registryReport', () => {
+  it('builds a sibling registry-compare.txt path from the left export', () => {
+    expect(defaultRegistryReportOutputPath('C:/regs/left.reg')).toBe('C:/regs/registry-compare.txt')
+    expect(defaultRegistryReportOutputPath('/tmp/exports/a.reg')).toBe(
+      '/tmp/exports/registry-compare.txt',
+    )
+    expect(defaultRegistryReportOutputPath('')).toBe('registry-compare.txt')
+    expect(defaultRegistryReportOutputPath('solo.reg')).toBe('registry-compare.txt')
+  })
+
+  it('builds the clipboard/file REGISTRY-REPORT payload', () => {
+    const text = buildRegistryReportText({
+      leftPath: 'C:/regs/left.reg',
+      rightPath: 'C:/regs/right.reg',
+      summary: { added: 0, removed: 0, modified: 1, unchanged: 1 },
+      values: [
+        {
+          keyPath: 'HKCU/Software/OpenDiff',
+          name: 'Theme',
+          left: 'REG_SZ dark',
+          right: 'REG_SZ light',
+          status: 'modified',
+        },
+        {
+          keyPath: 'HKCU/Software/OpenDiff',
+          name: 'Locale',
+          left: 'REG_SZ en',
+          right: 'REG_SZ en',
+          status: 'unchanged',
+        },
+      ],
+    })
+
+    expect(text).toContain('REGISTRY-REPORT')
+    expect(text).toContain('left: C:/regs/left.reg')
+    expect(text).toContain('modified: 1')
+    expect(text).toContain('HKCU/Software/OpenDiff\tTheme\tREG_SZ dark\tREG_SZ light\tmodified')
+    expect(text).toContain('HKCU/Software/OpenDiff\tLocale\tREG_SZ en\tREG_SZ en\tunchanged')
+  })
+})

--- a/src/app/registryReport.ts
+++ b/src/app/registryReport.ts
@@ -1,0 +1,57 @@
+export interface RegistryReportValueRow {
+  keyPath: string
+  name: string
+  left: string
+  right: string
+  status: string
+}
+
+export interface RegistryReportSummary {
+  added: number
+  removed: number
+  modified: number
+  unchanged: number
+}
+
+export interface BuildRegistryReportTextInput {
+  leftPath: string
+  rightPath: string
+  summary: RegistryReportSummary
+  values: RegistryReportValueRow[]
+}
+
+/** Sibling text report path next to the left export (matches picture/hex export style). */
+export function defaultRegistryReportOutputPath(leftPath: string): string {
+  const trimmed = leftPath.trim()
+
+  if (!trimmed) {
+    return 'registry-compare.txt'
+  }
+
+  const slash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+
+  if (slash < 0) {
+    return 'registry-compare.txt'
+  }
+
+  return `${trimmed.slice(0, slash + 1)}registry-compare.txt`
+}
+
+export function buildRegistryReportText(input: BuildRegistryReportTextInput): string {
+  const lines = [
+    'REGISTRY-REPORT',
+    `left: ${input.leftPath}`,
+    `right: ${input.rightPath}`,
+    `added: ${String(input.summary.added)}`,
+    `removed: ${String(input.summary.removed)}`,
+    `modified: ${String(input.summary.modified)}`,
+    `unchanged: ${String(input.summary.unchanged)}`,
+    '',
+    'values:',
+    ...input.values.map(
+      (row) => `${row.keyPath}\t${row.name}\t${row.left}\t${row.right}\t${row.status}`,
+    ),
+  ]
+
+  return `${lines.join('\n')}\n`
+}

--- a/src/app/sessionToolbars.test.ts
+++ b/src/app/sessionToolbars.test.ts
@@ -163,7 +163,7 @@ describe('sessionToolbars', () => {
     expect(toolbar.find((item) => item.id === 'prev-section')?.enabled).toBe(false)
   })
 
-  it('keeps Folder Sync toolbar chrome for expand/collapse/select/filters/home', () => {
+  it('keeps Folder Sync toolbar chrome for expand/collapse/select/filters/home/peek', () => {
     const toolbar = buildFolderSyncToolbar({
       home: true,
       expand: true,
@@ -173,12 +173,14 @@ describe('sessionToolbars', () => {
       refresh: true,
       swap: true,
       stop: false,
+      peek: true,
     })
 
     expect(toolbar.map((item) => item.id)).toEqual([...folderSyncToolbarOrder])
     expect(toolbar.find((item) => item.id === 'home')?.enabled).toBe(true)
     expect(toolbar.find((item) => item.id === 'select')?.enabled).toBe(true)
     expect(toolbar.find((item) => item.id === 'stop')?.enabled).toBe(false)
+    expect(toolbar.find((item) => item.id === 'peek')?.enabled).toBe(true)
   })
 
   it('keeps Folder Merge toolbar chrome for expand/collapse/select', () => {

--- a/src/app/sessionToolbars.ts
+++ b/src/app/sessionToolbars.ts
@@ -134,6 +134,7 @@ export const folderSyncToolbarOrder = [
   'refresh',
   'swap',
   'stop',
+  'peek',
 ] as const
 
 export const folderMergeToolbarOrder = [
@@ -283,6 +284,7 @@ const folderSyncMeta: Record<(typeof folderSyncToolbarOrder)[number], ToolbarMet
   refresh: { glyph: 'R', labelKey: 'ui.refresh' },
   swap: { glyph: '<>', labelKey: 'ui.swap' },
   stop: { glyph: 'X', labelKey: 'ui.stop' },
+  peek: { glyph: 'P', labelKey: 'ui.peek' },
 }
 
 const folderMergeMeta: Record<(typeof folderMergeToolbarOrder)[number], ToolbarMeta> = {

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -285,6 +285,7 @@ export const deDE: LanguagePack = {
     'ui.pictureCompare': 'Bildvergleich',
     'ui.pictureReport': 'Bildbericht',
     'ui.hexReport': 'Hex-Bericht',
+    'ui.registryReport': 'Registrierungsbericht',
     'ui.port': 'Hafen',
     'ui.preview': 'Vorschau',
     'ui.previewSync': 'Vorschau-Synchronisierung',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -330,6 +330,7 @@ export const enUS: LanguagePack = {
     'ui.pictureCompare': 'Picture Compare',
     'ui.pictureReport': 'Picture Report',
     'ui.hexReport': 'Hex Report',
+    'ui.registryReport': 'Registry Report',
     'ui.pictureCompareInspector': 'Picture compare inspector',
     'ui.policy': 'Policy',
     'ui.port': 'Port',

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -281,6 +281,7 @@ export const esES: LanguagePack = {
     'ui.pictureCompare': 'Comparar imágenes',
     'ui.pictureReport': 'Informe de imagen',
     'ui.hexReport': 'Informe hexadecimal',
+    'ui.registryReport': 'Informe del registro',
     'ui.port': 'Puerto',
     'ui.preview': 'Avance',
     'ui.previewSync': 'Vista previa de sincronización',

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -281,6 +281,7 @@ export const frFR: LanguagePack = {
     'ui.pictureCompare': "Comparaison d'images",
     'ui.pictureReport': 'Rapport image',
     'ui.hexReport': 'Rapport hexadécimal',
+    'ui.registryReport': 'Rapport du Registre',
     'ui.port': 'Port',
     'ui.preview': 'Aperçu',
     'ui.previewSync': "Synchronisation de l'aperçu",

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -329,6 +329,7 @@ export const jaJP: LanguagePack = {
     'ui.pictureCompare': 'Picture Compare',
     'ui.pictureReport': 'ピクチャレポート',
     'ui.hexReport': 'Hex レポート',
+    'ui.registryReport': 'レジストリレポート',
     'ui.pictureCompareInspector': 'Picture compare inspector',
     'ui.policy': 'Policy',
     'ui.port': 'Port',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -272,6 +272,7 @@ export const koKR: LanguagePack = {
     'ui.pictureCompare': '사진 비교',
     'ui.pictureReport': '그림 보고서',
     'ui.hexReport': 'Hex 보고서',
+    'ui.registryReport': '레지스트리 보고서',
     'ui.port': '포트',
     'ui.preview': '시사',
     'ui.previewSync': '미리보기 동기화',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -263,6 +263,7 @@ export const zhCN: LanguagePack = {
     'ui.pictureCompare': '图片比较',
     'ui.pictureReport': '图片报告',
     'ui.hexReport': '十六进制报告',
+    'ui.registryReport': '注册表报告',
     'ui.port': '端口',
     'ui.preview': '预览',
     'ui.previewSync': '预览同步',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -264,6 +264,7 @@ export const zhTW: LanguagePack = {
     'ui.pictureCompare': '圖片比較',
     'ui.pictureReport': '圖片報告',
     'ui.hexReport': '十六進位報告',
+    'ui.registryReport': '登錄檔報告',
     'ui.port': '連接埠',
     'ui.preview': '預覽',
     'ui.previewSync': '預覽同步',

--- a/src/views/FolderSyncView.test.ts
+++ b/src/views/FolderSyncView.test.ts
@@ -247,5 +247,15 @@ describe('FolderSyncView', () => {
     expect(wrapper.find('[data-testid="sync-row-copy-app"]').exists()).toBe(false)
     await wrapper.find('[data-testid="folder-sync-session-toolbar-expand"]').trigger('click')
     expect(wrapper.find('[data-testid="sync-row-copy-app"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="folder-sync-session-toolbar-peek"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-sync-peek-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-sync-peek-path"]').text()).toContain(
+      'package/app.exe',
+    )
+    await wrapper.find('[data-testid="sync-row-delete-old"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-sync-peek-path"]').text()).toContain('prod/old.dll')
+    await wrapper.find('[data-testid="folder-sync-peek-close"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-sync-peek-panel"]').exists()).toBe(false)
   })
 })

--- a/src/views/FolderSyncView.vue
+++ b/src/views/FolderSyncView.vue
@@ -73,6 +73,8 @@ const collapsedPrefixes = ref<Set<string>>(new Set())
 const showSyncFilters = ref(false)
 const showSyncSelect = ref(false)
 const checkedRowIds = ref<Set<string>>(new Set())
+const showPeek = ref(false)
+const selectedPeekRowId = ref('')
 const visibleActions = ref<Set<FolderSyncPreviewAction>>(
   new Set(['Copy', 'Delete', 'Leave', 'Conflict']),
 )
@@ -105,6 +107,9 @@ const visiblePreviewRows = computed(() =>
     (row) => !isPathHiddenByCollapse(row.relativePath, collapsedPrefixes.value),
   ),
 )
+const selectedPeekRow = computed(
+  () => previewRows.value.find((row) => row.id === selectedPeekRowId.value) ?? null,
+)
 const syncSessionToolbar = computed(() =>
   buildFolderSyncToolbar({
     home: true,
@@ -115,6 +120,7 @@ const syncSessionToolbar = computed(() =>
     refresh: Boolean(leftPath.value && rightPath.value) && !previewLoading.value,
     swap: Boolean(leftPath.value || rightPath.value),
     stop: previewLoading.value || syncRunning.value,
+    peek: previewRows.value.length > 0,
   }),
 )
 
@@ -195,6 +201,20 @@ function stopSyncWork(): void {
   syncChromeMessage.value = t('ui.stop')
 }
 
+function selectSyncPeekRow(row: SyncPreviewRow): void {
+  selectedPeekRowId.value = row.id
+  if (!showPeek.value) {
+    showPeek.value = true
+  }
+}
+
+function toggleSyncPeekPanel(): void {
+  showPeek.value = !showPeek.value
+  if (showPeek.value && !selectedPeekRowId.value && visiblePreviewRows.value[0]) {
+    selectedPeekRowId.value = visiblePreviewRows.value[0].id
+  }
+}
+
 function runSyncToolbarCommand(commandId: string): void {
   switch (commandId) {
     case 'home':
@@ -220,6 +240,9 @@ function runSyncToolbarCommand(commandId: string): void {
       break
     case 'stop':
       stopSyncWork()
+      break
+    case 'peek':
+      toggleSyncPeekPanel()
       break
     default:
       break
@@ -263,6 +286,8 @@ async function previewSync(): Promise<void> {
     syncChromeMessage.value = ''
     collapsedPrefixes.value = new Set()
     checkedRowIds.value = new Set()
+    selectedPeekRowId.value = ''
+    showPeek.value = false
     lastSelectionAction.value = ''
   } catch (error) {
     previewError.value = error instanceof Error ? error.message : String(error)
@@ -689,15 +714,17 @@ watch(
             class="sync-preview-row"
             :class="{
               'sync-row-overridden': row.overrideAction !== row.plannedAction,
-              'sync-row-selected': checkedRowIds.has(row.id),
+              'sync-row-selected': checkedRowIds.has(row.id) || row.id === selectedPeekRowId,
             }"
             :data-testid="`sync-row-${row.id}`"
+            @click="selectSyncPeekRow(row)"
           >
             <label class="sync-select-cell">
               <input
                 type="checkbox"
                 :checked="checkedRowIds.has(row.id)"
                 :data-testid="`sync-check-${row.id}`"
+                @click.stop
                 @change="toggleSyncRowChecked(row.id)"
               />
             </label>
@@ -712,6 +739,7 @@ watch(
               <select
                 v-model="row.overrideAction"
                 :data-testid="`sync-override-${row.id}`"
+                @click.stop
                 @change="planAccepted = false"
               >
                 <option
@@ -727,7 +755,7 @@ watch(
                 class="sync-reset-override"
                 :data-testid="`sync-reset-${row.id}`"
                 :disabled="row.overrideAction === row.plannedAction"
-                @click="resetRowOverride(row)"
+                @click.stop="resetRowOverride(row)"
               >
                 {{ $t('ui.reset') }}
               </button>
@@ -737,6 +765,69 @@ watch(
             <span>{{ row.detail }}</span>
           </div>
         </div>
+      </section>
+
+      <section
+        v-if="showPeek"
+        class="folder-sync-peek-panel"
+        data-testid="folder-sync-peek-panel"
+      >
+        <header>
+          <strong>{{ $t('ui.peekPanel') }}</strong>
+          <button
+            type="button"
+            data-testid="folder-sync-peek-close"
+            @click="showPeek = false"
+          >
+            {{ $t('ui.close') }}
+          </button>
+        </header>
+        <dl v-if="selectedPeekRow">
+          <div>
+            <dt>{{ $t('ui.path') }}</dt>
+            <dd data-testid="folder-sync-peek-path">{{ selectedPeekRow.relativePath }}</dd>
+          </div>
+          <div>
+            <dt>{{ $t('ui.plannedAction') }}</dt>
+            <dd data-testid="folder-sync-peek-planned">
+              {{
+                $t(
+                  overrideOptions.find((option) => option.value === selectedPeekRow?.plannedAction)
+                    ?.labelKey ?? 'ui.leave',
+                )
+              }}
+            </dd>
+          </div>
+          <div>
+            <dt>{{ $t('ui.override') }}</dt>
+            <dd data-testid="folder-sync-peek-override">
+              {{
+                $t(
+                  overrideOptions.find((option) => option.value === selectedPeekRow?.overrideAction)
+                    ?.labelKey ?? 'ui.leave',
+                )
+              }}
+            </dd>
+          </div>
+          <div>
+            <dt>{{ $t('ui.source') }}</dt>
+            <dd>{{ selectedPeekRow.sourcePath ?? '--' }}</dd>
+          </div>
+          <div>
+            <dt>{{ $t('ui.target') }}</dt>
+            <dd>{{ selectedPeekRow.targetPath ?? '--' }}</dd>
+          </div>
+          <div>
+            <dt>{{ $t('ui.detail') }}</dt>
+            <dd data-testid="folder-sync-peek-detail">{{ selectedPeekRow.detail }}</dd>
+          </div>
+        </dl>
+        <p
+          v-else
+          data-testid="folder-sync-peek-empty"
+        >
+          {{ $t('ui.noSelection') }}
+        </p>
       </section>
 
       <section
@@ -1055,5 +1146,37 @@ h1 {
 
 .sync-row-selected {
   background: color-mix(in srgb, var(--app-accent, #4c8bf5) 12%, transparent);
+}
+
+.folder-sync-peek-panel {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-surface);
+}
+
+.folder-sync-peek-panel header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.folder-sync-peek-panel dl {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.folder-sync-peek-panel dt {
+  color: var(--app-text-muted);
+  font-size: 12px;
+}
+
+.folder-sync-peek-panel dd {
+  margin: 2px 0 0;
+  font-size: 13px;
 }
 </style>

--- a/src/views/RegistryCompareView.test.ts
+++ b/src/views/RegistryCompareView.test.ts
@@ -1,11 +1,13 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import RegistryCompareView from './RegistryCompareView.vue'
-import { compareRegistryExports, readTextFile } from '@/api/diff'
+import { compareRegistryExports, readTextFile, saveTextFile } from '@/api/diff'
 import { queryLiveWindowsRegistry } from '@/api/policy'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
+
+const clipboardWriteText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -18,6 +20,10 @@ vi.mock('@/api/policy', () => ({
 }))
 
 vi.mock('@/api/diff', () => ({
+  saveTextFile: vi.fn().mockResolvedValue({
+    path: 'C:/drop/registry-compare.txt',
+    bytesWritten: 64,
+  }),
   compareRegistryExports: vi.fn().mockResolvedValue({
     leftName: 'fixture-left.reg',
     rightName: 'fixture-right.reg',
@@ -61,6 +67,14 @@ describe('RegistryCompareView', () => {
     setActivePinia(createPinia())
     vi.mocked(compareRegistryExports).mockClear()
     vi.mocked(readTextFile).mockClear()
+    vi.mocked(saveTextFile).mockClear()
+    clipboardWriteText.mockClear()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteText,
+      },
+    })
   })
 
   it('runs a registry export comparison and renders returned values', async () => {
@@ -168,5 +182,43 @@ describe('RegistryCompareView', () => {
     await Promise.resolve()
 
     expect(tabs.activeTab.title).toBe('left.reg <--> right.reg')
+  })
+
+  it('exports the registry report to clipboard and a sibling text file', async () => {
+    useSessionLaunchStore().setPendingLaunch({
+      id: 'launch-registry-report',
+      source: 'drop',
+      sessionType: 'registry-compare',
+      title: 'left.reg vs right.reg',
+      route: '/compare/registry',
+      autoRun: true,
+      locations: {
+        left: { uri: 'C:/drop/left.reg', kind: 'file', readOnly: false },
+        right: { uri: 'C:/drop/right.reg', kind: 'file', readOnly: false },
+      },
+    })
+
+    const wrapper = mount(RegistryCompareView)
+
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="registry-report-panel"]').exists()).toBe(true)
+    await wrapper.find('[data-testid="export-registry-report"]').trigger('click')
+    await flushPromises()
+
+    expect(clipboardWriteText).toHaveBeenCalled()
+    const payload = clipboardWriteText.mock.calls[0]?.[0] ?? ''
+
+    expect(payload).toContain('REGISTRY-REPORT')
+    expect(payload).toContain('left: C:/drop/left.reg')
+    expect(payload).toContain('Theme')
+    expect(saveTextFile).toHaveBeenCalledWith({
+      path: 'C:/drop/registry-compare.txt',
+      text: payload,
+      createBackup: false,
+    })
+    expect(wrapper.find('[data-testid="registry-report-status"]').text()).toBe(
+      'C:/drop/registry-compare.txt',
+    )
   })
 })

--- a/src/views/RegistryCompareView.vue
+++ b/src/views/RegistryCompareView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { compareRegistryExports, readTextFile } from '@/api/diff'
+import { compareRegistryExports, readTextFile, saveTextFile } from '@/api/diff'
 import { queryLiveWindowsRegistry } from '@/api/policy'
 import type {
   RegistryCompareResponse,
@@ -18,9 +18,11 @@ import {
   registryValueMatchesFilter,
   type RegistryValueFilter,
 } from '@/app/registryWorkspace'
+import { buildRegistryReportText, defaultRegistryReportOutputPath } from '@/app/registryReport'
 import { buildRegistryCompareToolbar, pathPairTitle } from '@/app/sessionToolbars'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
+import { useViewActionsStore } from '@/stores/viewActions'
 import { useI18n } from '@/i18n'
 
 interface FlatRegistryKeyNode extends RegistryKeyNode {
@@ -48,6 +50,10 @@ const liveQueryKey = ref('')
 const liveQueryResult = ref('')
 const liveQueryError = ref('')
 const liveQueryLoading = ref(false)
+const leftSourcePath = ref('')
+const rightSourcePath = ref('')
+const reportStatus = ref('')
+const viewActions = useViewActionsStore()
 
 onMounted(() => {
   const launch = sessionLaunch.consumeLaunch('/compare/registry')
@@ -199,6 +205,8 @@ async function loadLaunchRegistryExports(leftPath: string, rightPath: string): P
 
     leftExport.value = leftFile.text
     rightExport.value = rightFile.text
+    leftSourcePath.value = leftFile.path
+    rightSourcePath.value = rightFile.path
     leftName.value = fileNameFromPath(leftFile.path)
     rightName.value = fileNameFromPath(rightFile.path)
     await runRegistryCompare()
@@ -299,6 +307,109 @@ async function runLiveRegistryQuery(): Promise<void> {
     liveQueryLoading.value = false
   }
 }
+
+async function exportRegistryReport(): Promise<void> {
+  if (allRegistryValues.value.length === 0) {
+    return
+  }
+
+  const leftPath = leftSourcePath.value || leftName.value
+  const rightPath = rightSourcePath.value || rightName.value
+  const payload = buildRegistryReportText({
+    leftPath,
+    rightPath,
+    summary: {
+      added: registrySummary.value.added,
+      removed: registrySummary.value.removed,
+      modified: registrySummary.value.modified,
+      unchanged: registrySummary.value.unchanged,
+    },
+    values: allRegistryValues.value.map((value) => ({
+      keyPath: value.keyPath,
+      name: value.name,
+      left: registryValueText(value.left),
+      right: registryValueText(value.right),
+      status: value.status,
+    })),
+  })
+  const outputPath = defaultRegistryReportOutputPath(leftPath)
+
+  try {
+    await navigator.clipboard.writeText(payload)
+  } catch {
+    // Clipboard may be unavailable in headless tests; still try file export.
+  }
+
+  try {
+    await saveTextFile({
+      path: outputPath,
+      text: payload,
+      createBackup: false,
+    })
+    reportStatus.value = outputPath
+  } catch (event) {
+    error.value = String(event)
+  }
+}
+
+watch(
+  () => [viewActions.sequence, viewActions.name] as const,
+  ([, actionName]) => {
+    if (!actionName) {
+      return
+    }
+
+    switch (actionName) {
+      case 'compare':
+      case 'reload':
+        void runRegistryCompare()
+        break
+      case 'swap':
+        runRegistryToolbarCommand('swap')
+        break
+      case 'export':
+      case 'save':
+      case 'save-as':
+        void exportRegistryReport()
+        break
+      case 'show-all':
+        valueFilter.value = 'all'
+        break
+      case 'show-differences':
+      case 'filters':
+        valueFilter.value = 'diffs'
+        break
+      case 'copy':
+      case 'copy-right':
+        applySelectedValue('right')
+        break
+      case 'copy-left':
+        applySelectedValue('left')
+        break
+      case 'about':
+      case 'check-for-updates':
+      case 'close-tab':
+      case 'cut':
+      case 'delete':
+      case 'export-settings':
+      case 'help-contents':
+      case 'help-support':
+      case 'import-settings':
+      case 'next-difference':
+      case 'paste':
+      case 'previous-difference':
+      case 'redo':
+      case 'restore-factory-defaults':
+      case 'rules':
+      case 'save-snapshot':
+      case 'session-settings':
+      case 'undo':
+      case 'workspace-load':
+      case 'workspace-save':
+        break
+    }
+  },
+)
 
 const registrySessionToolbar = computed(() =>
   buildRegistryCompareToolbar({
@@ -459,6 +570,29 @@ function runRegistryToolbarCommand(commandId: string): void {
           </strong>
           <span>{{ statusLabel(status) }}</span>
         </article>
+      </section>
+
+      <section
+        v-if="allRegistryValues.length > 0"
+        class="registry-report-panel"
+        data-testid="registry-report-panel"
+      >
+        <header>
+          <strong>{{ $t('ui.registryReport') }}</strong>
+          <span>{{ $t('status.fieldCount', { count: allRegistryValues.length }) }}</span>
+          <button
+            type="button"
+            data-testid="export-registry-report"
+            @click="exportRegistryReport"
+          >
+            {{ $t('ui.export') }}
+          </button>
+          <span
+            v-if="reportStatus"
+            data-testid="registry-report-status"
+            >{{ reportStatus }}</span
+          >
+        </header>
       </section>
 
       <section
@@ -786,6 +920,32 @@ h1 {
 .registry-key-row.selected,
 .registry-value-row.selected {
   outline: 1px solid var(--app-accent);
+}
+
+.registry-report-panel {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-surface);
+}
+
+.registry-report-panel header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.registry-report-panel header button {
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-bg);
+  color: var(--app-text);
+  cursor: pointer;
 }
 
 .registry-summary-grid {


### PR DESCRIPTION
## Summary
- Add `REGISTRY-REPORT` text builder and wire Registry Compare Export / Session Export to clipboard plus a sibling `registry-compare.txt` save (same pattern as Picture/Hex).
- Enable Folder Sync Peek toolbar chrome with a detail panel and row selection, matching Folder Merge Peek behavior.

## Test plan
- [x] `vitest` for `registryReport`, `sessionToolbars`, `RegistryCompareView`, `FolderSyncView`, language skeletons
- [x] eslint / stylelint / prettier / `vue-tsc` on touched files (pre-commit quality also passed)
- [ ] Manual: open Registry Compare from two `.reg` files → Export → confirm clipboard + sibling report path
- [ ] Manual: Folder Sync preview → Peek toolbar / row click → confirm path/action/detail panel