### PR TITLE
Save Media and Folder Merge reports to disk

### DIFF
--- a/src/app/folderMergeReport.test.ts
+++ b/src/app/folderMergeReport.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { buildFolderMergeReportText, defaultFolderMergeReportOutputPath } from './folderMergeReport'
+
+describe('folderMergeReport', () => {
+  it('builds a sibling folder-merge.txt path from the left folder', () => {
+    expect(defaultFolderMergeReportOutputPath('D:/workspace/merge/left')).toBe(
+      'D:/workspace/merge/folder-merge.txt',
+    )
+    expect(defaultFolderMergeReportOutputPath('D:/workspace/merge/left/')).toBe(
+      'D:/workspace/merge/folder-merge.txt',
+    )
+    expect(defaultFolderMergeReportOutputPath('/tmp/a')).toBe('/tmp/folder-merge.txt')
+    expect(defaultFolderMergeReportOutputPath('')).toBe('folder-merge.txt')
+    expect(defaultFolderMergeReportOutputPath('solo')).toBe('folder-merge.txt')
+  })
+
+  it('builds the clipboard/file FOLDER-MERGE-REPORT payload', () => {
+    const text = buildFolderMergeReportText({
+      leftPath: 'D:/merge/left',
+      basePath: 'D:/merge/base',
+      rightPath: 'D:/merge/right',
+      outputPath: 'D:/merge/out',
+      summary: { actions: 2, automatic: 1, conflicts: 1 },
+      rows: [
+        {
+          path: 'same.txt',
+          action: 'Keep output',
+          detail: 'All sides match',
+        },
+        {
+          path: 'notes.txt',
+          action: 'Mark conflict',
+          detail: 'Left and right diverge',
+        },
+      ],
+    })
+
+    expect(text).toContain('FOLDER-MERGE-REPORT')
+    expect(text).toContain('left: D:/merge/left')
+    expect(text).toContain('base: D:/merge/base')
+    expect(text).toContain('actions: 2')
+    expect(text).toContain('same.txt\tKeep output\tAll sides match')
+    expect(text).toContain('notes.txt\tMark conflict\tLeft and right diverge')
+  })
+})

--- a/src/app/folderMergeReport.ts
+++ b/src/app/folderMergeReport.ts
@@ -1,0 +1,55 @@
+export interface FolderMergeReportRow {
+  path: string
+  action: string
+  detail: string
+}
+
+export interface FolderMergeReportSummary {
+  actions: number
+  automatic: number
+  conflicts: number
+}
+
+export interface BuildFolderMergeReportTextInput {
+  leftPath: string
+  basePath: string
+  rightPath: string
+  outputPath: string
+  summary: FolderMergeReportSummary
+  rows: FolderMergeReportRow[]
+}
+
+/** Sibling text report path next to the left merge folder (matches picture/version export style). */
+export function defaultFolderMergeReportOutputPath(leftPath: string): string {
+  const trimmed = leftPath.trim().replace(/[/\\]+$/u, '')
+
+  if (!trimmed) {
+    return 'folder-merge.txt'
+  }
+
+  const slash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+
+  if (slash < 0) {
+    return 'folder-merge.txt'
+  }
+
+  return `${trimmed.slice(0, slash + 1)}folder-merge.txt`
+}
+
+export function buildFolderMergeReportText(input: BuildFolderMergeReportTextInput): string {
+  const lines = [
+    'FOLDER-MERGE-REPORT',
+    `left: ${input.leftPath || '--'}`,
+    `base: ${input.basePath || '--'}`,
+    `right: ${input.rightPath || '--'}`,
+    `output: ${input.outputPath || '--'}`,
+    `actions: ${String(input.summary.actions)}`,
+    `automatic: ${String(input.summary.automatic)}`,
+    `conflicts: ${String(input.summary.conflicts)}`,
+    '',
+    'rows:',
+    ...input.rows.map((row) => `${row.path}\t${row.action}\t${row.detail}`),
+  ]
+
+  return lines.join('\n')
+}

