### PR TITLE
Add Text Compare context chrome and Hex EOF windowed browse

### DIFF
--- a/src/components/diff/TextDiffPanel.vue
+++ b/src/components/diff/TextDiffPanel.vue
@@ -423,9 +423,15 @@ const splitBySyntaxTokens = (
   return parts
 }
 
+const getDifferenceContextRowCount = (): number => differenceContextRows.value
+
+const getDisplayMode = (): DiffDisplayMode => displayMode.value
+
 defineExpose({
   setDisplayMode,
+  getDisplayMode,
   setDifferenceContextRowCount,
+  getDifferenceContextRowCount,
   jumpToNextDiff,
   jumpToPreviousDiff,
 })

--- a/src/i18n/locales/de-DE.ts
+++ b/src/i18n/locales/de-DE.ts
@@ -119,6 +119,8 @@ export const deDE: LanguagePack = {
     'ui.conflictPolicy': 'Konfliktstrategie',
     'ui.connectionProfiles': 'Verbindungsprofile',
     'ui.context': 'Kontext',
+    'ui.contextLines': 'Context lines',
+    'ui.contextLinesHint': 'Show surrounding lines when viewing differences only.',
     'ui.conversionRule': 'Konvertierungsregel',
     'ui.copy': 'Kopie',
     'ui.copyLeft': 'Nach links kopieren',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -120,6 +120,8 @@ export const enUS: LanguagePack = {
     'ui.conflictPolicy': 'Conflict policy',
     'ui.connectionProfiles': 'Connection profiles',
     'ui.context': 'Context',
+    'ui.contextLines': 'Context lines',
+    'ui.contextLinesHint': 'Show surrounding lines when viewing differences only.',
     'ui.conversionRule': 'Conversion Rule',
     'ui.copy': 'Copy',
     'ui.copyLeft': 'Copy Left',

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -115,6 +115,8 @@ export const esES: LanguagePack = {
     'ui.conflictPolicy': 'Política de conflictos',
     'ui.connectionProfiles': 'Perfiles de conexión',
     'ui.context': 'Contexto',
+    'ui.contextLines': 'Context lines',
+    'ui.contextLinesHint': 'Show surrounding lines when viewing differences only.',
     'ui.conversionRule': 'Regla de conversión',
     'ui.copy': 'Copiar',
     'ui.copyLeft': 'Copiar a la izquierda',

--- a/src/i18n/locales/fr-FR.ts
+++ b/src/i18n/locales/fr-FR.ts
@@ -116,6 +116,8 @@ export const frFR: LanguagePack = {
     'ui.conflictPolicy': 'Politique de conflit',
     'ui.connectionProfiles': 'Profils de connexion',
     'ui.context': 'Contexte',
+    'ui.contextLines': 'Context lines',
+    'ui.contextLinesHint': 'Show surrounding lines when viewing differences only.',
     'ui.conversionRule': 'Règle de conversion',
     'ui.copy': 'Copie',
     'ui.copyLeft': 'Copier à gauche',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -120,6 +120,8 @@ export const jaJP: LanguagePack = {
     'ui.conflictPolicy': '競合ポリシー',
     'ui.connectionProfiles': 'Connection profiles',
     'ui.context': 'Context',
+    'ui.contextLines': 'Context lines',
+    'ui.contextLinesHint': 'Show surrounding lines when viewing differences only.',
     'ui.conversionRule': 'Conversion Rule',
     'ui.copy': 'Copy',
     'ui.copyLeft': 'Copy Left',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -111,6 +111,8 @@ export const koKR: LanguagePack = {
     'ui.conflictPolicy': '충돌 정책',
     'ui.connectionProfiles': '연결 프로필',
     'ui.context': '문맥',
+    'ui.contextLines': 'Context lines',
+    'ui.contextLinesHint': 'Show surrounding lines when viewing differences only.',
     'ui.conversionRule': '변환 규칙',
     'ui.copy': '복사',
     'ui.copyLeft': '왼쪽으로 복사',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -103,6 +103,8 @@ export const zhCN: LanguagePack = {
     'ui.conflictPolicy': '冲突策略',
     'ui.connectionProfiles': '连接配置',
     'ui.context': '上下文',
+    'ui.contextLines': '上下文行数',
+    'ui.contextLinesHint': '在仅显示差异时展示周围行。',
     'ui.conversionRule': '转换规则',
     'ui.copy': '复制',
     'ui.copyLeft': '复制到左侧',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -104,6 +104,8 @@ export const zhTW: LanguagePack = {
     'ui.conflictPolicy': '衝突策略',
     'ui.connectionProfiles': '連線設定檔',
     'ui.context': '內容行',
+    'ui.contextLines': '上下文行數',
+    'ui.contextLinesHint': '在僅顯示差異時展示周圍行。',
     'ui.conversionRule': '轉換規則',
     'ui.copy': '複製',
     'ui.copyLeft': '複製到左側',

--- a/src/views/HexCompareView.test.ts
+++ b/src/views/HexCompareView.test.ts
@@ -59,7 +59,35 @@ async function runCompare(wrapper: ReturnType<typeof mount>): Promise<void> {
 describe('HexCompareView', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    vi.mocked(compareHexFiles).mockClear()
+    vi.mocked(compareHexFiles).mockReset()
+    vi.mocked(compareHexFiles).mockResolvedValue({
+      left: {
+        path: 'C:/bin/left.bin',
+        totalLen: 4,
+        cells: [
+          { offset: 0, byte: 65, hex: '41', ascii: 'A', different: false },
+          { offset: 1, byte: 66, hex: '42', ascii: 'B', different: true },
+          { offset: 2, byte: 67, hex: '43', ascii: 'C', different: false },
+          { offset: 3, byte: 68, hex: '44', ascii: 'D', different: false },
+        ],
+      },
+      right: {
+        path: 'C:/bin/right.bin',
+        totalLen: 4,
+        cells: [
+          { offset: 0, byte: 65, hex: '41', ascii: 'A', different: false },
+          { offset: 1, byte: 88, hex: '58', ascii: 'X', different: true },
+          { offset: 2, byte: 67, hex: '43', ascii: 'C', different: false },
+          { offset: 3, byte: 68, hex: '44', ascii: 'D', different: false },
+        ],
+      },
+      diffRanges: [{ offset: 1, leftBytes: [66], rightBytes: [88] }],
+      summary: {
+        leftBytes: 4,
+        rightBytes: 4,
+        differentRanges: 1,
+      },
+    })
     vi.mocked(findHexInFile).mockClear()
     vi.mocked(saveHexEdits).mockClear()
     vi.mocked(saveTextFile).mockClear()
@@ -257,9 +285,33 @@ describe('HexCompareView', () => {
   })
 
   it('pages and jumps through chunked offsets', async () => {
+    vi.mocked(compareHexFiles).mockResolvedValue({
+      left: {
+        path: 'C:/bin/left.bin',
+        totalLen: 2048,
+        cells: [{ offset: 0, byte: 65, hex: '41', ascii: 'A', different: false }],
+      },
+      right: {
+        path: 'C:/bin/right.bin',
+        totalLen: 2048,
+        cells: [{ offset: 0, byte: 65, hex: '41', ascii: 'A', different: false }],
+      },
+      diffRanges: [],
+      summary: {
+        leftBytes: 2048,
+        rightBytes: 2048,
+        differentRanges: 0,
+      },
+    })
+
     const wrapper = mount(HexCompareView)
 
     await runCompare(wrapper)
+    expect(wrapper.find('[data-testid="hex-window-range"]').text()).toContain('00000000')
+    expect(
+      (wrapper.find('[data-testid="hex-next-page"]').element as HTMLButtonElement).disabled,
+    ).toBe(false)
+
     await wrapper.find('[data-testid="hex-next-page"]').trigger('click')
     await wrapper.vm.$nextTick()
 
@@ -269,11 +321,49 @@ describe('HexCompareView', () => {
 
     await wrapper.find('[data-testid="hex-jump-offset"]').setValue('512')
     await wrapper.find('[data-testid="hex-jump"]').trigger('click')
-    await wrapper.vm.$nextTick()
+    await flushPromises()
 
     expect(compareHexFiles).toHaveBeenLastCalledWith(
       expect.objectContaining({ offset: 512, length: 256 }),
     )
+  })
+
+  it('clamps windowed browse at EOF and disables next/last there', async () => {
+    vi.mocked(compareHexFiles).mockResolvedValue({
+      left: {
+        path: 'C:/bin/left.bin',
+        totalLen: 300,
+        cells: [{ offset: 0, byte: 65, hex: '41', ascii: 'A', different: false }],
+      },
+      right: {
+        path: 'C:/bin/right.bin',
+        totalLen: 300,
+        cells: [{ offset: 0, byte: 65, hex: '41', ascii: 'A', different: false }],
+      },
+      diffRanges: [],
+      summary: {
+        leftBytes: 300,
+        rightBytes: 300,
+        differentRanges: 0,
+      },
+    })
+
+    const wrapper = mount(HexCompareView)
+
+    await runCompare(wrapper)
+    await wrapper.find('[data-testid="hex-next-page"]').trigger('click')
+    await flushPromises()
+
+    expect(compareHexFiles).toHaveBeenLastCalledWith(
+      expect.objectContaining({ offset: 44, length: 256 }),
+    )
+    expect(
+      (wrapper.find('[data-testid="hex-next-page"]').element as HTMLButtonElement).disabled,
+    ).toBe(true)
+    expect(
+      (wrapper.find('[data-testid="hex-last-page"]').element as HTMLButtonElement).disabled,
+    ).toBe(true)
+    expect(wrapper.find('[data-testid="hex-window-range"]').text()).toMatch(/0000002C/i)
   })
 
   it('finds bytes and saves queued edits', async () => {

--- a/src/views/HexCompareView.vue
+++ b/src/views/HexCompareView.vue
@@ -123,6 +123,28 @@ const visiblePairedHexRows = computed(() => {
 const loadedBytesLabel = computed(
   () => `${String(leftTotalLen.value)} / ${String(rightTotalLen.value)}`,
 )
+const hexFileTotal = computed(() => Math.max(leftTotalLen.value, rightTotalLen.value))
+const hexWindowEndExclusive = computed(() => {
+  if (hexFileTotal.value <= 0) {
+    return hexOffset.value + Math.max(0, hexLength.value)
+  }
+
+  return Math.min(hexFileTotal.value, hexOffset.value + Math.max(0, hexLength.value))
+})
+const canPagePrevious = computed(() => hexOffset.value > 0)
+const canPageNext = computed(
+  () =>
+    hexFileTotal.value > 0 && hexOffset.value + Math.max(0, hexLength.value) < hexFileTotal.value,
+)
+const hexWindowRangeLabel = computed(() => {
+  if (hexFileTotal.value <= 0) {
+    return formatOffset(hexOffset.value)
+  }
+
+  const endInclusive = Math.max(hexOffset.value, hexWindowEndExclusive.value - 1)
+
+  return `${formatOffset(hexOffset.value)}–${formatOffset(endInclusive)} / ${formatOffset(hexFileTotal.value)}`
+})
 
 function currentHexSessionOptions(): HexCompareSessionOptions {
   return {
@@ -428,24 +450,44 @@ async function runHexCompare(options?: { preserveNavigationRanges?: boolean }): 
 }
 
 function goToPreviousHexPage(): void {
-  hexOffset.value = Math.max(0, hexOffset.value - hexLength.value)
+  if (!canPagePrevious.value) {
+    return
+  }
+
+  hexOffset.value = Math.max(0, hexOffset.value - Math.max(1, hexLength.value))
+  jumpOffsetInput.value = hexOffsetInputValue(hexOffset.value)
   void runHexCompare()
 }
 
 function goToNextHexPage(): void {
-  hexOffset.value += hexLength.value
+  if (!canPageNext.value) {
+    return
+  }
+
+  const step = Math.max(1, hexLength.value)
+  const last = Math.max(0, hexFileTotal.value - step)
+
+  hexOffset.value = Math.min(hexOffset.value + step, last)
+  jumpOffsetInput.value = hexOffsetInputValue(hexOffset.value)
   void runHexCompare()
 }
 
 function goToFirstHexPage(): void {
+  if (!canPagePrevious.value) {
+    return
+  }
+
   hexOffset.value = 0
   jumpOffsetInput.value = hexOffsetInputValue(0)
   void runHexCompare()
 }
 
 function goToLastHexPage(): void {
-  const total = Math.max(leftTotalLen.value, rightTotalLen.value)
-  const last = Math.max(0, total - hexLength.value)
+  if (!canPageNext.value) {
+    return
+  }
+
+  const last = Math.max(0, hexFileTotal.value - Math.max(1, hexLength.value))
 
   hexOffset.value = last
   jumpOffsetInput.value = hexOffsetInputValue(last)
@@ -757,10 +799,15 @@ async function runHexSave(): Promise<void> {
         >
           {{ $t('ui.goTo') }}
         </button>
+        <strong
+          class="hex-window-range"
+          data-testid="hex-window-range"
+          >{{ hexWindowRangeLabel }}</strong
+        >
         <button
           type="button"
           data-testid="hex-first-page"
-          :disabled="loading || hexOffset <= 0"
+          :disabled="loading || !canPagePrevious"
           @click="goToFirstHexPage"
         >
           {{ $t('ui.firstPage') }}
@@ -768,7 +815,7 @@ async function runHexSave(): Promise<void> {
         <button
           type="button"
           data-testid="hex-previous-page"
-          :disabled="loading || hexOffset <= 0"
+          :disabled="loading || !canPagePrevious"
           @click="goToPreviousHexPage"
         >
           {{ $t('ui.previous') }}
@@ -776,7 +823,7 @@ async function runHexSave(): Promise<void> {
         <button
           type="button"
           data-testid="hex-next-page"
-          :disabled="loading"
+          :disabled="loading || !canPageNext"
           @click="goToNextHexPage"
         >
           {{ $t('ui.next') }}
@@ -784,7 +831,7 @@ async function runHexSave(): Promise<void> {
         <button
           type="button"
           data-testid="hex-last-page"
-          :disabled="loading"
+          :disabled="loading || !canPageNext"
           @click="goToLastHexPage"
         >
           {{ $t('ui.lastPage') }}

--- a/src/views/TextCompareView.test.ts
+++ b/src/views/TextCompareView.test.ts
@@ -168,6 +168,43 @@ describe('TextCompareView', () => {
     ).not.toContain('display: none')
   })
 
+  it('opens context chrome and adjusts surrounding lines from the session toolbar', async () => {
+    const wrapper = mountTextCompareView()
+
+    expect(wrapper.find('[data-testid="text-context-panel"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="text-session-toolbar-context"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="text-context-panel"]').exists()).toBe(true)
+    expect(
+      (wrapper.find('[data-testid="text-context-lines"]').element as HTMLInputElement).value,
+    ).toBe('2')
+
+    await wrapper.find('[data-testid="text-context-lines"]').setValue('5')
+    await wrapper.find('[data-testid="text-context-lines"]').trigger('input')
+    await wrapper.vm.$nextTick()
+
+    expect(
+      (wrapper.find('[data-testid="text-context-lines"]').element as HTMLInputElement).value,
+    ).toBe('5')
+
+    await wrapper.find('[data-testid="text-session-toolbar-context"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="text-context-panel"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="text-session-toolbar-context"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="text-context-panel"]').exists()).toBe(true)
+    expect(
+      (wrapper.find('[data-testid="text-context-lines"]').element as HTMLInputElement).value,
+    ).toBe('5')
+
+    await wrapper.find('[data-testid="text-session-toolbar-all"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="text-context-panel"]').exists()).toBe(false)
+  })
+
   it('marks display-mode toolbar buttons as active when pressed', async () => {
     const wrapper = mountTextCompareView()
 

--- a/src/views/TextCompareView.vue
+++ b/src/views/TextCompareView.vue
@@ -49,6 +49,8 @@ const ignoreCase = ref(initialTextSessionOptions.ignoreCase)
 const ignoreLineEndings = ref(initialTextSessionOptions.ignoreLineEndings)
 const ignoreRegexInput = ref(initialTextSessionOptions.ignoreRegexes.join(', '))
 const showTextRules = ref(true)
+const showContextPanel = ref(false)
+const contextLineCount = ref(2)
 const showSessionSettings = ref(false)
 const viewActions = useViewActionsStore()
 const folderSettingsPlaceholder = defaultFolderCompareCriteria()
@@ -156,16 +158,16 @@ watch(
         showTextRules.value = !showTextRules.value
         break
       case 'filters':
-        textDiffPanelRef.value?.setDisplayMode('differences')
+        leaveTextContextMode('differences')
         break
       case 'export':
         void exportCurrentReport('html')
         break
       case 'show-all':
-        textDiffPanelRef.value?.setDisplayMode('all')
+        leaveTextContextMode('all')
         break
       case 'show-differences':
-        textDiffPanelRef.value?.setDisplayMode('differences')
+        leaveTextContextMode('differences')
         break
       case 'previous-difference':
         goToPreviousDiff()
@@ -868,7 +870,9 @@ function closeHtmlPreviewWhenUnavailable(): void {
 
 const textDiffPanelRef = ref<{
   setDisplayMode: (mode: 'all' | 'differences' | 'same') => void
+  getDisplayMode: () => 'all' | 'differences' | 'same'
   setDifferenceContextRowCount: (value: number) => void
+  getDifferenceContextRowCount: () => number
 } | null>(null)
 const textDisplayMode = ref<'all' | 'differences' | 'same' | 'context'>('all')
 
@@ -920,10 +924,44 @@ function toggleTextMinorRules(): void {
   }
 }
 
+function leaveTextContextMode(mode?: 'all' | 'differences' | 'same'): void {
+  showContextPanel.value = false
+  if (mode) {
+    textDisplayMode.value = mode
+    textDiffPanelRef.value?.setDisplayMode(mode)
+  }
+}
+
 function showTextContextMode(): void {
+  if (showContextPanel.value) {
+    leaveTextContextMode('all')
+
+    return
+  }
+
+  showContextPanel.value = true
   textDisplayMode.value = 'context'
   textDiffPanelRef.value?.setDisplayMode('differences')
-  textDiffPanelRef.value?.setDifferenceContextRowCount(2)
+  textDiffPanelRef.value?.setDifferenceContextRowCount(contextLineCount.value)
+}
+
+function onContextLineCountInput(event: Event): void {
+  const target = event.target
+
+  if (!(target instanceof HTMLInputElement)) {
+    return
+  }
+
+  const parsed = Number.parseInt(target.value, 10)
+
+  if (Number.isNaN(parsed)) {
+    return
+  }
+
+  contextLineCount.value = Math.min(99, Math.max(0, parsed))
+  if (showContextPanel.value) {
+    textDiffPanelRef.value?.setDifferenceContextRowCount(contextLineCount.value)
+  }
 }
 
 function runTextToolbarCommand(commandId: string): void {
@@ -932,16 +970,13 @@ function runTextToolbarCommand(commandId: string): void {
       goHomeFromText()
       break
     case 'all':
-      textDisplayMode.value = 'all'
-      textDiffPanelRef.value?.setDisplayMode('all')
+      leaveTextContextMode('all')
       break
     case 'diffs':
-      textDisplayMode.value = 'differences'
-      textDiffPanelRef.value?.setDisplayMode('differences')
+      leaveTextContextMode('differences')
       break
     case 'same':
-      textDisplayMode.value = 'same'
-      textDiffPanelRef.value?.setDisplayMode('same')
+      leaveTextContextMode('same')
       break
     case 'context':
       showTextContextMode()
@@ -1196,6 +1231,28 @@ function toggleSourceEditors(): void {
             :placeholder="$t('ui.regex')"
           />
         </fieldset>
+        <section
+          v-if="showContextPanel"
+          class="text-context-panel"
+          data-testid="text-context-panel"
+        >
+          <header>
+            <strong>{{ $t('ui.context') }}</strong>
+            <span>{{ $t('ui.contextLinesHint') }}</span>
+          </header>
+          <label class="text-context-lines">
+            <span>{{ $t('ui.contextLines') }}</span>
+            <input
+              data-testid="text-context-lines"
+              type="number"
+              min="0"
+              max="99"
+              step="1"
+              :value="contextLineCount"
+              @input="onContextLineCountInput"
+            />
+          </label>
+        </section>
         <button
           type="button"
           data-testid="open-text-session-settings"
@@ -1576,6 +1633,45 @@ function toggleSourceEditors(): void {
 .text-rules-panel legend {
   padding: 0 4px;
   font-size: 12px;
+}
+
+.text-context-panel {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 6px 8px;
+  border: 1px solid var(--od-border, #d0d7de);
+  border-radius: 6px;
+}
+
+.text-context-panel header {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12px;
+}
+
+.text-context-panel header span {
+  color: var(--app-text-muted);
+}
+
+.text-context-lines {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.text-context-lines input {
+  width: 64px;
+  height: 24px;
+  padding: 0 6px;
+  border: 1px solid var(--app-border);
+  border-radius: 4px;
+  background: var(--app-canvas);
+  color: var(--app-text);
 }
 
 .algorithm-select {


### PR DESCRIPTION
## Summary
- Text Compare Context opens a session chrome panel with adjustable surrounding line count; toggling Context again or choosing All/Diffs/Same closes it.
- Hex Compare windowed browse clamps First/Prev/Next/Last at EOF, disables exhausted page controls, and shows the current window range.

## Test plan
- [x] `vitest` TextCompareView, HexCompareView, TextDiffPanel, i18n locale skeletons
- [x] eslint / stylelint / prettier / vue-tsc on touched files
- [ ] Manual: Text Compare Context panel lines sync into differences view; Hex Next stops at last window