### PR TITLE
Extract archive copy and filter Home session tree

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -824,12 +824,143 @@ pub fn copy_folder_compare_entry(
     let left_path = side_path(&left_root, &relative_path);
     let right_path = side_path(&right_root, &relative_path);
 
-    folder_core::copy_between_sides(folder_core::CopySideRequest {
+    let left_source = crate::sources::load_compare_source(&left_root).map_err(|error| {
+        AppErrorPayload::new(AppErrorCode::Unknown, "error.app.unknown.title", error)
+            .with_param("path", &left_root)
+    })?;
+    let right_source = crate::sources::load_compare_source(&right_root).map_err(|error| {
+        AppErrorPayload::new(AppErrorCode::Unknown, "error.app.unknown.title", error)
+            .with_param("path", &right_root)
+    })?;
+
+    let (source, target, source_path, target_path) = match direction {
+        folder_core::CopyDirection::ToLeft => (
+            &right_source,
+            &left_source,
+            right_path.clone(),
+            left_path.clone(),
+        ),
+        folder_core::CopyDirection::ToRight => (
+            &left_source,
+            &right_source,
+            left_path.clone(),
+            right_path.clone(),
+        ),
+    };
+
+    match (source, target) {
+        (crate::sources::CompareSource::Local(_), crate::sources::CompareSource::Local(_)) => {
+            folder_core::copy_between_sides(folder_core::CopySideRequest {
+                direction,
+                left_path,
+                right_path,
+            })
+            .map_err(|error| folder_scan_error(&relative_path, error))
+        }
+        (
+            crate::sources::CompareSource::Archive(_),
+            crate::sources::CompareSource::Local(target_root),
+        ) => extract_archive_entry_to_folder(
+            source,
+            target_root.as_path(),
+            &relative_path,
+            direction,
+            source_path,
+            target_path,
+        ),
+        (_, crate::sources::CompareSource::Archive(_))
+        | (_, crate::sources::CompareSource::Snapshot(_)) => Err(AppErrorPayload::new(
+            AppErrorCode::Unknown,
+            "error.app.unknown.title",
+            format!("cannot copy into archive or snapshot side: {target_path}"),
+        )
+        .with_param("path", &target_path)),
+        (crate::sources::CompareSource::Snapshot(_), _) => Err(AppErrorPayload::new(
+            AppErrorCode::Unknown,
+            "error.app.unknown.title",
+            format!("cannot copy from snapshot side: {source_path}"),
+        )
+        .with_param("path", &source_path)),
+    }
+}
+
+fn extract_archive_entry_to_folder(
+    source: &crate::sources::CompareSource,
+    target_root: &Path,
+    relative_path: &str,
+    direction: folder_core::CopyDirection,
+    source_path: String,
+    target_path: String,
+) -> Result<folder_core::CopySideResult, AppErrorPayload> {
+    let bytes = crate::sources::read_compare_file(source, relative_path).map_err(|error| {
+        AppErrorPayload::new(AppErrorCode::Unknown, "error.app.unknown.title", error)
+            .with_param("path", &source_path)
+    })?;
+
+    let destination = if relative_path.is_empty() {
+        target_root.to_path_buf()
+    } else {
+        target_root.join(relative_path)
+    };
+
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AppErrorPayload::new(
+                AppErrorCode::FileWriteFailed,
+                "error.app.unknown.title",
+                error.to_string(),
+            )
+            .with_param("path", &destination.display().to_string())
+        })?;
+    }
+
+    fs::write(&destination, &bytes).map_err(|error| {
+        AppErrorPayload::new(
+            AppErrorCode::FileWriteFailed,
+            "error.app.unknown.title",
+            error.to_string(),
+        )
+        .with_param("path", &destination.display().to_string())
+    })?;
+
+    let written = fs::read(&destination).map_err(|error| {
+        AppErrorPayload::new(
+            AppErrorCode::Unknown,
+            "error.app.unknown.title",
+            error.to_string(),
+        )
+        .with_param("path", &destination.display().to_string())
+    })?;
+    let refreshed_status = if written == bytes {
+        folder_core::FolderCompareStatus::Same
+    } else {
+        folder_core::FolderCompareStatus::Different
+    };
+
+    let name = destination
+        .file_name()
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_else(|| relative_path.to_owned());
+    let extension = destination
+        .extension()
+        .map(|value| value.to_string_lossy().into_owned());
+
+    Ok(folder_core::CopySideResult {
         direction,
-        left_path,
-        right_path,
+        source_path,
+        target_path,
+        target_metadata: vfs_core::VfsMetadata {
+            kind: vfs_core::VfsEntryKind::File,
+            name,
+            extension,
+            size: written.len() as u64,
+            readonly: false,
+            created_at_ms: None,
+            modified_at_ms: None,
+            accessed_at_ms: None,
+        },
+        refreshed_status,
     })