--- a/src/app/mediaReport.test.ts
+++ b/src/app/mediaReport.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { buildMediaReportText, defaultMediaReportOutputPath } from './mediaReport'
+
+describe('mediaReport', () => {
+  it('builds a sibling media-compare.txt path from the left media file', () => {
+    expect(defaultMediaReportOutputPath('C:/music/left.mp3')).toBe('C:/music/media-compare.txt')
+    expect(defaultMediaReportOutputPath('/opt/audio/a.flac')).toBe('/opt/audio/media-compare.txt')
+    expect(defaultMediaReportOutputPath('')).toBe('media-compare.txt')
+    expect(defaultMediaReportOutputPath('solo.mp3')).toBe('media-compare.txt')
+  })
+
+  it('builds the clipboard/file MEDIA-REPORT payload', () => {
+    const text = buildMediaReportText({
+      leftPath: 'C:/music/left.mp3',
+      rightPath: 'C:/music/right.mp3',
+      summary: { added: 0, removed: 0, modified: 1, unchanged: 1 },
+      fields: [
+        {
+          field: 'Title',
+          left: 'Alpha',
+          right: 'Beta',
+          status: 'modified',
+          important: true,
+        },
+        {
+          field: 'Comment',
+          left: 'demo',
+          right: 'demo-b',
+          status: 'modified',
+          important: false,
+        },
+      ],
+    })
+
+    expect(text).toContain('MEDIA-REPORT')
+    expect(text).toContain('left: C:/music/left.mp3')
+    expect(text).toContain('modified: 1')
+    expect(text).toContain('Title\tAlpha\tBeta\tmodified\timportant')
+    expect(text).toContain('Comment\tdemo\tdemo-b\tmodified\tunimportant')
+  })
+})

--- a/src/app/mediaReport.ts
+++ b/src/app/mediaReport.ts
@@ -1,0 +1,58 @@
+export interface MediaReportFieldRow {
+  field: string
+  left: string
+  right: string
+  status: string
+  important: boolean
+}
+
+export interface MediaReportSummary {
+  added: number
+  removed: number
+  modified: number
+  unchanged: number
+}
+
+export interface BuildMediaReportTextInput {
+  leftPath: string
+  rightPath: string
+  summary: MediaReportSummary
+  fields: MediaReportFieldRow[]
+}
+
+/** Sibling text report path next to the left media file (matches picture/version export style). */
+export function defaultMediaReportOutputPath(leftPath: string): string {
+  const trimmed = leftPath.trim()
+
+  if (!trimmed) {
+    return 'media-compare.txt'
+  }
+
+  const slash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+
+  if (slash < 0) {
+    return 'media-compare.txt'
+  }
+
+  return `${trimmed.slice(0, slash + 1)}media-compare.txt`
+}
+
+export function buildMediaReportText(input: BuildMediaReportTextInput): string {
+  const lines = [
+    'MEDIA-REPORT',
+    `left: ${input.leftPath}`,
+    `right: ${input.rightPath}`,
+    `added: ${String(input.summary.added)}`,
+    `removed: ${String(input.summary.removed)}`,
+    `modified: ${String(input.summary.modified)}`,
+    `unchanged: ${String(input.summary.unchanged)}`,
+    '',
+    'fields:',
+    ...input.fields.map(
+      (row) =>
+        `${row.field}\t${row.left}\t${row.right}\t${row.status}\t${row.important ? 'important' : 'unimportant'}`,
+    ),
+  ]
+
+  return lines.join('\n')
+}

--- a/src/views/FolderMergeView.test.ts
+++ b/src/views/FolderMergeView.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
 import { buildFolderMergePlan, executeFolderMergePlan } from '@/api/folderMerge'
