### PR TITLE
Mark session toolbar toggles active and add large button option

### DIFF
--- a/src/app/sessionToolbars.ts
+++ b/src/app/sessionToolbars.ts
@@ -5,6 +5,8 @@ export interface SessionToolbarCommand {
   glyph: string
   labelKey: string
   enabled: boolean
+  /** Pressed/toggle chrome for capture-like session toolbars. */
+  active?: boolean
 }
 
 export const folderCompareToolbarOrder = [

--- a/src/app/settingsPackage.test.ts
+++ b/src/app/settingsPackage.test.ts
@@ -29,6 +29,7 @@ const sample: SettingsPackage = {
   wrapTextDefault: false,
   showSessionToolbars: true,
   showToolbarLabels: true,
+  largeToolbarButtons: true,
   createBackupOnSave: false,
   showStatusBar: true,
   showPathBars: true,

--- a/src/app/settingsPackage.ts
+++ b/src/app/settingsPackage.ts
@@ -22,6 +22,7 @@ export interface SettingsPackage {
   wrapTextDefault: boolean
   showSessionToolbars: boolean
   showToolbarLabels: boolean
+  largeToolbarButtons: boolean
   createBackupOnSave: boolean
   showStatusBar?: boolean
   showPathBars?: boolean
@@ -51,6 +52,7 @@ export function isSettingsPackage(value: unknown): value is SettingsPackage {
     typeof candidate.wrapTextDefault === 'boolean' &&
     typeof candidate.showSessionToolbars === 'boolean' &&
     typeof candidate.showToolbarLabels === 'boolean' &&
+    typeof candidate.largeToolbarButtons === 'boolean' &&
     typeof candidate.createBackupOnSave === 'boolean'
   )
 }

--- a/src/components/workbench/WorkbenchShell.vue
+++ b/src/components/workbench/WorkbenchShell.vue
@@ -25,11 +25,12 @@ const toolbarItems = computed(() => {
     return props.toolbarCommands
   }
 
-  return toolbarForTitle(props.title).map((item) => ({
+  return toolbarForTitle(props.title).map((item): SessionToolbarCommand => ({
     id: item.id,
     glyph: item.glyph,
     labelKey: item.labelKey,
     enabled: false,
+    active: false,
   }))
 })
 const showSessionToolbar = computed(
@@ -291,16 +292,23 @@ function onToolbarCommand(command: SessionToolbarCommand): void {
       <section
         v-if="showSessionToolbar"
         class="bc-session-toolbar"
-        :class="{ 'bc-session-toolbar-glyphs-only': !settings.showToolbarLabels }"
+        :class="{
+          'bc-session-toolbar-glyphs-only': !settings.showToolbarLabels,
+          'bc-session-toolbar-compact': !settings.largeToolbarButtons,
+        }"
         :data-testid="`${testIdPrefix}-bar`"
+        :data-large-buttons="settings.largeToolbarButtons ? 'true' : 'false'"
       >
         <button
           v-for="toolbarItem in toolbarItems"
           :key="toolbarItem.id"
           type="button"
           class="bc-toolbar-command"
+          :class="{ 'bc-toolbar-command-active': toolbarItem.active }"
           :disabled="!toolbarItem.enabled"
+          :aria-pressed="toolbarItem.active ? 'true' : 'false'"
           :data-testid="`${testIdPrefix}-${toolbarItem.id}`"
+          :data-active="toolbarItem.active ? 'true' : 'false'"
           :title="t(toolbarItem.labelKey)"
           @click="onToolbarCommand(toolbarItem)"
         >

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -928,6 +928,7 @@ export const deDE: LanguagePack = {
     'ui.optionsGroupSystem': 'System',
     'ui.showSessionToolbars': 'Show session toolbars',
     'ui.showToolbarLabels': 'Show toolbar labels',
+    'ui.largeToolbarButtons': 'Large toolbar buttons',
     'ui.showStatusBar': 'Show status bar',
     'ui.showPathBars': 'Show path bars',
     'ui.appearanceChromeHint':

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -908,6 +908,7 @@ export const enUS: LanguagePack = {
     'ui.optionsGroupSystem': 'System',
     'ui.showSessionToolbars': 'Show session toolbars',
     'ui.showToolbarLabels': 'Show toolbar labels',
+    'ui.largeToolbarButtons': 'Large toolbar buttons',
     'ui.showStatusBar': 'Show status bar',
     'ui.showPathBars': 'Show path bars',
     'ui.appearanceChromeHint':

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -923,6 +923,7 @@ export const esES: LanguagePack = {
     'ui.optionsGroupSystem': 'System',
     'ui.showSessionToolbars': 'Show session toolbars',
     'ui.showToolbarLabels': 'Show toolbar labels',
+    'ui.largeToolbarButtons': 'Large toolbar buttons',
     'ui.showStatusBar': 'Show status bar',
     'ui.showPathBars': 'Show path bars',
     'ui.appearanceChromeHint':

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -925,6 +925,7 @@ export const frFR: LanguagePack = {
     'ui.optionsGroupSystem': 'System',
     'ui.showSessionToolbars': 'Show session toolbars',
     'ui.showToolbarLabels': 'Show toolbar labels',
+    'ui.largeToolbarButtons': 'Large toolbar buttons',
     'ui.showStatusBar': 'Show status bar',
     'ui.showPathBars': 'Show path bars',
     'ui.appearanceChromeHint':

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -908,6 +908,7 @@ export const jaJP: LanguagePack = {
     'ui.optionsGroupSystem': 'System',
     'ui.showSessionToolbars': 'Show session toolbars',
     'ui.showToolbarLabels': 'Show toolbar labels',
+    'ui.largeToolbarButtons': 'Large toolbar buttons',
     'ui.showStatusBar': 'Show status bar',
     'ui.showPathBars': 'Show path bars',
     'ui.appearanceChromeHint':

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -902,6 +902,7 @@ export const koKR: LanguagePack = {
     'ui.optionsGroupSystem': 'System',
     'ui.showSessionToolbars': 'Show session toolbars',
     'ui.showToolbarLabels': 'Show toolbar labels',
+    'ui.largeToolbarButtons': 'Large toolbar buttons',
     'ui.showStatusBar': 'Show status bar',
     'ui.showPathBars': 'Show path bars',
     'ui.appearanceChromeHint':

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -882,6 +882,7 @@ export const zhCN: LanguagePack = {
     'ui.optionsGroupSystem': '系统',
     'ui.showSessionToolbars': '显示会话工具栏',
     'ui.showToolbarLabels': '显示工具栏标签',
+    'ui.largeToolbarButtons': '大工具栏按钮',
     'ui.showStatusBar': '显示状态栏',
     'ui.showPathBars': '显示路径栏',
     'ui.appearanceChromeHint': '可隐藏状态栏和路径栏，不影响比较结果。',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -883,6 +883,7 @@ export const zhTW: LanguagePack = {
     'ui.optionsGroupSystem': '系統',
     'ui.showSessionToolbars': '顯示工作階段工具列',
     'ui.showToolbarLabels': '顯示工具列標籤',
+    'ui.largeToolbarButtons': '大型工具列按鈕',
     'ui.showStatusBar': '顯示狀態列',
     'ui.showPathBars': '顯示路徑列',
     'ui.appearanceChromeHint': '可隱藏狀態列與路徑列，不影響比較結果。',

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -203,14 +203,17 @@ describe('useSettingsStore', () => {
 
     expect(store.showSessionToolbars).toBe(true)
     expect(store.showToolbarLabels).toBe(true)
+    expect(store.largeToolbarButtons).toBe(true)
     expect(store.createBackupOnSave).toBe(true)
 
     store.setShowSessionToolbars(false)
     store.setShowToolbarLabels(false)
+    store.setLargeToolbarButtons(false)
     store.setCreateBackupOnSave(false)
 
     expect(localStorage.getItem('open-diff-show-session-toolbars')).toBe('0')
     expect(localStorage.getItem('open-diff-show-toolbar-labels')).toBe('0')
+    expect(localStorage.getItem('open-diff-large-toolbar-buttons')).toBe('0')
     expect(localStorage.getItem('open-diff-create-backup-on-save')).toBe('0')
   })
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -66,6 +66,7 @@ const confirmBeforeDeleteStorageKey = 'open-diff-confirm-before-delete'
 const wrapTextDefaultStorageKey = 'open-diff-wrap-text-default'
 const showSessionToolbarsStorageKey = 'open-diff-show-session-toolbars'
 const showToolbarLabelsStorageKey = 'open-diff-show-toolbar-labels'
+const largeToolbarButtonsStorageKey = 'open-diff-large-toolbar-buttons'
 const createBackupOnSaveStorageKey = 'open-diff-create-backup-on-save'
 const showStatusBarStorageKey = 'open-diff-show-status-bar'
 const showPathBarsStorageKey = 'open-diff-show-path-bars'
@@ -96,6 +97,7 @@ export const useSettingsStore = defineStore('settings', () => {
   const wrapTextDefault = ref(loadWrapTextDefault())
   const showSessionToolbars = ref(loadShowSessionToolbars())
   const showToolbarLabels = ref(loadShowToolbarLabels())
+  const largeToolbarButtons = ref(loadLargeToolbarButtons())
   const createBackupOnSave = ref(loadCreateBackupOnSave())
   const showStatusBar = ref(loadShowStatusBar())
   const showPathBars = ref(loadShowPathBars())
@@ -201,6 +203,14 @@ export const useSettingsStore = defineStore('settings', () => {
     showToolbarLabels,
     (value) => {
       localStorage.setItem(showToolbarLabelsStorageKey, value ? '1' : '0')
+    },
+    { immediate: true, flush: 'sync' },
+  )
+
+  watch(
+    largeToolbarButtons,
+    (value) => {
+      localStorage.setItem(largeToolbarButtonsStorageKey, value ? '1' : '0')
     },
     { immediate: true, flush: 'sync' },
   )
@@ -368,6 +378,10 @@ export const useSettingsStore = defineStore('settings', () => {
     showToolbarLabels.value = value
   }
 
+  function setLargeToolbarButtons(value: boolean): void {
+    largeToolbarButtons.value = value
+  }
+
   function setCreateBackupOnSave(value: boolean): void {
     createBackupOnSave.value = value
   }
@@ -396,6 +410,7 @@ export const useSettingsStore = defineStore('settings', () => {
       wrapTextDefault: wrapTextDefault.value,
       showSessionToolbars: showSessionToolbars.value,
       showToolbarLabels: showToolbarLabels.value,
+      largeToolbarButtons: largeToolbarButtons.value,
       createBackupOnSave: createBackupOnSave.value,
       showStatusBar: showStatusBar.value,
       showPathBars: showPathBars.value,
@@ -429,6 +444,7 @@ export const useSettingsStore = defineStore('settings', () => {
     setWrapTextDefault(packageValue.wrapTextDefault)
     setShowSessionToolbars(packageValue.showSessionToolbars)
     setShowToolbarLabels(packageValue.showToolbarLabels)
+    setLargeToolbarButtons(packageValue.largeToolbarButtons)
     setCreateBackupOnSave(packageValue.createBackupOnSave)
     setShowStatusBar(
       typeof packageValue.showStatusBar === 'boolean' ? packageValue.showStatusBar : true,
@@ -453,6 +469,7 @@ export const useSettingsStore = defineStore('settings', () => {
     setWrapTextDefault(false)
     setShowSessionToolbars(true)
     setShowToolbarLabels(true)
+    setLargeToolbarButtons(true)
     setCreateBackupOnSave(false)
     setShowStatusBar(true)
     setShowPathBars(true)
@@ -472,6 +489,7 @@ export const useSettingsStore = defineStore('settings', () => {
     wrapTextDefault,
     showSessionToolbars,
     showToolbarLabels,
+    largeToolbarButtons,
     createBackupOnSave,
     showStatusBar,
     showPathBars,
@@ -492,6 +510,7 @@ export const useSettingsStore = defineStore('settings', () => {
     setWrapTextDefault,
     setShowSessionToolbars,
     setShowToolbarLabels,
+    setLargeToolbarButtons,
     setCreateBackupOnSave,
     setShowStatusBar,
     setShowPathBars,
@@ -678,6 +697,16 @@ function loadShowSessionToolbars(): boolean {
 
 function loadShowToolbarLabels(): boolean {
   const stored = localStorage.getItem(showToolbarLabelsStorageKey)
+
+  if (stored === null) {
+    return true
+  }
+
+  return stored !== '0'
+}
+
+function loadLargeToolbarButtons(): boolean {
+  const stored = localStorage.getItem(largeToolbarButtonsStorageKey)
 
   if (stored === null) {
     return true

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -255,14 +255,47 @@ select {
   white-space: nowrap;
 }
 
-.bc-toolbar-command:first-child,
-.bc-toolbar-command:nth-child(3) {
+.bc-toolbar-command-active {
   background: #c8e4ff;
   box-shadow: inset 0 0 0 1px #89bdea;
 }
 
 .bc-toolbar-command:hover:not(:disabled) {
   background: #dceeff;
+}
+
+.bc-toolbar-command-active:hover:not(:disabled) {
+  background: #b7dbf8;
+}
+
+.bc-session-toolbar-compact {
+  min-height: 44px;
+}
+
+.bc-session-toolbar-compact .bc-toolbar-command {
+  grid-template-rows: 22px auto;
+  min-width: 52px;
+  max-width: 96px;
+  height: 44px;
+  padding: 2px 6px 3px;
+  font-size: 11px;
+  line-height: 12px;
+}
+
+.bc-session-toolbar-compact .bc-toolbar-glyph {
+  min-width: 20px;
+  height: 20px;
+  font-size: 16px;
+}
+
+.bc-session-toolbar-glyphs-only .bc-toolbar-command {
+  min-width: 48px;
+  max-width: 64px;
+}
+
+.bc-session-toolbar-compact.bc-session-toolbar-glyphs-only .bc-toolbar-command {
+  min-width: 40px;
+  max-width: 48px;
 }
 
 .bc-toolbar-command:disabled {

--- a/src/views/PictureCompareView.test.ts
+++ b/src/views/PictureCompareView.test.ts
@@ -272,6 +272,12 @@ describe('PictureCompareView', () => {
     expect(
       wrapper.find('[data-testid="picture-session-toolbar-rules"]').attributes('disabled'),
     ).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="picture-session-toolbar-meta"]').attributes('data-active'),
+    ).toBe('true')
+    expect(
+      wrapper.find('[data-testid="picture-session-toolbar-tol"]').attributes('data-active'),
+    ).toBe('false')
     expect(wrapper.html()).not.toContain('unimplemented')
   })
 
@@ -353,14 +359,29 @@ describe('PictureCompareView', () => {
     await wrapper.find('[data-testid="picture-session-toolbar-blend"]').trigger('click')
     expect(wrapper.find('[data-testid="picture-blend-panel"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="picture-blend-overlay"]').exists()).toBe(true)
+    expect(
+      wrapper.find('[data-testid="picture-session-toolbar-blend"]').attributes('data-active'),
+    ).toBe('true')
+
+    await wrapper.find('[data-testid="picture-session-toolbar-tol"]').trigger('click')
+    expect(wrapper.find('[data-testid="picture-tol-panel"]').exists()).toBe(true)
+    expect(
+      wrapper.find('[data-testid="picture-session-toolbar-tol"]').attributes('data-active'),
+    ).toBe('true')
 
     await wrapper.find('[data-testid="picture-session-toolbar-meta"]').trigger('click')
     expect(wrapper.find('[data-testid="picture-metadata-panel"]').exists()).toBe(false)
+    expect(
+      wrapper.find('[data-testid="picture-session-toolbar-meta"]').attributes('data-active'),
+    ).toBe('false')
     await wrapper.find('[data-testid="picture-session-toolbar-meta"]').trigger('click')
     expect(wrapper.find('[data-testid="picture-metadata-panel"]').exists()).toBe(true)
 
     await wrapper.find('[data-testid="picture-session-toolbar-minor"]').trigger('click')
     expect(wrapper.find('[data-testid="picture-metadata-dimensions"]').exists()).toBe(false)
+    expect(
+      wrapper.find('[data-testid="picture-session-toolbar-minor"]').attributes('data-active'),
+    ).toBe('true')
   })
 
   it('exports the picture report to clipboard and a sibling text file', async () => {

--- a/src/views/PictureCompareView.vue
+++ b/src/views/PictureCompareView.vue
@@ -286,7 +286,15 @@ const pictureSessionToolbar = computed(() =>
     swap: Boolean(leftPath.value || rightPath.value),
     reload: Boolean(leftPath.value && rightPath.value),
     meta: true,
-  }),
+  }).map((item) => ({
+    ...item,
+    active:
+      (item.id === 'tol' && showTolPanel.value) ||
+      (item.id === 'range' && showRangePanel.value) ||
+      (item.id === 'blend' && blendEnabled.value) ||
+      (item.id === 'minor' && showMinor.value) ||
+      (item.id === 'meta' && showMetaPanel.value),
+  })),
 )
 
 function clampByte(value: number, fallback = 0): number {

--- a/src/views/SettingsView.test.ts
+++ b/src/views/SettingsView.test.ts
@@ -282,6 +282,8 @@ describe('SettingsView', () => {
     expect(wrapper.find('[data-testid="options-toolbars-card"]').isVisible()).toBe(true)
     await wrapper.find('[data-testid="show-session-toolbars"]').setValue(false)
     expect(settings.showSessionToolbars).toBe(false)
+    await wrapper.find('[data-testid="large-toolbar-buttons"]').setValue(false)
+    expect(settings.largeToolbarButtons).toBe(false)
 
     await wrapper.find('[data-testid="options-section-openWith"]').trigger('click')
     expect(wrapper.find('[data-testid="options-open-with-card"]').isVisible()).toBe(true)

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -284,6 +284,16 @@ function onShowToolbarLabelsChange(event: Event): void {
   settings.setShowToolbarLabels(target.checked)
 }
 
+function onLargeToolbarButtonsChange(event: Event): void {
+  const target = event.target
+
+  if (!(target instanceof HTMLInputElement)) {
+    return
+  }
+
+  settings.setLargeToolbarButtons(target.checked)
+}
+
 function onShowStatusBarChange(event: Event): void {
   const target = event.target
 
@@ -648,6 +658,15 @@ function parseShortcutText(value: string): string[] {
             @change="onShowToolbarLabelsChange"
           />
           <span>{{ $t('ui.showToolbarLabels') }}</span>
+        </label>
+        <label class="tweak-row">
+          <input
+            data-testid="large-toolbar-buttons"
+            type="checkbox"
+            :checked="settings.largeToolbarButtons"
+            @change="onLargeToolbarButtonsChange"
+          />
+          <span>{{ $t('ui.largeToolbarButtons') }}</span>
         </label>
         <p class="options-hint">{{ $t('ui.toolbarsHint') }}</p>
       </NCard>

--- a/src/views/TextCompareView.test.ts
+++ b/src/views/TextCompareView.test.ts
@@ -134,6 +134,15 @@ describe('TextCompareView', () => {
     expect(
       wrapper.find('[data-testid="text-session-toolbar-rules"]').attributes('disabled'),
     ).toBeUndefined()
+    expect(wrapper.find('[data-testid="text-session-toolbar-all"]').attributes('data-active')).toBe(
+      'true',
+    )
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-rules"]').attributes('data-active'),
+    ).toBe('true')
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-bar"]').attributes('data-large-buttons'),
+    ).toBe('true')
     expect(wrapper.html()).not.toContain('未实现')
   })
 
@@ -143,23 +152,53 @@ describe('TextCompareView', () => {
     expect(
       wrapper.find('[data-testid="text-rules-panel"]').attributes('style') ?? '',
     ).not.toContain('display: none')
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-rules"]').attributes('data-active'),
+    ).toBe('true')
     await wrapper.find('[data-testid="text-session-toolbar-rules"]').trigger('click')
     expect(wrapper.find('[data-testid="text-rules-panel"]').attributes('style') ?? '').toContain(
       'display: none',
     )
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-rules"]').attributes('data-active'),
+    ).toBe('false')
     await wrapper.find('[data-testid="text-session-toolbar-rules"]').trigger('click')
     expect(
       wrapper.find('[data-testid="text-rules-panel"]').attributes('style') ?? '',
     ).not.toContain('display: none')
   })
 
-  it('toggles minor whitespace ignore from the session toolbar', async () => {
+  it('marks display-mode toolbar buttons as active when pressed', async () => {
     const wrapper = mountTextCompareView()
 
+    await wrapper.find('[data-testid="text-session-toolbar-diffs"]').trigger('click')
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-diffs"]').attributes('data-active'),
+    ).toBe('true')
+    expect(wrapper.find('[data-testid="text-session-toolbar-all"]').attributes('data-active')).toBe(
+      'false',
+    )
+
+    await wrapper.find('[data-testid="text-session-toolbar-context"]').trigger('click')
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-context"]').attributes('data-active'),
+    ).toBe('true')
+  })
+
+  it('toggles minor whitespace ignore from the session toolbar', async () => {
+    localStorage.clear()
+    const wrapper = mountTextCompareView()
+
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-minor"]').attributes('data-active'),
+    ).toBe('false')
     await wrapper.find('[data-testid="text-session-toolbar-minor"]').trigger('click')
     expect(
       (wrapper.find('[data-testid="ignore-whitespace"]').element as HTMLInputElement).checked,
     ).toBe(true)
+    expect(
+      wrapper.find('[data-testid="text-session-toolbar-minor"]').attributes('data-active'),
+    ).toBe('true')
   })
 
   it('swaps paths from the session toolbar', async () => {

--- a/src/views/TextCompareView.vue
+++ b/src/views/TextCompareView.vue
@@ -870,6 +870,7 @@ const textDiffPanelRef = ref<{
   setDisplayMode: (mode: 'all' | 'differences' | 'same') => void
   setDifferenceContextRowCount: (value: number) => void
 } | null>(null)
+const textDisplayMode = ref<'all' | 'differences' | 'same' | 'context'>('all')
 
 function syncTextTabTitle(): void {
   if (!leftPathLabel.value || !rightPathLabel.value) {
@@ -899,7 +900,16 @@ const textSessionToolbar = computed(() =>
     swap: Boolean(leftPathLabel.value || rightPathLabel.value || left.value || right.value),
     reload:
       Boolean(leftPathLabel.value && rightPathLabel.value) || Boolean(left.value || right.value),
-  }),
+  }).map((item) => ({
+    ...item,
+    active:
+      (item.id === 'all' && textDisplayMode.value === 'all') ||
+      (item.id === 'diffs' && textDisplayMode.value === 'differences') ||
+      (item.id === 'same' && textDisplayMode.value === 'same') ||
+      (item.id === 'context' && textDisplayMode.value === 'context') ||
+      (item.id === 'minor' && ignoreWhitespace.value) ||
+      (item.id === 'rules' && showTextRules.value),
+  })),
 )
 
 function toggleTextMinorRules(): void {
@@ -911,6 +921,7 @@ function toggleTextMinorRules(): void {
 }
 
 function showTextContextMode(): void {
+  textDisplayMode.value = 'context'
   textDiffPanelRef.value?.setDisplayMode('differences')
   textDiffPanelRef.value?.setDifferenceContextRowCount(2)
 }
@@ -921,12 +932,15 @@ function runTextToolbarCommand(commandId: string): void {
       goHomeFromText()
       break
     case 'all':
+      textDisplayMode.value = 'all'
       textDiffPanelRef.value?.setDisplayMode('all')
       break
     case 'diffs':
+      textDisplayMode.value = 'differences'
       textDiffPanelRef.value?.setDisplayMode('differences')
       break
     case 'same':
+      textDisplayMode.value = 'same'
       textDiffPanelRef.value?.setDisplayMode('same')
       break
     case 'context':


### PR DESCRIPTION
## Summary
- Replace the hard-coded first/third session toolbar highlight with real pressed (`active`) state for Text Compare display/rules/minor toggles and Picture Tol/Range/Blend/Meta/Minor.
- Add Options → Toolbars **Large toolbar buttons** (persisted, package export/import, factory restore) so WorkbenchShell can switch between large and compact session toolbar chrome.

## Test plan
- [x] `vitest` for settings package/store, SettingsView, TextCompareView, PictureCompareView, sessionToolbars, i18n locales
- [x] Pre-commit: prettier, eslint, stylelint, vue-tsc, rust fmt/clippy
- [ ] Manual: Text Compare All/Diffs/Same/Context/Rules/Minor show pressed chrome; Picture Tol/Blend/Meta pressed; Options Toolbars large-buttons off shrinks session toolbar