### PR TITLE
Save Folder Sync reports and accept CLI sync alias

### DIFF
--- a/src-tauri/crates/cli-core/src/lib.rs
+++ b/src-tauri/crates/cli-core/src/lib.rs
@@ -244,7 +244,7 @@ where
         "compare-folders" => parse_compare_folders(args.collect()),
         "open-session" => parse_open_session(args.collect()),
         "open" => parse_open_compare(args.collect()),
-        "sync-preview" => parse_sync_preview(args.collect()),
+        "sync-preview" | "sync" => parse_sync_preview(args.collect()),
         "merge-text" => parse_merge_text(args.collect()),
         unknown => Err(usage_error(format!("unknown command: {unknown}"))),
     }
@@ -284,7 +284,7 @@ pub fn cli_help_text() -> String {
         "      --favor-left       prefer left on merge conflicts".to_owned(),
         "      --favor-right      prefer right on merge conflicts".to_owned(),
         "      --edit             open in an editable session when applicable".to_owned(),
-        "  sync-preview [--quiet] <left> <right>".to_owned(),
+        "  sync-preview|sync [--quiet] <left> <right>".to_owned(),
         "  merge-text --automerge [--favor-left|--favor-right] <base> <left> <right> [output]"
             .to_owned(),
         "Switches accept --name, -name, or /name forms.".to_owned(),
@@ -1446,6 +1446,17 @@ mod tests {
             .expect("sync-preview should parse");
         assert_eq!(
             sync.command,
+            CliCommand::SyncPreview {
+                left: "/tmp/a".to_owned(),
+                right: "/tmp/b".to_owned(),
+                quiet: false,
+            }
+        );
+
+        let sync_alias = parse_cli_args(["open-diff-cli", "sync", "/tmp/a", "/tmp/b"])
+            .expect("sync alias should parse as sync-preview");
+        assert_eq!(
+            sync_alias.command,
             CliCommand::SyncPreview {
                 left: "/tmp/a".to_owned(),
                 right: "/tmp/b".to_owned(),

--- a/src/app/folderSyncReport.test.ts
+++ b/src/app/folderSyncReport.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { buildFolderSyncReportText, defaultFolderSyncReportOutputPath } from './folderSyncReport'
+
+describe('folderSyncReport', () => {
+  it('builds a sibling folder-sync.txt path from the left folder', () => {
+    expect(defaultFolderSyncReportOutputPath('D:/deploy/package')).toBe('D:/deploy/folder-sync.txt')
+    expect(defaultFolderSyncReportOutputPath('D:/deploy/package/')).toBe(
+      'D:/deploy/folder-sync.txt',
+    )
+    expect(defaultFolderSyncReportOutputPath('/tmp/a')).toBe('/tmp/folder-sync.txt')
+    expect(defaultFolderSyncReportOutputPath('')).toBe('folder-sync.txt')
+    expect(defaultFolderSyncReportOutputPath('solo')).toBe('folder-sync.txt')
+  })
+
+  it('builds the clipboard/file FOLDER-SYNC-REPORT payload', () => {
+    const text = buildFolderSyncReportText({
+      leftPath: 'D:/deploy/package',
+      rightPath: 'D:/deploy/prod',
+      strategy: 'mirrorRight',
+      planName: 'Mirror to Right',
+      summary: { total: 2, copy: 1, delete: 1, leave: 0, conflict: 0, overridden: 1 },
+      rows: [
+        {
+          path: 'package/app.exe',
+          action: 'Copy',
+          planned: 'copyLeftToRight',
+          override: 'leave',
+          detail: 'Left item only exists',
+        },
+        {
+          path: 'prod/old.dll',
+          action: 'Delete',
+          planned: 'delete',
+          override: 'delete',
+          detail: 'Right item does not exist on left',
+        },
+      ],
+    })
+
+    expect(text).toContain('FOLDER-SYNC-REPORT')
+    expect(text).toContain('left: D:/deploy/package')
+    expect(text).toContain('strategy: mirrorRight')
+    expect(text).toContain('overridden: 1')
+    expect(text).toContain('package/app.exe\tCopy\tcopyLeftToRight\tleave\tLeft item only exists')
+    expect(text).toContain(
+      'prod/old.dll\tDelete\tdelete\tdelete\tRight item does not exist on left',
+    )
+  })
+})

--- a/src/app/folderSyncReport.ts
+++ b/src/app/folderSyncReport.ts
@@ -1,0 +1,65 @@
+export interface FolderSyncReportRow {
+  path: string
+  action: string
+  planned: string
+  override: string
+  detail: string
+}
+
+export interface FolderSyncReportSummary {
+  total: number
+  copy: number
+  delete: number
+  leave: number
+  conflict: number
+  overridden: number
+}
+
+export interface BuildFolderSyncReportTextInput {
+  leftPath: string
+  rightPath: string
+  strategy: string
+  planName: string
+  summary: FolderSyncReportSummary
+  rows: FolderSyncReportRow[]
+}
+
+/** Sibling text report path next to the left sync folder (matches folder-merge export style). */
+export function defaultFolderSyncReportOutputPath(leftPath: string): string {
+  const trimmed = leftPath.trim().replace(/[/\\]+$/u, '')
+
+  if (!trimmed) {
+    return 'folder-sync.txt'
+  }
+
+  const slash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+
+  if (slash < 0) {
+    return 'folder-sync.txt'
+  }
+
+  return `${trimmed.slice(0, slash + 1)}folder-sync.txt`
+}
+
+export function buildFolderSyncReportText(input: BuildFolderSyncReportTextInput): string {
+  const lines = [
+    'FOLDER-SYNC-REPORT',
+    `left: ${input.leftPath || '--'}`,
+    `right: ${input.rightPath || '--'}`,
+    `strategy: ${input.strategy || '--'}`,
+    `plan: ${input.planName || '--'}`,
+    `total: ${String(input.summary.total)}`,
+    `copy: ${String(input.summary.copy)}`,
+    `delete: ${String(input.summary.delete)}`,
+    `leave: ${String(input.summary.leave)}`,
+    `conflict: ${String(input.summary.conflict)}`,
+    `overridden: ${String(input.summary.overridden)}`,
+    '',
+    'rows:',
+    ...input.rows.map(
+      (row) => `${row.path}\t${row.action}\t${row.planned}\t${row.override}\t${row.detail}`,
+    ),
+  ]
+
+  return lines.join('\n')
+}

--- a/src/views/FolderSyncView.test.ts
+++ b/src/views/FolderSyncView.test.ts
@@ -9,7 +9,17 @@ vi.mock('vue-router', () => ({
   useRouter: () => ({ push }),
 }))
 import { executeFolderSync, previewFolderSync } from '@/api/sync'
+import { saveTextFile } from '@/api/diff'
 import { useSessionLaunchStore } from '@/stores/sessionLaunch'
+import { useViewActionsStore } from '@/stores/viewActions'
+
+vi.mock('@/api/diff', () => ({
+  createFolderSnapshot: vi.fn(),
+  saveTextFile: vi.fn().mockResolvedValue({
+    path: 'D:/deploy/folder-sync.txt',
+    bytesWritten: 64,
+  }),
+}))
 
 vi.mock('@/api/sync', () => ({
   executeFolderSync: vi.fn().mockResolvedValue({
@@ -69,10 +79,16 @@ vi.mock('@/api/sync', () => ({
   }),
 }))
 
+const clipboardWriteText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+
 describe('FolderSyncView', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: clipboardWriteText },
+    })
   })
 
   it('configures folder paths, strategy, preview, and run status', async () => {
@@ -257,5 +273,73 @@ describe('FolderSyncView', () => {
     expect(wrapper.find('[data-testid="folder-sync-peek-path"]').text()).toContain('prod/old.dll')
     await wrapper.find('[data-testid="folder-sync-peek-close"]').trigger('click')
     expect(wrapper.find('[data-testid="folder-sync-peek-panel"]').exists()).toBe(false)
+  })
+
+  it('exports the folder sync report to clipboard and a sibling text file', async () => {
+    const wrapper = mount(FolderSyncView, {
+      global: {
+        stubs: {
+          NButton: {
+            props: ['disabled', 'loading'],
+            emits: ['click'],
+            template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+          },
+        },
+      },
+    })
+
+    await wrapper.find('[data-testid="folder-sync-left-path"]').setValue('D:/deploy/package')
+    await wrapper.find('[data-testid="folder-sync-right-path"]').setValue('D:/deploy/prod')
+    await wrapper.find('[data-testid="folder-sync-strategy"]').setValue('mirrorRight')
+    await wrapper.find('[data-testid="folder-sync-preview"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('[data-testid="export-folder-sync-report"]').trigger('click')
+    await flushPromises()
+
+    expect(clipboardWriteText).toHaveBeenCalled()
+    const payload = clipboardWriteText.mock.calls[0]?.[0] ?? ''
+
+    expect(payload).toContain('FOLDER-SYNC-REPORT')
+    expect(payload).toContain('left: D:/deploy/package')
+    expect(payload).toContain('package/app.exe')
+    expect(saveTextFile).toHaveBeenCalledWith({
+      path: 'D:/deploy/folder-sync.txt',
+      text: payload,
+      createBackup: false,
+    })
+    expect(wrapper.find('[data-testid="folder-sync-report-status"]').text()).toBe(
+      'D:/deploy/folder-sync.txt',
+    )
+  })
+
+  it('wires Session Export to the sync report instead of toggling filters', async () => {
+    const wrapper = mount(FolderSyncView, {
+      global: {
+        stubs: {
+          NButton: {
+            props: ['disabled', 'loading'],
+            emits: ['click'],
+            template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+          },
+        },
+      },
+    })
+
+    await wrapper.find('[data-testid="folder-sync-left-path"]').setValue('D:/deploy/package')
+    await wrapper.find('[data-testid="folder-sync-right-path"]').setValue('D:/deploy/prod')
+    await wrapper.find('[data-testid="folder-sync-preview"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="folder-sync-filters-panel"]').exists()).toBe(false)
+
+    useViewActionsStore().dispatch('export')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="folder-sync-filters-panel"]').exists()).toBe(false)
+    expect(saveTextFile).toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="folder-sync-report-status"]').text()).toBe(
+      'D:/deploy/folder-sync.txt',
+    )
   })
 })