+import { saveTextFile } from '@/api/diff'
+import { useViewActionsStore } from '@/stores/viewActions'
 import FolderMergeView from './FolderMergeView.vue'
 import type {
   FolderMergeEntryKind,
@@ -24,6 +26,16 @@ vi.mock('@/api/folderMerge', () => ({
   buildFolderMergePlan: vi.fn(),
   executeFolderMergePlan: vi.fn(),
 }))
+
+vi.mock('@/api/diff', () => ({
+  createFolderSnapshot: vi.fn(),
+  saveTextFile: vi.fn().mockResolvedValue({
+    path: 'D:/workspace/merge/folder-merge.txt',
+    bytesWritten: 64,
+  }),
+}))
+
+const clipboardWriteText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
 
 function mountFolderMergeView(): VueWrapper {
   return mount(FolderMergeView, {
@@ -54,6 +66,14 @@ describe('FolderMergeView', () => {
     push.mockClear()
     vi.mocked(buildFolderMergePlan).mockReset()
     vi.mocked(executeFolderMergePlan).mockReset()
+    vi.mocked(saveTextFile).mockClear()
+    clipboardWriteText.mockClear()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteText,
+      },
+    })
     vi.mocked(buildFolderMergePlan).mockResolvedValue(createMergePlanResponse())
     vi.mocked(executeFolderMergePlan).mockResolvedValue(createMergeExecutionResponse())
   })
@@ -251,6 +271,51 @@ describe('FolderMergeView', () => {
 
     await wrapper.find('[data-testid="folder-merge-session-toolbar-filters"]').trigger('click')
     expect(wrapper.find('[data-testid="folder-merge-filters-panel"]').exists()).toBe(true)
+  })
+
+  it('exports the folder merge report to clipboard and a sibling text file', async () => {
+    const wrapper = mountFolderMergeView()
+
+    await fillMergePaths(wrapper)
+    await wrapper.find('[data-testid="folder-merge-build-plan"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('[data-testid="export-folder-merge-report"]').trigger('click')
+    await flushPromises()
+
+    expect(clipboardWriteText).toHaveBeenCalled()
+    const payload = clipboardWriteText.mock.calls[0]?.[0] ?? ''
+
+    expect(payload).toContain('FOLDER-MERGE-REPORT')
+    expect(payload).toContain('left: D:/workspace/merge/left')
+    expect(payload).toContain('same.txt')
+    expect(saveTextFile).toHaveBeenCalledWith({
+      path: 'D:/workspace/merge/folder-merge.txt',
+      text: payload,
+      createBackup: false,
+    })
+    expect(wrapper.find('[data-testid="folder-merge-report-status"]').text()).toBe(
+      'D:/workspace/merge/folder-merge.txt',
+    )
+  })
+
+  it('wires Session Export to the merge report instead of toggling filters', async () => {
+    const wrapper = mountFolderMergeView()
+
+    await fillMergePaths(wrapper)
+    await wrapper.find('[data-testid="folder-merge-build-plan"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="folder-merge-filters-panel"]').exists()).toBe(false)
+
+    useViewActionsStore().dispatch('export')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="folder-merge-filters-panel"]').exists()).toBe(false)
+    expect(saveTextFile).toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="folder-merge-report-status"]').text()).toBe(
+      'D:/workspace/merge/folder-merge.txt',
+    )
   })
 })
 

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -16,7 +16,11 @@ import type {
 } from '@/types/folderMerge'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
-import { createFolderSnapshot } from '@/api/diff'
+import { createFolderSnapshot, saveTextFile } from '@/api/diff'
+import {
+  buildFolderMergeReportText,
+  defaultFolderMergeReportOutputPath,
+} from '@/app/folderMergeReport'
 import { folderSnapshotOutputPath } from '@/app/snapshotPath'
 import { collectExpandablePrefixes, isPathHiddenByCollapse } from '@/app/folderPathGroups'
 import { buildFolderMergeToolbar, mergeSessionTitle, pathBaseName } from '@/app/sessionToolbars'
@@ -31,6 +35,8 @@ const plan = ref<FolderMergePlanResponse>()
 const execution = ref<FolderMergeExecutionResponse>()
 const mergeExecuting = ref(false)
 const mergeExecutionError = ref<string>()
+const reportStatus = ref('')
+const reportError = ref('')
 const router = useRouter()
 const sessionLaunch = useSessionLaunchStore()
 const tabs = useTabsStore()
@@ -233,6 +239,8 @@ async function buildFolderMergePlan(): Promise<void> {
   })
   execution.value = undefined
   mergeExecutionError.value = undefined
+  reportStatus.value = ''
+  reportError.value = ''
   collapsedPrefixes.value = new Set()
   checkedRowIds.value = new Set()
   lastSelectionAction.value = ''
@@ -340,6 +348,44 @@ function togglePeekPanel(): void {
   }
 }
 
