### PR TITLE
Show Text Patch section preview panes and restore Options defaults

### DIFF
--- a/src/app/textPatchSections.test.ts
+++ b/src/app/textPatchSections.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   clampSectionIndex,
   flattenPatchSections,
+  reconstructAlignedRows,
   reconstructSidesFromFile,
   reconstructSidesFromHunk,
 } from './textPatchSections'
@@ -72,6 +73,32 @@ describe('textPatchSections', () => {
     expect(sides.left).toContain('gone')
     expect(sides.right).toContain('new')
     expect(sides.right).not.toContain('gone')
+  })
+
+  it('aligns remove+add as one side-by-side row', () => {
+    const rows = reconstructAlignedRows(sampleFiles[0].hunks[0].lines)
+
+    expect(rows).toEqual([
+      {
+        left: { text: 'keep', kind: 'context', lineNumber: 1 },
+        right: { text: 'keep', kind: 'context', lineNumber: 1 },
+      },
+      {
+        left: { text: 'old', kind: 'removed', lineNumber: 2 },
+        right: { text: 'new', kind: 'added', lineNumber: 2 },
+      },
+    ])
+  })
+
+  it('keeps unpaired removals and additions on their own rows', () => {
+    const rows = reconstructAlignedRows(sampleFiles[0].hunks[1].lines)
+
+    expect(rows).toEqual([
+      {
+        left: { text: 'gone', kind: 'removed', lineNumber: 10 },
+        right: { text: '', kind: 'empty', lineNumber: null },
+      },
+    ])
   })
 
   it('clamps section indices', () => {

--- a/src/app/textPatchSections.ts
+++ b/src/app/textPatchSections.ts
@@ -79,6 +79,81 @@ export function reconstructSidesFromFile(file: PatchFile): ReconstructedPatchSid
   return reconstructSidesFromLines(lines, file.oldPath, file.newPath)
 }
 
+export type ReconstructedPatchSideKind = 'context' | 'added' | 'removed' | 'empty'
+
+export interface ReconstructedPatchSideCell {
+  text: string
+  kind: ReconstructedPatchSideKind
+  lineNumber: number | null
+}
+
+export interface ReconstructedPatchRow {
+  left: ReconstructedPatchSideCell
+  right: ReconstructedPatchSideCell
+}
+
+function emptySideCell(): ReconstructedPatchSideCell {
+  return { text: '', kind: 'empty', lineNumber: null }
+}
+
+/** Align unified hunk lines into side-by-side rows (pairs remove+add as one row). */
+export function reconstructAlignedRows(lines: PatchLine[]): ReconstructedPatchRow[] {
+  const rows: ReconstructedPatchRow[] = []
+  let index = 0
+
+  while (index < lines.length) {
+    const line = lines[index]
+
+    if (line.kind === 'context') {
+      rows.push({
+        left: { text: line.text, kind: 'context', lineNumber: line.oldNumber },
+        right: { text: line.text, kind: 'context', lineNumber: line.newNumber },
+      })
+      index += 1
+      continue
+    }
+
+    if (line.kind === 'removed' && index + 1 < lines.length && lines[index + 1].kind === 'added') {
+      const next = lines[index + 1]
+
+      rows.push({
+        left: { text: line.text, kind: 'removed', lineNumber: line.oldNumber },
+        right: { text: next.text, kind: 'added', lineNumber: next.newNumber },
+      })
+      index += 2
+      continue
+    }
+
+    if (line.kind === 'removed') {
+      rows.push({
+        left: { text: line.text, kind: 'removed', lineNumber: line.oldNumber },
+        right: emptySideCell(),
+      })
+      index += 1
+      continue
+    }
+
+    rows.push({
+      left: emptySideCell(),
+      right: { text: line.text, kind: 'added', lineNumber: line.newNumber },
+    })
+    index += 1
+  }
+
+  return rows
+}
+
+export function reconstructAlignedRowsFromHunk(
+  file: PatchFile,
+  hunk: PatchHunk,
+): { rows: ReconstructedPatchRow[]; leftSource: string; rightSource: string } {
+  return {
+    rows: reconstructAlignedRows(hunk.lines),
+    leftSource: file.oldPath,
+    rightSource: file.newPath,
+  }
+}
+
 export function clampSectionIndex(index: number, total: number): number {
   if (total <= 0) {
     return 0

--- a/src/views/SettingsView.test.ts
+++ b/src/views/SettingsView.test.ts
@@ -238,6 +238,27 @@ describe('SettingsView', () => {
     expect(settings.wrapTextDefault).toBe(true)
   })
 
+  it('restores factory defaults from the Tweaks options card', async () => {
+    const wrapper = mountSettingsView()
+    const settings = useSettingsStore()
+
+    settings.setTheme('dark')
+    settings.setFontSize(18)
+    settings.setConfirmBeforeDelete(false)
+    settings.setShowSessionToolbars(false)
+
+    await wrapper.find('[data-testid="options-section-tweaks"]').trigger('click')
+    await wrapper.find('[data-testid="restore-factory-defaults"]').trigger('click')
+
+    expect(settings.theme).toBe('light')
+    expect(settings.fontSize).toBe(14)
+    expect(settings.confirmBeforeDelete).toBe(true)
+    expect(settings.showSessionToolbars).toBe(true)
+    expect(wrapper.find('[data-testid="options-restore-status"]').text()).toContain(
+      'Restore Factory Defaults',
+    )
+  })
+
   it('exposes tree-style options for toolbars, open with, shell, and backup', async () => {
     const wrapper = mountSettingsView()
     const settings = useSettingsStore()

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -39,6 +39,7 @@ const gitScope = ref<'global' | 'local'>('global')
 const executablePath = ref('open-diff')
 const svnWrapperPath = ref('')
 const integrationStatus = ref('')
+const optionsStatus = ref('')
 const integrationError = ref('')
 const integrationWriting = ref(false)
 const shortcutSearch = ref('')
@@ -281,6 +282,11 @@ function onShowToolbarLabelsChange(event: Event): void {
   }
 
   settings.setShowToolbarLabels(target.checked)
+}
+
+function restoreFactoryDefaultsFromOptions(): void {
+  settings.restoreFactoryDefaults()
+  optionsStatus.value = t('ui.restoreFactoryDefaults')
 }
 
 function onCreateBackupOnSaveChange(event: Event): void {
@@ -802,6 +808,19 @@ function parseShortcutText(value: string): string[] {
           />
           <span>{{ $t('ui.wrapTextDefault') }}</span>
         </label>
+        <NButton
+          size="small"
+          data-testid="restore-factory-defaults"
+          @click="restoreFactoryDefaultsFromOptions"
+          >{{ $t('ui.restoreFactoryDefaults') }}</NButton
+        >
+        <p
+          v-if="optionsStatus"
+          class="options-hint"
+          data-testid="options-restore-status"
+        >
+          {{ optionsStatus }}
+        </p>
       </NCard>
 
       <NCard

--- a/src/views/TextPatchView.test.ts
+++ b/src/views/TextPatchView.test.ts
@@ -198,6 +198,50 @@ describe('TextPatchView', () => {
     )
   })
 
+  it('shows a dual-pane reconstructed preview for the selected section', async () => {
+    const wrapper = mountTextPatchView()
+
+    wrapper
+      .findComponent(NInputStub)
+      .vm.$emit('update:value', 'diff --git a/src/main.ts b/src/main.ts')
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-testid="parse-text-patch"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="patch-section-preview"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="patch-section-preview-left-path"]').text()).toContain(
+      'a/src/main.ts',
+    )
+    expect(wrapper.find('[data-testid="patch-section-preview-right-path"]').text()).toContain(
+      'b/src/main.ts',
+    )
+    const leftRows = wrapper
+      .findAll('[data-testid="patch-section-preview-left-row"]')
+      .map((row) => row.text())
+    const rightRows = wrapper
+      .findAll('[data-testid="patch-section-preview-right-row"]')
+      .map((row) => row.text())
+
+    expect(leftRows.some((text) => text.includes('old'))).toBe(true)
+    expect(rightRows.some((text) => text.includes('new'))).toBe(true)
+
+    await wrapper.find('[data-testid="patch-next-section"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="patch-section-preview-position"]').text()).toContain(
+      '2 of 2',
+    )
+    const nextLeft = wrapper
+      .findAll('[data-testid="patch-section-preview-left-row"]')
+      .map((row) => row.text())
+    const nextRight = wrapper
+      .findAll('[data-testid="patch-section-preview-right-row"]')
+      .map((row) => row.text())
+
+    expect(nextLeft.some((text) => text.includes('gone'))).toBe(true)
+    expect(nextRight.some((text) => text.includes('here'))).toBe(true)
+  })
+
   it('opens reconstructed sides in Text Compare', async () => {
     const wrapper = mountTextPatchView()
     const inputs = wrapper.findAllComponents(NInputStub)

--- a/src/views/TextPatchView.vue
+++ b/src/views/TextPatchView.vue
@@ -6,6 +6,7 @@ import { buildTextPatchToolbar } from '@/app/sessionToolbars'
 import {
   clampSectionIndex,
   flattenPatchSections,
+  reconstructAlignedRowsFromHunk,
   reconstructSidesFromFile,
   reconstructSidesFromHunk,
 } from '@/app/textPatchSections'
@@ -63,6 +64,19 @@ const sectionPositionLabel = computed(() => {
     index: clampSectionIndex(selectedSectionIndex.value, total) + 1,
     total,
   })
+})
+const currentSectionPreview = computed(() => {
+  const section = currentSection.value
+  const files = result.value?.files ?? []
+
+  if (!section) {
+    return null
+  }
+
+  const file = files[section.fileIndex]
+  const hunk = file.hunks[section.hunkIndex]
+
+  return reconstructAlignedRowsFromHunk(file, hunk)
 })
 const patchSessionToolbar = computed(() =>
   buildTextPatchToolbar({
@@ -569,6 +583,63 @@ function lineNumber(value: number | null): string {
       </NAlert>
 
       <section
+        v-if="currentSectionPreview"
+        class="patch-section-preview"
+        data-testid="patch-section-preview"
+      >
+        <header class="patch-section-preview-header">
+          <strong>{{ $t('ui.section') }} · {{ $t('ui.preview') }}</strong>
+          <span data-testid="patch-section-preview-position">{{ sectionPositionLabel }}</span>
+        </header>
+        <div class="patch-section-panes">
+          <article
+            class="patch-section-pane"
+            data-testid="patch-section-preview-left"
+          >
+            <header data-testid="patch-section-preview-left-path">
+              {{ currentSectionPreview.leftSource }}
+            </header>
+            <div class="patch-section-pane-body">
+              <div
+                v-for="(row, rowIndex) in currentSectionPreview.rows"
+                :key="`left-${rowIndex}`"
+                class="patch-preview-row"
+                :class="`patch-preview-${row.left.kind}`"
+                data-testid="patch-section-preview-left-row"
+              >
+                <span class="patch-preview-line-number">{{
+                  row.left.lineNumber === null ? '' : row.left.lineNumber
+                }}</span>
+                <span class="patch-preview-text">{{ row.left.text }}</span>
+              </div>
+            </div>
+          </article>
+          <article
+            class="patch-section-pane"
+            data-testid="patch-section-preview-right"
+          >
+            <header data-testid="patch-section-preview-right-path">
+              {{ currentSectionPreview.rightSource }}
+            </header>
+            <div class="patch-section-pane-body">
+              <div
+                v-for="(row, rowIndex) in currentSectionPreview.rows"
+                :key="`right-${rowIndex}`"
+                class="patch-preview-row"
+                :class="`patch-preview-${row.right.kind}`"
+                data-testid="patch-section-preview-right-row"
+              >
+                <span class="patch-preview-line-number">{{
+                  row.right.lineNumber === null ? '' : row.right.lineNumber
+                }}</span>
+                <span class="patch-preview-text">{{ row.right.text }}</span>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section
         v-if="result"
         class="patch-result"
         data-testid="text-patch-result"
@@ -685,7 +756,7 @@ function lineNumber(value: number | null): string {
 
 .patch-workbench-main {
   display: grid;
-  grid-template-rows: minmax(112px, 0.34fr) auto minmax(0, 1fr);
+  grid-template-rows: minmax(96px, 0.28fr) auto minmax(140px, 0.42fr) minmax(0, 1fr);
   gap: 10px;
   height: 100%;
   min-height: 0;
@@ -850,5 +921,109 @@ function lineNumber(value: number | null): string {
   border-radius: 4px;
   color: var(--app-text-muted);
   place-items: center;
+}
+
+.patch-section-preview {
+  display: grid;
+  grid-template-rows: 28px minmax(0, 1fr);
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--app-border);
+  background: var(--app-canvas);
+}
+
+.patch-section-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--app-border);
+  background: var(--app-surface-low);
+  color: var(--app-text-muted);
+  font-size: 12px;
+}
+
+.patch-section-preview-header strong {
+  color: var(--app-text);
+}
+
+.patch-section-panes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.patch-section-pane {
+  display: grid;
+  grid-template-rows: 28px minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  border-right: 1px solid var(--app-border);
+}
+
+.patch-section-pane:last-child {
+  border-right: none;
+}
+
+.patch-section-pane > header {
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--app-border);
+  background: var(--app-surface-low);
+  color: var(--app-text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.patch-section-pane-body {
+  min-height: 0;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.patch-preview-row {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 8px;
+  min-height: 20px;
+  padding: 0 8px;
+}
+
+.patch-preview-line-number {
+  color: var(--app-text-muted);
+  text-align: right;
+  user-select: none;
+}
+
+.patch-preview-text {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.patch-preview-removed {
+  background: color-mix(in srgb, var(--diff-deleted-bg, #fff0f0) 85%, transparent);
+  color: var(--diff-deleted-fg, #b42318);
+}
+
+.patch-preview-added {
+  background: color-mix(in srgb, var(--diff-added-bg, #f0fff4) 85%, transparent);
+  color: var(--diff-added-fg, #027a48);
+}
+
+.patch-preview-empty {
+  background: transparent;
+  color: transparent;
+}
+
+.patch-preview-context {
+  background: transparent;
 }
 </style>


### PR DESCRIPTION
## Summary
- Text Patch shows a dual-pane reconstructed preview for the selected section (paths + aligned rows), updating with Next/Prev Section.
- Options Tweaks includes Restore Factory Defaults (same reset as Tools menu).

## Still short of captures
- Text Patch chrome is still Workbench-based; raw hunk list remains below the preview.
- Options Appearance/Toolbars/Tweaks depth is still thinner than a full options tree.

## Test plan
- [x] `vitest` for `textPatchSections`, `TextPatchView`, `SettingsView` (29 passed)
- [x] eslint / prettier / stylelint / `vue-tsc` on touched files
- [ ] Manual: parse a multi-hunk patch, confirm dual-pane preview flips with Next/Prev Section
- [ ] Manual: Options → Tweaks → Restore Factory Defaults resets theme/font/tweaks