-    .map_err(|error| folder_scan_error(&relative_path, error))
 }
 
 #[tauri::command]
@@ -5311,6 +5442,50 @@ mod tests {
             .rows
             .iter()
             .any(|row| row.relative_path == "same.txt" && row.status == "Same"));
+    }
+
+    #[test]
+    fn copy_folder_compare_entry_extracts_from_zip_into_folder() {
+        let root = unique_temp_dir("zip-extract-copy-command");
+        fs::create_dir_all(&root).expect("fixture directory should be created");
+        let archive_doc = archive_core::ArchiveDocument::new("bundle.zip")
+            .with_file("/nested/readme.txt", b"from-archive".to_vec())
+            .with_file("/solo.txt", b"solo".to_vec());
+        let archive = root.join("bundle.zip");
+        let folder = root.join("out");
+        fs::create_dir_all(&folder).expect("output folder should be created");
+        fs::write(
+            &archive,
+            archive_core::write_zip_bytes(&archive_doc).unwrap(),
+        )
+        .unwrap();
+
+        let copy = copy_folder_compare_entry(
+            archive.display().to_string(),
+            folder.display().to_string(),
+            "nested/readme.txt".to_owned(),
+            folder_core::CopyDirection::ToRight,
+        )
+        .expect("archive file should extract into the folder side");
+
+        assert_eq!(
+            copy.refreshed_status,
+            folder_core::FolderCompareStatus::Same
+        );
+        assert_eq!(
+            fs::read_to_string(folder.join("nested").join("readme.txt"))
+                .expect("extracted file should be readable"),
+            "from-archive"
+        );
+
+        let rejected = copy_folder_compare_entry(
+            folder.display().to_string(),
+            archive.display().to_string(),
+            "solo.txt".to_owned(),
+            folder_core::CopyDirection::ToRight,
+        )
+        .expect_err("copy into an archive side should stay rejected");
+        assert!(rejected.debug_message.contains("cannot copy into archive"));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -910,7 +910,7 @@ fn extract_archive_entry_to_folder(
                 "error.app.unknown.title",
                 error.to_string(),
             )
-            .with_param("path", &destination.display().to_string())
+            .with_param("path", destination.display().to_string())
         })?;
     }
 
@@ -920,7 +920,7 @@ fn extract_archive_entry_to_folder(
             "error.app.unknown.title",
             error.to_string(),
         )
