### PR TITLE
Deepen Folder Merge and Sync session toolbar chrome

### DIFF
--- a/src/app/sessionToolbars.test.ts
+++ b/src/app/sessionToolbars.test.ts
@@ -163,40 +163,53 @@ describe('sessionToolbars', () => {
     expect(toolbar.find((item) => item.id === 'prev-section')?.enabled).toBe(false)
   })
 
-  it('keeps Folder Sync toolbar chrome for expand/collapse/select/filters/home/peek', () => {
+  it('keeps Folder Sync toolbar chrome with Accept/Cancel/Sync Now', () => {
     const toolbar = buildFolderSyncToolbar({
       home: true,
+      minor: true,
       expand: true,
       collapse: true,
       select: true,
-      filters: true,
       refresh: true,
-      swap: true,
       stop: false,
       peek: true,
+      'sync-now': true,
+      cancel: true,
+      accept: true,
     })
 
     expect(toolbar.map((item) => item.id)).toEqual([...folderSyncToolbarOrder])
     expect(toolbar.find((item) => item.id === 'home')?.enabled).toBe(true)
-    expect(toolbar.find((item) => item.id === 'select')?.enabled).toBe(true)
+    expect(toolbar.find((item) => item.id === 'accept')?.enabled).toBe(true)
+    expect(toolbar.find((item) => item.id === 'sync-now')?.enabled).toBe(true)
     expect(toolbar.find((item) => item.id === 'stop')?.enabled).toBe(false)
-    expect(toolbar.find((item) => item.id === 'peek')?.enabled).toBe(true)
   })
 
-  it('keeps Folder Merge toolbar chrome for expand/collapse/select', () => {
+  it('keeps Folder Merge toolbar chrome with Same OK / Merge / To Output', () => {
     const toolbar = buildFolderMergeToolbar({
       home: true,
+      all: true,
+      same: true,
+      minor: true,
+      'same-ok': true,
+      rules: true,
+      merge: true,
+      'to-output': true,
       expand: true,
       collapse: true,
       select: true,
-      same: true,
-      filters: true,
+      files: true,
       refresh: true,
+      swap: true,
+      stop: false,
+      filters: true,
       peek: true,
     })
 
     expect(toolbar.map((item) => item.id)).toEqual([...folderMergeToolbarOrder])
-    expect(toolbar.find((item) => item.id === 'expand')?.enabled).toBe(true)
+    expect(toolbar.find((item) => item.id === 'merge')?.enabled).toBe(true)
+    expect(toolbar.find((item) => item.id === 'to-output')?.enabled).toBe(true)
+    expect(toolbar.find((item) => item.id === 'same-ok')?.enabled).toBe(true)
     expect(toolbar.find((item) => item.id === 'peek')?.enabled).toBe(true)
   })
 })

--- a/src/app/sessionToolbars.ts
+++ b/src/app/sessionToolbars.ts
@@ -127,24 +127,35 @@ export const clipboardCompareToolbarOrder = [
 
 export const folderSyncToolbarOrder = [
   'home',
+  'minor',
   'expand',
   'collapse',
   'select',
-  'filters',
   'refresh',
-  'swap',
   'stop',
   'peek',
+  'sync-now',
+  'cancel',
+  'accept',
 ] as const
 
 export const folderMergeToolbarOrder = [
   'home',
+  'all',
+  'same',
+  'minor',
+  'same-ok',
+  'rules',
+  'merge',
+  'to-output',
   'expand',
   'collapse',
   'select',
-  'same',
-  'filters',
+  'files',
   'refresh',
+  'swap',
+  'stop',
+  'filters',
   'peek',
 ] as const
 
@@ -277,24 +288,35 @@ const clipboardMeta: Record<(typeof clipboardCompareToolbarOrder)[number], Toolb
 
 const folderSyncMeta: Record<(typeof folderSyncToolbarOrder)[number], ToolbarMeta> = {
   home: { glyph: 'H', labelKey: 'ui.home' },
+  minor: { glyph: '~', labelKey: 'ui.minor' },
   expand: { glyph: '+', labelKey: 'ui.expand' },
   collapse: { glyph: '-', labelKey: 'ui.collapse' },
   select: { glyph: 'V', labelKey: 'ui.select' },
-  filters: { glyph: 'F', labelKey: 'ui.filters' },
   refresh: { glyph: 'R', labelKey: 'ui.refresh' },
-  swap: { glyph: '<>', labelKey: 'ui.swap' },
   stop: { glyph: 'X', labelKey: 'ui.stop' },
   peek: { glyph: 'P', labelKey: 'ui.peek' },
+  'sync-now': { glyph: '>', labelKey: 'ui.syncNow' },
+  cancel: { glyph: 'X', labelKey: 'ui.cancel' },
+  accept: { glyph: 'OK', labelKey: 'ui.accept' },
 }
 
 const folderMergeMeta: Record<(typeof folderMergeToolbarOrder)[number], ToolbarMeta> = {
   home: { glyph: 'H', labelKey: 'ui.home' },
+  all: { glyph: '*', labelKey: 'ui.all' },
+  same: { glyph: '=', labelKey: 'ui.same' },
+  minor: { glyph: '~', labelKey: 'ui.minor' },
+  'same-ok': { glyph: 'OK', labelKey: 'ui.sameOk' },
+  rules: { glyph: 'R', labelKey: 'ui.rules' },
+  merge: { glyph: 'M', labelKey: 'ui.merge' },
+  'to-output': { glyph: 'O', labelKey: 'ui.toOutput' },
   expand: { glyph: '+', labelKey: 'ui.expand' },
   collapse: { glyph: '-', labelKey: 'ui.collapse' },
   select: { glyph: 'V', labelKey: 'ui.select' },
-  same: { glyph: '=', labelKey: 'ui.sameOk' },
-  filters: { glyph: 'F', labelKey: 'ui.filters' },
+  files: { glyph: 'F', labelKey: 'ui.files' },
   refresh: { glyph: 'R', labelKey: 'ui.refresh' },
+  swap: { glyph: '<>', labelKey: 'ui.swap' },
+  stop: { glyph: 'X', labelKey: 'ui.stop' },
+  filters: { glyph: 'F', labelKey: 'ui.filters' },
   peek: { glyph: 'P', labelKey: 'ui.peek' },
 }
 

--- a/src/components/workbench/WorkbenchShell.vue
+++ b/src/components/workbench/WorkbenchShell.vue
@@ -56,9 +56,14 @@ function toolbarForTitle(title: string): LegacyToolbarItem[] {
       item('all', 'ui.all', '*'),
       item('same', 'ui.same', '='),
       item('minor', 'ui.minor', '~'),
+      item('same-ok', 'ui.sameOk', 'OK'),
       item('rules', 'ui.rules', 'R'),
+      item('merge', 'ui.merge', 'M'),
+      item('to-output', 'ui.toOutput', 'O'),
       item('expand', 'ui.expand', '+'),
       item('collapse', 'ui.collapse', '-'),
+      item('select', 'ui.select', 'V'),
+      item('files', 'ui.files', 'F'),
       item('refresh', 'ui.refresh', 'R'),
       item('swap', 'ui.swap', '<>'),
       item('stop', 'ui.stop', 'X'),
@@ -73,9 +78,13 @@ function toolbarForTitle(title: string): LegacyToolbarItem[] {
       item('minor', 'ui.minor', '~'),
       item('expand', 'ui.expand', '+'),
       item('collapse', 'ui.collapse', '-'),
+      item('select', 'ui.select', 'V'),
       item('refresh', 'ui.refresh', 'R'),
       item('stop', 'ui.stop', 'X'),
       item('peek', 'ui.peek', 'P'),
+      item('sync-now', 'ui.syncNow', '>'),
+      item('cancel', 'ui.cancel', 'X'),
+      item('accept', 'ui.accept', 'OK'),
     ]
   }
 

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -960,6 +960,9 @@ export const deDE: LanguagePack = {
     'ui.windowLength': 'Window length',
     'ui.accept': 'Akzeptieren',
     'ui.syncNow': 'Jetzt synchronisieren',
+    'ui.toOutput': 'Zur Ausgabe',
+    'ui.folderMergeRulesHint':
+      'Automatische Kopien gehen in die Ausgabe; Konflikte öffnen die Textzusammenführung.',
     'ui.sameOk': 'Gleiche OK',
     'ui.plannedAction': 'Geplant',
     'ui.override': 'Überschreiben',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -940,6 +940,8 @@ export const enUS: LanguagePack = {
     'ui.windowLength': 'Window length',
     'ui.accept': 'Accept',
     'ui.syncNow': 'Sync Now',
+    'ui.toOutput': 'To Output',
+    'ui.folderMergeRulesHint': 'Automatic copies go to output; conflicts open in Text Merge.',
     'ui.sameOk': 'Same OK',
     'ui.plannedAction': 'Planned',
     'ui.override': 'Override',

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -955,6 +955,9 @@ export const esES: LanguagePack = {
     'ui.windowLength': 'Window length',
     'ui.accept': 'Aceptar',
     'ui.syncNow': 'Sincronizar ahora',
+    'ui.toOutput': 'A la salida',
+    'ui.folderMergeRulesHint':
+      'Las copias automáticas van a la salida; los conflictos se abren en la fusión de texto.',
     'ui.sameOk': 'Iguales OK',
     'ui.plannedAction': 'Planificado',
     'ui.override': 'Anular',

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -957,6 +957,9 @@ export const frFR: LanguagePack = {
     'ui.windowLength': 'Window length',
     'ui.accept': 'Accepter',
     'ui.syncNow': 'Synchroniser maintenant',
+    'ui.toOutput': 'Vers la sortie',
+    'ui.folderMergeRulesHint':
+      'Les copies automatiques vont vers la sortie ; les conflits s’ouvrent dans la fusion de texte.',
     'ui.sameOk': 'Identiques OK',
     'ui.plannedAction': 'Prévu',
     'ui.override': 'Remplacer',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -940,6 +940,8 @@ export const jaJP: LanguagePack = {
     'ui.windowLength': 'Window length',
     'ui.accept': '承認',
     'ui.syncNow': '今すぐ同期',
+    'ui.toOutput': '出力へ',
+    'ui.folderMergeRulesHint': '自動コピーは出力へ。競合はテキストマージで開きます。',
     'ui.sameOk': '同一 OK',
     'ui.plannedAction': '予定',
     'ui.override': '上書き',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -934,6 +934,8 @@ export const koKR: LanguagePack = {
     'ui.windowLength': 'Window length',
     'ui.accept': '수락',
     'ui.syncNow': '지금 동기화',
+    'ui.toOutput': '출력으로',
+    'ui.folderMergeRulesHint': '자동 복사는 출력으로 가고, 충돌은 텍스트 병합에서 엽니다.',
     'ui.sameOk': '동일 OK',
     'ui.plannedAction': '예정',
     'ui.override': '재정의',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -913,6 +913,8 @@ export const zhCN: LanguagePack = {
     'ui.windowLength': '窗口长度',
     'ui.accept': '接受',
     'ui.syncNow': '立即同步',
+    'ui.toOutput': '到输出',
+    'ui.folderMergeRulesHint': '可自动复制的项写入输出；冲突在文本合并中处理。',
     'ui.sameOk': '相同可用',
     'ui.plannedAction': '计划操作',
     'ui.override': '覆盖',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -914,6 +914,8 @@ export const zhTW: LanguagePack = {
     'ui.windowLength': '視窗長度',
     'ui.accept': '接受',
     'ui.syncNow': '立即同步',
+    'ui.toOutput': '到輸出',
+    'ui.folderMergeRulesHint': '可自動複製的項目寫入輸出；衝突在文字合併中處理。',
     'ui.sameOk': '相同可用',
     'ui.plannedAction': '計劃操作',
     'ui.override': '覆寫',

--- a/src/views/FolderMergeView.test.ts
+++ b/src/views/FolderMergeView.test.ts
@@ -261,6 +261,11 @@ describe('FolderMergeView', () => {
       true,
     )
     expect(wrapper.find('[data-testid="folder-merge-session-toolbar-select"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-merge-session-toolbar-same-ok"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-merge-session-toolbar-merge"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-merge-session-toolbar-to-output"]').exists()).toBe(
+      true,
+    )
 
     await wrapper.find('[data-testid="folder-merge-session-toolbar-select"]').trigger('click')
     expect(wrapper.find('[data-testid="folder-merge-select-panel"]').exists()).toBe(true)
@@ -271,6 +276,17 @@ describe('FolderMergeView', () => {
 
     await wrapper.find('[data-testid="folder-merge-session-toolbar-filters"]').trigger('click')
     expect(wrapper.find('[data-testid="folder-merge-filters-panel"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="folder-merge-session-toolbar-rules"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-merge-rules-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-merge-rules-summary"]').text()).toContain('1')
+
+    await wrapper.find('[data-testid="folder-merge-session-toolbar-same"]').trigger('click')
+    expect(wrapper.find('[data-testid="folder-merge-filter-state"]').text()).toContain('Same')
+
+    await wrapper.find('[data-testid="folder-merge-session-toolbar-merge"]').trigger('click')
+    await flushPromises()
+    expect(executeFolderMergePlan).toHaveBeenCalled()
   })
 
   it('exports the folder merge report to clipboard and a sibling text file', async () => {

--- a/src/views/FolderMergeView.vue
+++ b/src/views/FolderMergeView.vue
@@ -44,37 +44,63 @@ const { t } = useI18n()
 const viewActions = useViewActionsStore()
 const lastOpenedConflictPath = ref('')
 const sameOkOnly = ref(false)
+const importanceFilter = ref<'all' | 'same' | 'minor'>('all')
+const filesOnlyFilter = ref(false)
 const showPeek = ref(false)
+const showMergeRules = ref(false)
 const selectedPlanRowId = ref('')
 const collapsedPrefixes = ref<Set<string>>(new Set())
 const showMergeFilters = ref(false)
 const showMergeSelect = ref(false)
 const checkedRowIds = ref<Set<string>>(new Set())
 const lastSelectionAction = ref('')
+const mergeChromeMessage = ref('')
 
 const planRows = computed<FolderMergePlanRow[]>(() => plan.value?.rows ?? [])
 const hasPlan = computed(() => planRows.value.length > 0)
 const filteredPlanRows = computed(() => {
-  if (!sameOkOnly.value) {
-    return planRows.value
+  let rows = planRows.value
+
+  if (sameOkOnly.value || importanceFilter.value === 'same') {
+    rows = rows.filter((row) => row.action === 'Keep output')
+  } else if (importanceFilter.value === 'minor') {
+    rows = rows.filter((row) => !row.conflict && row.action !== 'Keep output')
   }
 
-  return planRows.value.filter((row) => row.action === 'Keep output')
+  if (filesOnlyFilter.value) {
+    rows = rows.filter(
+      (row) => row.left.kind === 'File' || row.right.kind === 'File' || row.base.kind === 'File',
+    )
+  }
+
+  return rows
 })
 const visiblePlanRows = computed(() =>
   filteredPlanRows.value.filter(
     (row) => !isPathHiddenByCollapse(row.path, collapsedPrefixes.value),
   ),
 )
+const canBuildMergePlan = computed(() =>
+  Boolean(leftPath.value && basePath.value && rightPath.value),
+)
 const mergeSessionToolbar = computed(() =>
   buildFolderMergeToolbar({
     home: true,
+    all: hasPlan.value,
+    same: hasPlan.value,
+    minor: hasPlan.value,
+    'same-ok': hasPlan.value,
+    rules: hasPlan.value,
+    merge: hasPlan.value && Boolean(outputPath.value) && !mergeExecuting.value,
+    'to-output': Boolean(outputPath.value),
     expand: hasPlan.value,
     collapse: hasPlan.value,
     select: hasPlan.value,
-    same: hasPlan.value,
+    files: hasPlan.value,
+    refresh: canBuildMergePlan.value,
+    swap: Boolean(leftPath.value || rightPath.value),
+    stop: mergeExecuting.value,
     filters: hasPlan.value,
-    refresh: Boolean(leftPath.value && basePath.value && rightPath.value),
     peek: hasPlan.value,
   }),
 )
@@ -145,6 +171,27 @@ function runMergeToolbarCommand(commandId: string): void {
     case 'home':
       goHomeFromMerge()
       break
+    case 'all':
+      setImportanceFilter('all')
+      break
+    case 'same':
+      setImportanceFilter('same')
+      break
+    case 'minor':
+      toggleMinorImportanceFilter()
+      break
+    case 'same-ok':
+      toggleSameOkFilter()
+      break
+    case 'rules':
+      showMergeRules.value = !showMergeRules.value
+      break
+    case 'merge':
+      void runFolderMerge()
+      break
+    case 'to-output':
+      openOutputFolderCompare()
+      break
     case 'expand':
       expandAllMergePaths()
       break
@@ -154,8 +201,8 @@ function runMergeToolbarCommand(commandId: string): void {
     case 'select':
       showMergeSelect.value = !showMergeSelect.value
       break
-    case 'same':
-      toggleSameOkFilter()
+    case 'files':
+      filesOnlyFilter.value = !filesOnlyFilter.value
       break
     case 'filters':
       showMergeFilters.value = !showMergeFilters.value
@@ -163,12 +210,57 @@ function runMergeToolbarCommand(commandId: string): void {
     case 'refresh':
       void buildFolderMergePlan()
       break
+    case 'swap':
+      swapMergeSides()
+      break
+    case 'stop':
+      stopMergeWork()
+      break
     case 'peek':
       togglePeekPanel()
       break
     default:
       break
   }
+}
+
+function swapMergeSides(): void {
+  const previousLeft = leftPath.value
+
+  leftPath.value = rightPath.value
+  rightPath.value = previousLeft
+  plan.value = undefined
+  execution.value = undefined
+  mergeChromeMessage.value = t('ui.swap')
+}
+
+function stopMergeWork(): void {
+  mergeChromeMessage.value = t('ui.stop')
+}
+
+function openOutputFolderCompare(): void {
+  const output = outputPath.value.trim()
+
+  if (!output) {
+    return
+  }
+
+  const compareRight = leftPath.value.trim() || basePath.value.trim() || rightPath.value.trim()
+
+  sessionLaunch.setPendingLaunch({
+    id: crypto.randomUUID(),
+    source: 'command',
+    sessionType: 'folder-compare',
+    title: pathBaseName(output),
+    route: '/compare/folder',
+    autoRun: Boolean(compareRight),
+    locations: {
+      left: { uri: output, kind: 'directory', readOnly: false },
+      ...(compareRight ? { right: { uri: compareRight, kind: 'directory', readOnly: false } } : {}),
+    },
+  })
+  tabs.openTab({ title: pathBaseName(output), route: '/compare/folder', dirty: false })
+  void router.push('/compare/folder')
 }
 
 const selectedPlanRow = computed(
@@ -252,6 +344,7 @@ async function buildFolderMergePlan(): Promise<void> {
 async function runFolderMerge(): Promise<void> {
   mergeExecuting.value = true
   mergeExecutionError.value = undefined
+  mergeChromeMessage.value = ''
 
   try {
     execution.value = await executeFolderMergePlan({
@@ -339,6 +432,15 @@ function selectPlanRow(row: FolderMergePlanRow): void {
 
 function toggleSameOkFilter(): void {
   sameOkOnly.value = !sameOkOnly.value
+}
+
+function setImportanceFilter(next: 'all' | 'same' | 'minor'): void {
+  importanceFilter.value = next
+  sameOkOnly.value = false
+}
+
+function toggleMinorImportanceFilter(): void {
+  setImportanceFilter(importanceFilter.value === 'minor' ? 'all' : 'minor')
 }
 
 function togglePeekPanel(): void {
@@ -580,6 +682,27 @@ watch(
         </div>
       </section>
 
+      <p
+        v-if="mergeChromeMessage"
+        class="merge-open-status"
+        data-testid="folder-merge-chrome-status"
+      >
+        {{ mergeChromeMessage }}
+      </p>
+
+      <section
+        v-if="showMergeRules && hasPlan"
+        class="merge-chrome-panel"
+        data-testid="folder-merge-rules-panel"
+      >
+        <strong>{{ $t('ui.rules') }}</strong>
+        <span data-testid="folder-merge-rules-summary">
+          {{ $t('ui.actions') }}: {{ summary.actions }} / {{ $t('ui.conflicts') }}:
+          {{ summary.conflicts }} / {{ $t('ui.sameOk') }}: {{ sameOkCount }}
+        </span>
+        <span>{{ $t('ui.folderMergeRulesHint') }}</span>
+      </section>
+
       <section
         v-if="lastOpenedConflictPath"
         class="merge-open-status"
@@ -627,12 +750,49 @@ watch(
         <strong>{{ $t('ui.filters') }}</strong>
         <button
           type="button"
+          data-testid="folder-merge-filter-all"
+          @click="setImportanceFilter('all')"
+        >
+          {{ $t('ui.all') }}
+        </button>
+        <button
+          type="button"
+          data-testid="folder-merge-filter-same"
+          @click="setImportanceFilter('same')"
+        >
+          {{ $t('ui.same') }}
+        </button>
+        <button
+          type="button"
+          data-testid="folder-merge-filter-minor"
+          @click="toggleMinorImportanceFilter"
+        >
+          {{ $t('ui.minor') }}
+        </button>
+        <button
+          type="button"
           data-testid="folder-merge-filter-same-ok"
           @click="toggleSameOkFilter"
         >
           {{ $t('ui.sameOk') }} ({{ sameOkCount }})
         </button>
-        <span>{{ sameOkOnly ? $t('ui.sameOk') : $t('ui.all') }}</span>
+        <label class="merge-files-only">
+          <input
+            v-model="filesOnlyFilter"
+            type="checkbox"
+            data-testid="folder-merge-files-only"
+          />
+          <span>{{ $t('ui.filesOnly') }}</span>
+        </label>
+        <span data-testid="folder-merge-filter-state">{{
+          sameOkOnly
+            ? $t('ui.sameOk')
+            : importanceFilter === 'same'
+              ? $t('ui.same')
+              : importanceFilter === 'minor'
+                ? $t('ui.minor')
+                : $t('ui.all')
+        }}</span>
       </section>
 
       <section

--- a/src/views/FolderSyncView.test.ts
+++ b/src/views/FolderSyncView.test.ts
@@ -251,8 +251,24 @@ describe('FolderSyncView', () => {
       wrapper.find('[data-testid="folder-sync-session-toolbar-collapse"]').attributes('disabled'),
     ).toBeUndefined()
 
-    await wrapper.find('[data-testid="folder-sync-session-toolbar-filters"]').trigger('click')
-    expect(wrapper.find('[data-testid="folder-sync-filters-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-accept"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-cancel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-sync-now"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="folder-sync-session-toolbar-minor"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="folder-sync-session-toolbar-accept"]').trigger('click')
+    expect(
+      wrapper.find('[data-testid="folder-sync-chrome-status"]').text().toLowerCase(),
+    ).toContain('accept')
+    expect(
+      wrapper.find('[data-testid="folder-sync-session-toolbar-sync-now"]').attributes('disabled'),
+    ).toBeUndefined()
+
+    await wrapper.find('[data-testid="folder-sync-session-toolbar-minor"]').trigger('click')
+    expect(wrapper.find('[data-testid="sync-row-copy-app"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="folder-sync-session-toolbar-minor"]').trigger('click')
+    expect(wrapper.find('[data-testid="sync-row-copy-app"]').exists()).toBe(true)
 
     await wrapper.find('[data-testid="folder-sync-session-toolbar-select"]').trigger('click')
     expect(wrapper.find('[data-testid="folder-sync-select-panel"]').exists()).toBe(true)

--- a/src/views/FolderSyncView.vue
+++ b/src/views/FolderSyncView.vue
@@ -78,6 +78,7 @@ const showSyncFilters = ref(false)
 const showSyncSelect = ref(false)
 const checkedRowIds = ref<Set<string>>(new Set())
 const showPeek = ref(false)
+const minorOnly = ref(false)
 const selectedPeekRowId = ref('')
 const visibleActions = ref<Set<FolderSyncPreviewAction>>(
   new Set(['Copy', 'Delete', 'Leave', 'Conflict']),
@@ -106,7 +107,17 @@ const syncSessionTitle = computed(() => {
   return t('ui.folderSync')
 })
 const filteredPreviewRows = computed(() =>
-  previewRows.value.filter((row) => visibleActions.value.has(row.action)),
+  previewRows.value.filter((row) => {
+    if (!visibleActions.value.has(row.action)) {
+      return false
+    }
+
+    if (minorOnly.value) {
+      return row.action === 'Leave'
+    }
+
+    return true
+  }),
 )
 const visiblePreviewRows = computed(() =>
   filteredPreviewRows.value.filter(
@@ -119,14 +130,16 @@ const selectedPeekRow = computed(
 const syncSessionToolbar = computed(() =>
   buildFolderSyncToolbar({
     home: true,
+    minor: previewRows.value.length > 0,
     expand: previewRows.value.length > 0,
     collapse: previewRows.value.length > 0,
     select: previewRows.value.length > 0,
-    filters: previewRows.value.length > 0,
     refresh: Boolean(leftPath.value && rightPath.value) && !previewLoading.value,
-    swap: Boolean(leftPath.value || rightPath.value),
     stop: previewLoading.value || syncRunning.value,
     peek: previewRows.value.length > 0,
+    'sync-now': canRunSync.value,
+    cancel: previewRows.value.length > 0,
+    accept: previewRows.value.length > 0 && !planAccepted.value,
   }),
 )
 
@@ -226,6 +239,9 @@ function runSyncToolbarCommand(commandId: string): void {
     case 'home':
       goHomeFromSync()
       break
+    case 'minor':
+      minorOnly.value = !minorOnly.value
+      break
     case 'expand':
       expandAllSyncPaths()
       break
@@ -235,20 +251,23 @@ function runSyncToolbarCommand(commandId: string): void {
     case 'select':
       showSyncSelect.value = !showSyncSelect.value
       break
-    case 'filters':
-      showSyncFilters.value = !showSyncFilters.value
-      break
     case 'refresh':
       void previewSync()
-      break
-    case 'swap':
-      swapSyncPaths()
       break
     case 'stop':
       stopSyncWork()
       break
     case 'peek':
       toggleSyncPeekPanel()
+      break
+    case 'sync-now':
+      void runSync()
+      break
+    case 'cancel':
+      cancelSyncOverrides()
+      break
+    case 'accept':
+      acceptSyncPlan()
       break
     default:
       break
@@ -294,6 +313,7 @@ async function previewSync(): Promise<void> {
     checkedRowIds.value = new Set()
     selectedPeekRowId.value = ''
     showPeek.value = false
+    minorOnly.value = false
     lastSelectionAction.value = ''
     reportStatus.value = ''
     reportError.value = ''


### PR DESCRIPTION
## Summary
- Folder Merge session toolbar follows capture order (All / Same / Minor / Same OK / Rules / Merge / To Output / Files / Swap / Stop, etc.) with real filters, execute, and open-output compare.
- Folder Sync session toolbar adds Minor, Sync Now, Accept, and Cancel wired to the existing plan/execute path.

## Still short of captures
- Toolbar glyphs are still text labels, not icon artwork.
- Folder Merge Rules is a summary panel, not a full session-settings tree.
- Folder Sync Minor only isolates Leave rows; Filters/Swap moved off the session toolbar (Filters still via view actions).

## Test plan
- [x] vitest for `sessionToolbars`, `FolderMergeView`, `FolderSyncView`, language skeletons (43 passed)
- [x] eslint / prettier / stylelint on touched files; `vue-tsc`
- [ ] Manual: build a Folder Merge plan, use Same/Minor/Same OK/Files, Merge, and To Output
- [ ] Manual: preview Folder Sync, Accept, then Sync Now; try Minor leave-only filter