+async function exportFolderMergeReport(): Promise<void> {
+  if (!hasPlan.value) {
+    return
+  }
+
+  const payload = buildFolderMergeReportText({
+    leftPath: leftPath.value,
+    basePath: basePath.value,
+    rightPath: rightPath.value,
+    outputPath: outputPath.value,
+    summary: summary.value,
+    rows: planRows.value.map((row) => ({
+      path: row.path,
+      action: row.action,
+      detail: row.detail,
+    })),
+  })
+  const reportPath = defaultFolderMergeReportOutputPath(leftPath.value)
+
+  try {
+    await navigator.clipboard.writeText(payload)
+  } catch {
+    // Clipboard may be unavailable in headless tests; still try file export.
+  }
+
+  try {
+    await saveTextFile({
+      path: reportPath,
+      text: payload,
+      createBackup: false,
+    })
+    reportStatus.value = reportPath
+    reportError.value = ''
+  } catch (event) {
+    reportError.value = String(event)
+  }
+}
+
 function joinRoot(root: string, relativePath: string): string {
   const normalizedRoot = root.replaceAll('\\', '/').replace(/\/$/u, '')
   const normalizedRelative = relativePath.replaceAll('\\', '/').replace(/^\//u, '')
@@ -386,6 +432,8 @@ watch(
       case 'cut':
       case 'delete':
       case 'export':
+        void exportFolderMergeReport()
+        break
       case 'export-settings':
       case 'filters':
         showMergeFilters.value = !showMergeFilters.value
@@ -501,6 +549,24 @@ watch(
             :disabled="!hasPlan"
             @click="togglePeekPanel"
             >{{ $t('ui.peek') }}</NButton
+          >
+          <NButton
+            size="small"
+            secondary
+            data-testid="export-folder-merge-report"
+            :disabled="!hasPlan"
+            @click="exportFolderMergeReport"
+            >{{ $t('ui.export') }}</NButton
+          >
+          <span
+            v-if="reportStatus"
+            data-testid="folder-merge-report-status"
+            >{{ reportStatus }}</span
+          >
+          <span
+            v-if="reportError"
+            data-testid="folder-merge-report-error"
+            >{{ reportError }}</span
           >
           <NButton
             size="small"

--- a/src/views/MediaCompareView.test.ts
+++ b/src/views/MediaCompareView.test.ts
@@ -2,15 +2,21 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MediaCompareView from './MediaCompareView.vue'
-import { compareMediaFiles } from '@/api/diff'
+import { compareMediaFiles, saveTextFile } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
 import { useTabsStore } from '@/stores/tabs'
+
+const clipboardWriteText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 
 vi.mock('@/api/diff', () => ({
+  saveTextFile: vi.fn().mockResolvedValue({
+    path: 'C:/music/media-compare.txt',
+    bytesWritten: 64,
+  }),
   compareMediaFiles: vi.fn().mockResolvedValue({
     left: {
       name: 'fixture-left.mp3',
@@ -68,6 +74,14 @@ describe('MediaCompareView', () => {
     setActivePinia(createPinia())
     localStorage.clear()
     vi.mocked(compareMediaFiles).mockClear()
+    vi.mocked(saveTextFile).mockClear()
+    clipboardWriteText.mockClear()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteText,
+      },
+    })
   })
 
   it('runs a real media comparison request and renders returned metadata', async () => {
@@ -214,5 +228,34 @@ describe('MediaCompareView', () => {
     await wrapper.find('[data-testid="media-session-toolbar-same"]').trigger('click')
     expect(wrapper.find('[data-testid="media-field-Artist"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="media-field-Title"]').exists()).toBe(false)
+  })
+
+  it('exports the media report to clipboard and a sibling text file', async () => {
+    const wrapper = mount(MediaCompareView)
+
+    await wrapper.find('[data-testid="media-left-path"]').setValue('C:/music/fixture-left.mp3')
+    await wrapper.find('[data-testid="media-right-path"]').setValue('C:/music/fixture-right.mp3')
+    await wrapper.find('[data-testid="run-media-compare"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await Promise.resolve()
+
+    await wrapper.find('[data-testid="export-media-report"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await Promise.resolve()
+
+    expect(clipboardWriteText).toHaveBeenCalled()
+    const payload = clipboardWriteText.mock.calls[0]?.[0] ?? ''
+
+    expect(payload).toContain('MEDIA-REPORT')
+    expect(payload).toContain('left: C:/music/fixture-left.mp3')
+    expect(payload).toContain('Title')
+    expect(saveTextFile).toHaveBeenCalledWith({
+      path: 'C:/music/media-compare.txt',
+      text: payload,
+      createBackup: false,
+    })
+    expect(wrapper.find('[data-testid="media-report-status"]').text()).toBe(
+      'C:/music/media-compare.txt',
+    )
   })
 })

--- a/src/views/MediaCompareView.vue
+++ b/src/views/MediaCompareView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { compareMediaFiles } from '@/api/diff'
+import { compareMediaFiles, saveTextFile } from '@/api/diff'
+import { buildMediaReportText, defaultMediaReportOutputPath } from '@/app/mediaReport'
 import type {
   MediaCompareResponse,
   MediaFieldRow,
@@ -57,6 +58,7 @@ const mediaSummaryOverride = ref<Record<MediaFieldStatus, number> | null>(null)
 const fieldFilter = ref<MediaFieldFilter>('all')
 const loading = ref(false)
 const error = ref('')
+const reportStatus = ref('')
 const showMediaRules = ref(false)
 const mediaOptions = ref<MediaCompareOptionsState>(loadMediaCompareOptions())
 const leftPlayer = ref<HTMLMediaElement | null>(null)
@@ -120,6 +122,44 @@ function applyMediaResult(result: MediaCompareResponse): void {
   rightMedia.value = result.right
   mediaFields.value = result.fields
   mediaSummaryOverride.value = result.summary
+  reportStatus.value = ''
+}
+
+async function exportMediaReport(): Promise<void> {
+  if (mediaFields.value.length === 0) {
+    return
+  }
+
+  const payload = buildMediaReportText({
+    leftPath: leftPath.value,
+    rightPath: rightPath.value,
+    summary: mediaSummary.value,
+    fields: mediaFields.value.map((row) => ({
+      field: row.field,
+      left: valueText(row.left),
+      right: valueText(row.right),
+      status: row.status,
+      important: fieldIsImportant(row.field),
+    })),
+  })
+  const outputPath = defaultMediaReportOutputPath(leftPath.value)
+
+  try {
+    await navigator.clipboard.writeText(payload)
+  } catch {
+    // Clipboard may be unavailable in headless tests; still try file export.
+  }
+
+  try {
+    await saveTextFile({
+      path: outputPath,
+      text: payload,
+      createBackup: false,
+    })
+    reportStatus.value = outputPath
+  } catch (event) {
+    error.value = String(event)
+  }
 }
 
 async function runMediaCompare(): Promise<void> {
@@ -593,6 +633,19 @@ function runMediaToolbarCommand(commandId: string): void {
         <header>
           <strong>{{ $t('ui.tagFieldReport') }}</strong>
           <span>{{ $t('status.fieldCount', { count: mediaFields.length }) }}</span>
+          <button
+            type="button"
+            data-testid="export-media-report"
+            :disabled="mediaFields.length === 0"
+            @click="exportMediaReport"
+          >
+            {{ $t('ui.export') }}
+          </button>
+          <span
+            v-if="reportStatus"
+            data-testid="media-report-status"
+            >{{ reportStatus }}</span
+          >
         </header>
         <div
           class="media-report-table"
@@ -777,6 +830,10 @@ h1 {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+.media-report-panel header button {
+  margin-left: auto;
 }
 
 .media-side dl {


### PR DESCRIPTION
## Summary
- Media Compare builds a MEDIA-REPORT text payload, copies it to the clipboard, and writes a sibling `media-compare.txt` next to the left path (same pattern as Version/Picture export).
- Folder Merge wires Session Export to a real FOLDER-MERGE-REPORT save instead of accidentally toggling the filters panel, and adds an Export control on the plan actions row.
- Shared helpers live in `mediaReport` / `folderMergeReport` with unit coverage; views cover the save path and the Session Export fix.

Based on `origin/master` (`390dff8`, #97). PR #98 is still open, so this avoids registryReport / FolderSync Peek / RegistryCompareView export files.

## Test plan
- [x] `vitest run` mediaReport + folderMergeReport + MediaCompareView + FolderMergeView (24 passed)
- [x] prettier / eslint / stylelint / `vue-tsc` on touched files
- [ ] Manual: Media Compare two files → Export → confirm clipboard + sibling `media-compare.txt`
- [ ] Manual: Folder Merge build plan → Export / Session → Export → confirm report; filters stay closed
- [ ] Do not merge until reviewed; leave open