-        .with_param("path", &destination.display().to_string())
+        .with_param("path", destination.display().to_string())
     })?;
 
     let written = fs::read(&destination).map_err(|error| {
@@ -929,7 +929,7 @@ fn extract_archive_entry_to_folder(
             "error.app.unknown.title",
             error.to_string(),
         )
-        .with_param("path", &destination.display().to_string())
+        .with_param("path", destination.display().to_string())
     })?;
     let refreshed_status = if written == bytes {
         folder_core::FolderCompareStatus::Same

--- a/src/app/sessionCatalog.test.ts
+++ b/src/app/sessionCatalog.test.ts
@@ -37,7 +37,7 @@ describe('sessionCatalog', () => {
     expect(byType['folder-sync']).toBe('partial')
     expect(byType['text-merge']).toBe('partial')
     expect(byType['media-compare']).toBe('partial')
-    expect(byType['archive-compare']).toBe('limited')
+    expect(byType['archive-compare']).toBe('partial')
     expect(byType.script).toBe('limited')
     expect(sessionCatalog.every((entry) => Boolean(entry.maturity))).toBe(true)
   })

--- a/src/app/sessionCatalog.ts
+++ b/src/app/sessionCatalog.ts
@@ -178,11 +178,12 @@ export const sessionCatalog: SessionCatalogEntry[] = [
     type: 'archive-compare',
     title: 'Archive Compare',
     titleKey: 'ui.archiveCompare',
-    summary: 'Opens Folder Compare for ZIP/TAR-style paths (not a separate archive engine)',
+    summary:
+      'Opens Folder Compare for ZIP/TAR sides with extract-on-copy into a folder (7z still unavailable)',
     summaryKey: 'session.summary.archiveCompare',
     priority: 'P2',
     implemented: true,
-    maturity: 'limited',
+    maturity: 'partial',
     route: '/compare/folder',
   },
   {

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -701,7 +701,8 @@ export const deDE: LanguagePack = {
     'ui.sheetSelectionEmpty': 'Sheets appear after Excel or HTML compare',
     'ui.sheetSelectionSummary':
       '{leftCount} left / {rightCount} right · {leftSheet} vs {rightSheet}',
-    'session.summary.archiveCompare': 'Compare ZIP or TAR contents (7z not available)',
+    'session.summary.archiveCompare':
+      'Compare ZIP/TAR sides and copy files out into a folder (7z not available)',
     'session.summary.script': 'Run a simple script to load, compare, and export a report',
     'ui.archiveCompare': 'Archivvergleich',
     'ui.archivePathHint':

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -684,7 +684,8 @@ export const enUS: LanguagePack = {
     'session.summary.textMerge': 'Combine left, right, and a base file into one result',
     'session.summary.textPatch': 'Review and apply a patch file',
     'session.summary.versionCompare': 'Compare version info inside program files',
-    'session.summary.archiveCompare': 'Compare ZIP or TAR contents (7z not available)',
+    'session.summary.archiveCompare':
+      'Compare ZIP/TAR sides and copy files out into a folder (7z not available)',
     'session.summary.script': 'Run a simple script to load, compare, and export a report',
     'ui.archiveCompare': 'Archive Compare',
     'ui.archivePathHint':

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -695,7 +695,8 @@ export const esES: LanguagePack = {
     'ui.sheetSelectionEmpty': 'Sheets appear after Excel or HTML compare',
     'ui.sheetSelectionSummary':
       '{leftCount} left / {rightCount} right · {leftSheet} vs {rightSheet}',
-    'session.summary.archiveCompare': 'Compare ZIP or TAR contents (7z not available)',
+    'session.summary.archiveCompare':
+      'Compare ZIP/TAR sides and copy files out into a folder (7z not available)',
     'session.summary.script': 'Run a simple script to load, compare, and export a report',
     'ui.archiveCompare': 'Comparar archivos',
     'ui.archivePathHint':

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -696,7 +696,8 @@ export const frFR: LanguagePack = {
     'ui.sheetSelectionEmpty': 'Sheets appear after Excel or HTML compare',
     'ui.sheetSelectionSummary':
       '{leftCount} left / {rightCount} right · {leftSheet} vs {rightSheet}',
-    'session.summary.archiveCompare': 'Compare ZIP or TAR contents (7z not available)',
+    'session.summary.archiveCompare':
+      'Compare ZIP/TAR sides and copy files out into a folder (7z not available)',
     'session.summary.script': 'Run a simple script to load, compare, and export a report',
     'ui.archiveCompare': 'Comparaison d’archives',
     'ui.archivePathHint':

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -683,7 +683,8 @@ export const jaJP: LanguagePack = {
     'session.summary.textMerge': 'Combine left, right, and a base file into one result',
     'session.summary.textPatch': 'Review and apply a patch file',
     'session.summary.versionCompare': 'Compare version info inside program files',
-    'session.summary.archiveCompare': 'Compare ZIP or TAR contents (7z not available)',
+    'session.summary.archiveCompare':
+      'Compare ZIP/TAR sides and copy files out into a folder (7z not available)',
     'session.summary.script': 'Run a simple script to load, compare, and export a report',
     'ui.archiveCompare': 'アーカイブ比較',
     'ui.archivePathHint':

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -680,7 +680,8 @@ export const koKR: LanguagePack = {
     'ui.sheetSelectionEmpty': 'Sheets appear after Excel or HTML compare',
     'ui.sheetSelectionSummary':
       '{leftCount} left / {rightCount} right · {leftSheet} vs {rightSheet}',
-    'session.summary.archiveCompare': 'Compare ZIP or TAR contents (7z not available)',
+    'session.summary.archiveCompare':
+      'Compare ZIP/TAR sides and copy files out into a folder (7z not available)',
     'session.summary.script': 'Run a simple script to load, compare, and export a report',
     'ui.archiveCompare': '아카이브 비교',
     'ui.archivePathHint':

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -667,7 +667,7 @@ export const zhCN: LanguagePack = {
     'ui.sheetNotSelected': '未选择',
     'ui.sheetSelectionEmpty': 'Excel 或 HTML 比较后显示工作表',
     'ui.sheetSelectionSummary': '左 {leftCount} / 右 {rightCount} · {leftSheet} vs {rightSheet}',
-    'session.summary.archiveCompare': '对比 ZIP/TAR 压缩包内容（7z 未实现）',
+    'session.summary.archiveCompare': '对比 ZIP/TAR 压缩包并支持复制到文件夹（7z 未实现）',
     'session.summary.script': '运行简单脚本：加载、比较、导出报告',
     'ui.archiveCompare': '压缩包比较',
     'ui.archivePathHint':

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -668,7 +668,7 @@ export const zhTW: LanguagePack = {
     'ui.sheetNotSelected': '未選擇',
     'ui.sheetSelectionEmpty': 'Excel 或 HTML 比較後顯示工作表',
     'ui.sheetSelectionSummary': '左 {leftCount} / 右 {rightCount} · {leftSheet} vs {rightSheet}',
-    'session.summary.archiveCompare': '對比 ZIP/TAR 壓縮檔內容（7z 未實作）',
+    'session.summary.archiveCompare': '對比 ZIP/TAR 壓縮檔並支援複製到資料夾（7z 未實作）',
     'session.summary.script': '執行簡單指令碼：載入、比較、匯出報告',
     'ui.archiveCompare': '壓縮檔比較',
     'ui.archivePathHint':

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -731,6 +731,25 @@ describe('FolderCompareView', () => {
     expect(wrapper.find('[data-testid="folder-browse-archive-left"]').exists()).toBe(true)
   })
 
+  it('disables copy into archive sides while leaving extract-to-folder enabled', async () => {
+    const wrapper = mountFolderCompareView()
+
+    await runCompare(wrapper)
+    await wrapper.find('[data-row-id="src-main-ts"]').trigger('click')
+
+    await wrapper.find('[data-testid="folder-left-root"]').setValue('/tmp/out-folder')
+    await wrapper.find('[data-testid="folder-right-root"]').setValue('/tmp/right.zip')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="folder-right-archive-chip"]').exists()).toBe(true)
+    expect(
+      wrapper.find('[data-testid="copy-selected-to-right"]').attributes('disabled'),
+    ).toBeDefined()
+    expect(
+      wrapper.find('[data-testid="copy-selected-to-left"]').attributes('disabled'),
+    ).toBeUndefined()
+  })
+
   it('shows snapshot side chips when roots are snapshot JSON paths', async () => {
     const wrapper = mountFolderCompareView()
 

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -701,7 +701,7 @@ const folderSessionToolbar = computed(() =>
     same: true,
     minor: false,
     rules: true,
-    copy: Boolean(selectedFilePath.value),
+    copy: canCopyToRight.value,
     expand: true,
     collapse: true,
     select: true,
@@ -729,7 +729,7 @@ function runFolderToolbarCommand(commandId: string): void {
       showFolderRules.value = !showFolderRules.value
       break
     case 'copy':
-      if (selectedFilePath.value) {
+      if (canCopyToRight.value) {
         copySelectedTo('Right')
       }
       break
@@ -1150,6 +1150,13 @@ const leftSideIsArchive = computed(() => isArchivePath(leftRoot.value))
 const rightSideIsArchive = computed(() => isArchivePath(rightRoot.value))
 const leftSideIsSnapshot = computed(() => isSnapshotPath(leftRoot.value))
 const rightSideIsSnapshot = computed(() => isSnapshotPath(rightRoot.value))
+/** Archives/snapshots are read-only targets; copy from archive into a folder is supported. */
+const canCopyToLeft = computed(
+  () => Boolean(selectedFilePath.value) && !leftSideIsArchive.value && !leftSideIsSnapshot.value,
+)
+const canCopyToRight = computed(
+  () => Boolean(selectedFilePath.value) && !rightSideIsArchive.value && !rightSideIsSnapshot.value,
+)
 
 async function browseArchive(side: 'left' | 'right'): Promise<void> {
   const selected = await pickNativePath({ directory: false })
@@ -2108,7 +2115,7 @@ onUnmounted(() => {
             size="small"
             secondary
             data-testid="copy-selected-to-left"
-            :disabled="!selectedFilePath"
+            :disabled="!canCopyToLeft"
             @click="copySelectedTo('Left')"
             >{{ $t('ui.copyLeft') }}</NButton
           >
@@ -2116,7 +2123,7 @@ onUnmounted(() => {
             size="small"
             secondary
             data-testid="copy-selected-to-right"
-            :disabled="!selectedFilePath"
+            :disabled="!canCopyToRight"
             @click="copySelectedTo('Right')"
             >{{ $t('ui.copyRight') }}</NButton
           >
@@ -2876,7 +2883,7 @@ onUnmounted(() => {
       <button
         type="button"
         data-testid="folder-ctx-copy-left"
-        :disabled="!selectedFilePath"
+        :disabled="!canCopyToLeft"
         @click="contextCopySelectedTo('Left')"
       >
         {{ $t('ui.copyLeft') }}
@@ -2884,7 +2891,7 @@ onUnmounted(() => {
       <button
         type="button"
         data-testid="folder-ctx-copy-right"
-        :disabled="!selectedFilePath"
+        :disabled="!canCopyToRight"
         @click="contextCopySelectedTo('Right')"
       >
         {{ $t('ui.copyRight') }}

--- a/src/views/HomeView.test.ts
+++ b/src/views/HomeView.test.ts
@@ -269,6 +269,51 @@ describe('HomeView', () => {
     expect(recentSessions.text()).not.toContain('Compare sample text')
   })
 
+  it('filters Auto-saved and Today tree rows by the same search box', async () => {
+    seedSampleSessions()
+    const store = useSavedSessionsStore()
+    const baseSession = store.sessions.at(0)
+
+    if (!baseSession) {
+      throw new Error('Expected the sample session list to contain at least one session.')
+    }
+
+    const today = new Date().toISOString()
+
+    store.saveSession({
+      ...baseSession,
+      id: 'today-release',
+      name: 'Today release check',
+      metadata: {
+        ...baseSession.metadata,
+        lastOpenedAt: today,
+        autoSaved: false,
+        locked: false,
+      },
+    })
+    store.autoSaveSession(
+      {
+        ...baseSession,
+        id: 'auto-other',
+        name: 'Auto other draft',
+        metadata: {
+          ...baseSession.metadata,
+          lastOpenedAt: today,
+        },
+      },
+      10,
+    )
+    const wrapper = mountHomeView()
+
+    expect(wrapper.find('[data-testid="home-tree-today-today-release"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="home-tree-autosaved-auto-other"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="session-search"]').setValue('release')
+
+    expect(wrapper.find('[data-testid="home-tree-today-today-release"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="home-tree-autosaved-auto-other"]').exists()).toBe(false)
+  })
+
   it('applies saved session management actions from the tree', async () => {
     seedSampleSessions()
     const wrapper = mountHomeView()

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -173,7 +173,7 @@ const todaySessions = computed(() => {
 
   const startMs = start.getTime()
 
-  return savedSessions.sessions.filter((session) => {
+  const todays = savedSessions.sessions.filter((session) => {
     const stamp = session.metadata.lastOpenedAt
 
     if (!stamp) {
@@ -184,8 +184,18 @@ const todaySessions = computed(() => {
 
     return Number.isFinite(opened) && opened >= startMs
   })
+
+  return filterSavedSessions(todays, {
+    query: sessionSearch.value,
+    types: new Set(),
+  })
 })
-const autoSavedTreeSessions = computed(() => savedSessions.autoSavedSessions)
+const autoSavedTreeSessions = computed(() =>
+  filterSavedSessions(savedSessions.autoSavedSessions, {
+    query: sessionSearch.value,
+    types: new Set(),
+  }),
+)
 const historyItems = computed(() =>
   savedSessions.sessions.slice(0, 6).map((session) => ({
     title: session.name,


### PR DESCRIPTION
## Summary
- Folder Compare copy can extract a file from a ZIP/TAR side into a normal folder (archives/snapshots stay read-only targets in the UI).
- Home Sessions search now filters Auto-saved and Today tree rows, not only the recent table.
- Archive Compare catalog maturity moves to partial with an updated summary.

## Test plan
- [x] `vitest` for HomeView, FolderCompareView, sessionCatalog, language skeletons
- [x] `cargo test --lib copy_folder_compare_entry_extracts_from_zip_into_folder`
- [x] eslint / prettier / vue-tsc on touched files
- [ ] Manual: open Folder Compare with a `.zip` on the left and a folder on the right → Copy Right extracts the selected file
- [ ] Manual: Home → type in the Sessions filter → Auto-saved / Today rows narrow with the recent table