--- a/src/views/FolderSyncView.vue
+++ b/src/views/FolderSyncView.vue
@@ -12,7 +12,11 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import WorkbenchShell from '@/components/workbench/WorkbenchShell.vue'
 import WorkbenchInspector from '@/components/workbench/WorkbenchInspector.vue'
-import { createFolderSnapshot } from '@/api/diff'
+import { createFolderSnapshot, saveTextFile } from '@/api/diff'
+import {
+  buildFolderSyncReportText,
+  defaultFolderSyncReportOutputPath,
+} from '@/app/folderSyncReport'
 import { folderSnapshotOutputPath } from '@/app/snapshotPath'
 import { collectExpandablePrefixes, isPathHiddenByCollapse } from '@/app/folderPathGroups'
 import { buildFolderSyncToolbar, pathBaseName, syncPathPairTitle } from '@/app/sessionToolbars'
@@ -79,6 +83,8 @@ const visibleActions = ref<Set<FolderSyncPreviewAction>>(
   new Set(['Copy', 'Delete', 'Leave', 'Conflict']),
 )
 const lastSelectionAction = ref('')
+const reportStatus = ref('')
+const reportError = ref('')
 
 const selectedStrategyLabel = computed(() =>
   t(
@@ -289,6 +295,8 @@ async function previewSync(): Promise<void> {
     selectedPeekRowId.value = ''
     showPeek.value = false
     lastSelectionAction.value = ''
+    reportStatus.value = ''
+    reportError.value = ''
   } catch (error) {
     previewError.value = error instanceof Error ? error.message : String(error)
   } finally {
@@ -437,6 +445,54 @@ function swapSyncPaths(): void {
   leftPath.value = nextLeft
 }
 
+async function exportFolderSyncReport(): Promise<void> {
+  if (previewRows.value.length === 0) {
+    return
+  }
+
+  const summary = {
+    total: previewRows.value.length,
+    copy: previewRows.value.filter((row) => row.action === 'Copy').length,
+    delete: previewRows.value.filter((row) => row.action === 'Delete').length,
+    leave: previewRows.value.filter((row) => row.action === 'Leave').length,
+    conflict: previewRows.value.filter((row) => row.action === 'Conflict').length,
+    overridden: previewRows.value.filter((row) => row.overrideAction !== row.plannedAction).length,
+  }
+  const payload = buildFolderSyncReportText({
+    leftPath: leftPath.value,
+    rightPath: rightPath.value,
+    strategy: selectedStrategy.value,
+    planName: previewName.value,
+    summary,
+    rows: previewRows.value.map((row) => ({
+      path: row.relativePath,
+      action: row.action,
+      planned: row.plannedAction,
+      override: row.overrideAction,
+      detail: row.detail,
+    })),
+  })
+  const reportPath = defaultFolderSyncReportOutputPath(leftPath.value)
+
+  try {
+    await navigator.clipboard.writeText(payload)
+  } catch {
+    // Clipboard may be unavailable in headless tests; still try file export.
+  }
+
+  try {
+    await saveTextFile({
+      path: reportPath,
+      text: payload,
+      createBackup: false,
+    })
+    reportStatus.value = reportPath
+    reportError.value = ''
+  } catch (event) {
+    reportError.value = String(event)
+  }
+}
+
 async function saveSyncFolderSnapshot(): Promise<void> {
   const sourceRoot = leftPath.value.trim()
 
@@ -490,6 +546,8 @@ watch(
       case 'cut':
       case 'delete':
       case 'export':
+        void exportFolderSyncReport()
+        break
       case 'export-settings':
       case 'filters':
         showSyncFilters.value = !showSyncFilters.value
@@ -593,6 +651,24 @@ watch(
             :disabled="previewRows.length === 0 || syncRunning"
             @click="cancelSyncOverrides"
             >{{ $t('ui.cancel') }}</NButton
+          >
+          <NButton
+            size="small"
+            secondary
+            data-testid="export-folder-sync-report"
+            :disabled="previewRows.length === 0 || syncRunning"
+            @click="exportFolderSyncReport"
+            >{{ $t('ui.export') }}</NButton
+          >
+          <span
+            v-if="reportStatus"
+            data-testid="folder-sync-report-status"
+            >{{ reportStatus }}</span
+          >
+          <span
+            v-if="reportError"
+            data-testid="folder-sync-report-error"
+            >{{ reportError }}</span
           >
           <NButton
             size="small"


### PR DESCRIPTION
## Summary
- Folder Sync can export a sibling `folder-sync.txt` report (clipboard + disk), matching the other session report exports.
- Session Export on Folder Sync writes that report instead of toggling the filters panel.
- CLI accepts `sync` as an alias for `sync-preview`.

## Test plan
- [x] `vitest` for `folderSyncReport` + `FolderSyncView` (8 passed)
- [x] `cargo test -p cli-core parses_help_and_command_arguments`
- [x] eslint / prettier / rustfmt on touched files
- [ ] Manual: Folder Sync → Preview → Export → confirm sibling `folder-sync.txt` and status path
- [ ] Manual: Session → Export with a preview loaded → report writes, filters stay closed
- [ ] Manual: `open-diff-cli sync /tmp/a /tmp/b` behaves like `sync-preview`