### PR TITLE
Enable Folder Compare Minor for timestamp-only differences

### DIFF
--- a/src-tauri/crates/folder-core/src/lib.rs
+++ b/src-tauri/crates/folder-core/src/lib.rs
@@ -954,6 +954,22 @@ fn encode_file_link(value: &str) -> String {
         .collect()
 }
 
+/// True when both sides share kind and size but modified times do not match under `options`.
+/// Used to classify timestamp-only folder differences as unimportant (Minor).
+pub fn is_timestamp_only_metadata_difference(
+    left: &FolderScanNode,
+    right: &FolderScanNode,
+    options: &FolderCompareOptions,
+) -> bool {
+    left.kind == right.kind
+        && left.metadata.size == right.metadata.size
+        && !modified_times_match(
+            left.metadata.modified_at_ms,
+            right.metadata.modified_at_ms,
+            options,
+        )
+}
+
 fn folder_metadata_matches(
     left: &FolderScanNode,
     right: &FolderScanNode,
@@ -1462,6 +1478,44 @@ mod tests {
             classify_folder_alignment(None, Some(&same_right)),
             FolderCompareStatus::RightOnly
         );
+    }
+
+    #[test]
+    fn detects_timestamp_only_metadata_differences_for_minor_filter() {
+        let left = FolderScanNode::new_file(
+            "same.txt",
+            "same.txt",
+            metadata_with_modified_at(VfsEntryKind::File, "same.txt", Some("txt"), 20, Some(1_000)),
+        );
+        let right_time = FolderScanNode::new_file(
+            "same.txt",
+            "same.txt",
+            metadata_with_modified_at(VfsEntryKind::File, "same.txt", Some("txt"), 20, Some(2_000)),
+        );
+        let right_size = FolderScanNode::new_file(
+            "same.txt",
+            "same.txt",
+            metadata_with_modified_at(VfsEntryKind::File, "same.txt", Some("txt"), 21, Some(2_000)),
+        );
+        let options = FolderCompareOptions {
+            compare_size: true,
+            compare_modified_time: true,
+            case_sensitive_names: true,
+            compare_contents: false,
+            compare_crc: false,
+            ..Default::default()
+        };
+
+        assert!(is_timestamp_only_metadata_difference(
+            &left,
+            &right_time,
+            &options
+        ));
+        assert!(!is_timestamp_only_metadata_difference(
+            &left,
+            &right_size,
+            &options
+        ));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -413,6 +413,9 @@ pub struct FolderCompareRow {
     pub relative_path: String,
     pub depth: usize,
     pub status: String,
+    /// Timestamp-only (or equivalent) difference — surfaces under Folder Compare Minor.
+    #[serde(default)]
+    pub unimportant: bool,
     pub left: Option<FolderCompareSideEntry>,
     pub right: Option<FolderCompareSideEntry>,
 }
@@ -2713,7 +2716,7 @@ fn folder_compare_row(
     right_root: &str,
     criteria: &FolderCompareCriteria,
 ) -> Result<FolderCompareRow, AppErrorPayload> {
-    let status = folder_row_status(
+    let (status, unimportant) = folder_row_classification(
         row,
         left_source,
         right_source,
@@ -2726,6 +2729,7 @@ fn folder_compare_row(
         relative_path: row.relative_path.clone(),
         depth: row.depth,
         status: folder_status_label(&status),
+        unimportant,
         left: row
             .left
             .as_ref()
@@ -2737,14 +2741,14 @@ fn folder_compare_row(
     })
 }
 
-fn folder_row_status(
+fn folder_row_classification(
     row: &FolderAlignmentRow,
     left_source: &crate::sources::CompareSource,
     right_source: &crate::sources::CompareSource,
     left_root: &str,
     right_root: &str,
     criteria: &FolderCompareCriteria,
-) -> Result<FolderCompareStatus, AppErrorPayload> {
+) -> Result<(FolderCompareStatus, bool), AppErrorPayload> {
     let options = criteria.to_options();
     let metadata_status = folder_core::classify_folder_alignment_with_options(
         row.left.as_ref(),
@@ -2752,12 +2756,35 @@ fn folder_row_status(
         &options,
     );
 
-    if metadata_status != FolderCompareStatus::Same || !row_is_file_pair(row) {
-        return Ok(metadata_status);
+    if matches!(
+        metadata_status,
+        FolderCompareStatus::LeftOnly
+            | FolderCompareStatus::RightOnly
+            | FolderCompareStatus::Unknown
+            | FolderCompareStatus::Error
+    ) {
+        return Ok((metadata_status, false));
+    }
+
+    let timestamp_only = matches!(
+        (&row.left, &row.right),
+        (Some(left), Some(right))
+            if folder_core::is_timestamp_only_metadata_difference(left, right, &options)
+    );
+
+    if metadata_status == FolderCompareStatus::Different && !timestamp_only {
+        return Ok((FolderCompareStatus::Different, false));
+    }
+
+    if !row_is_file_pair(row) {
+        return Ok((metadata_status, false));
     }
 
     if !criteria.compare_contents && !criteria.compare_crc {
-        return Ok(metadata_status);
+        let unimportant = metadata_status == FolderCompareStatus::Different
+            && timestamp_only
+            && options.compare_modified_time;
+        return Ok((metadata_status, unimportant));
     }
 
     let left_bytes = crate::sources::read_compare_file(left_source, &row.relative_path)
@@ -2765,28 +2792,43 @@ fn folder_row_status(
     let right_bytes = crate::sources::read_compare_file(right_source, &row.relative_path)
         .map_err(|error| compare_source_error(right_root, error))?;
 
+    let mut content_status = FolderCompareStatus::Same;
+
     if criteria.compare_crc {
-        let status = folder_core::classify_folder_alignment_with_crc32(
+        content_status = folder_core::classify_folder_alignment_with_crc32(
             row.left.as_ref(),
             row.right.as_ref(),
-            &options,
+            &folder_core::FolderCompareOptions {
+                compare_modified_time: false,
+                compare_size: false,
+                ..options.clone()
+            },
             Some(folder_core::calculate_crc32(&left_bytes)),
             Some(folder_core::calculate_crc32(&right_bytes)),
         );
-        if status != FolderCompareStatus::Same || !criteria.compare_contents {
-            return Ok(status);
+        if content_status != FolderCompareStatus::Same && !criteria.compare_contents {
+            return Ok((FolderCompareStatus::Different, false));
         }
     }
 
     if criteria.compare_contents {
-        return Ok(
+        content_status =
             folder_core::compare_binary_streams(&left_bytes[..], &right_bytes[..], 8192)
                 .map_err(|error| file_io_error(left_root, error))?
-                .status,
-        );
+                .status;
     }
 
-    Ok(metadata_status)
+    if content_status != FolderCompareStatus::Same {
+        return Ok((FolderCompareStatus::Different, false));
+    }
+
+    if metadata_status == FolderCompareStatus::Same {
+        return Ok((FolderCompareStatus::Same, false));
+    }
+
+    // Content matches; metadata differs only by timestamp under active mtime criteria.
+    let unimportant = timestamp_only && options.compare_modified_time;
+    Ok((FolderCompareStatus::Different, unimportant))
 }
 
 fn row_is_file_pair(row: &FolderAlignmentRow) -> bool {
@@ -4822,14 +4864,65 @@ mod tests {
         )
         .expect("tolerant timestamp compare");
 
-        assert!(strict
-            .rows
-            .iter()
-            .any(|row| row.relative_path == "note.txt" && row.status == "Different"));
+        assert!(strict.rows.iter().any(|row| {
+            row.relative_path == "note.txt" && row.status == "Different" && row.unimportant
+        }));
         assert!(tolerant
             .rows
             .iter()
-            .any(|row| row.relative_path == "note.txt" && row.status == "Same"));
+            .any(|row| row.relative_path == "note.txt"
+                && row.status == "Same"
+                && !row.unimportant));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn compare_folder_paths_marks_content_diffs_as_important_even_with_mtime_skew() {
+        let root = unique_temp_dir("folder-minor-content");
+        let left = root.join("left");
+        let right = root.join("right");
+        fs::create_dir_all(&left).expect("left");
+        fs::create_dir_all(&right).expect("right");
+        let left_file = left.join("note.txt");
+        let right_file = right.join("note.txt");
+        fs::write(&left_file, b"same-size!").expect("left file");
+        fs::write(&right_file, b"different!").expect("right file");
+
+        let left_time = UNIX_EPOCH + Duration::from_millis(1_000_000);
+        let right_time = UNIX_EPOCH + Duration::from_millis(2_000_000);
+        File::options()
+            .write(true)
+            .open(&left_file)
+            .expect("open left")
+            .set_modified(left_time)
+            .expect("left mtime");
+        File::options()
+            .write(true)
+            .open(&right_file)
+            .expect("open right")
+            .set_modified(right_time)
+            .expect("right mtime");
+
+        let response = compare_folder_paths(
+            left.display().to_string(),
+            right.display().to_string(),
+            Some(FolderCompareCriteria {
+                compare_size: true,
+                compare_modified_time: true,
+                compare_contents: true,
+                compare_crc: false,
+                follow_symlinks: false,
+                timestamp_tolerance_ms: 0,
+                ignore_daylight_saving_hour_offset: false,
+            }),
+            None,
+        )
+        .expect("content+mtime compare");
+
+        assert!(response.rows.iter().any(|row| {
+            row.relative_path == "note.txt" && row.status == "Different" && !row.unimportant
+        }));
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -197,6 +197,8 @@ export interface FolderCompareRow {
   relativePath: string
   depth: number
   status: FolderCompareStatus
+  /** Timestamp-only difference — Folder Compare Minor filter. */
+  unimportant?: boolean
   left?: FolderCompareSideEntry
   right?: FolderCompareSideEntry
 }

--- a/src/views/FolderCompareView.test.ts
+++ b/src/views/FolderCompareView.test.ts
@@ -102,6 +102,26 @@ vi.mock('@/api/diff', () => ({
         right: { name: 'main.ts', kind: 'file', size: 14, path: 'D:/right/src/main.ts' },
       },
       {
+        relativePath: 'stamp.txt',
+        depth: 0,
+        status: 'Different',
+        unimportant: true,
+        left: {
+          name: 'stamp.txt',
+          kind: 'file',
+          size: 8,
+          modifiedAtMs: 1000,
+          path: 'D:/left/stamp.txt',
+        },
+        right: {
+          name: 'stamp.txt',
+          kind: 'file',
+          size: 8,
+          modifiedAtMs: 2000,
+          path: 'D:/right/stamp.txt',
+        },
+      },
+      {
         relativePath: 'README.md',
         depth: 0,
         status: 'Same',
@@ -121,7 +141,7 @@ vi.mock('@/api/diff', () => ({
         right: { name: 'extra-right.md', kind: 'file', size: 3, path: 'D:/right/extra-right.md' },
       },
     ],
-    summary: { total: 5, same: 2, different: 1, leftOnly: 1, rightOnly: 1 },
+    summary: { total: 6, same: 2, different: 2, leftOnly: 1, rightOnly: 1 },
   }),
   copyFolderCompareEntry: vi.fn().mockResolvedValue({
     direction: 'toRight',
@@ -288,6 +308,37 @@ describe('FolderCompareView', () => {
       wrapper.find('[data-testid="folder-session-toolbar-select"]').attributes('disabled'),
     ).toBeUndefined()
     expect(wrapper.html()).not.toContain('未实现')
+  })
+
+  it('filters to unimportant timestamp differences from the Minor toolbar', async () => {
+    const wrapper = mountFolderCompareView()
+
+    await runCompare(wrapper)
+
+    expect(
+      wrapper.find('[data-testid="folder-session-toolbar-minor"]').attributes('disabled'),
+    ).toBeUndefined()
+    expect(wrapper.find('[data-testid="folder-summary-minor"]').text()).toContain('1')
+
+    await wrapper.find('[data-testid="folder-session-toolbar-minor"]').trigger('click')
+    await flushPromises()
+
+    const visiblePaths = wrapper
+      .findAll('[data-testid="folder-row"]')
+      .map((row) => row.attributes('data-row-id'))
+
+    expect(visiblePaths).toEqual(['stamp-txt'])
+    expect(
+      wrapper.find('[data-testid="folder-session-toolbar-minor"]').attributes('data-active'),
+    ).toBe('true')
+    expect(wrapper.find('[data-unimportant="true"]').text()).toContain('Minor')
+
+    await wrapper.find('[data-testid="folder-session-toolbar-all"]').trigger('click')
+    await flushPromises()
+    expect(
+      wrapper.find('[data-testid="folder-session-toolbar-minor"]').attributes('data-active'),
+    ).not.toBe('true')
+    expect(wrapper.findAll('[data-testid="folder-row"]').length).toBeGreaterThan(1)
   })
 
   it('selects visible rows by status and name from the Select toolbar', async () => {

--- a/src/views/FolderCompareView.vue
+++ b/src/views/FolderCompareView.vue
@@ -106,6 +106,7 @@ interface FolderTreeRow {
   rightPath?: string
   status: FolderStatus
   kind: 'file' | 'directory'
+  unimportant?: boolean
   manualAlignment?: boolean
   alignedLeftRelativePath?: string
   alignedRightRelativePath?: string
@@ -160,6 +161,7 @@ const initialDisplayFilters = loadFolderDisplayFilters()
 const visibleStatuses = ref<Set<FolderStatus>>(new Set(initialDisplayFilters.statuses))
 const showSuppressedFilters = ref(initialDisplayFilters.showSuppressed)
 const filesOnlyFilter = ref(initialDisplayFilters.filesOnly)
+const minorOnly = ref(false)
 const showFolderRules = ref(true)
 const showFolderFilters = ref(true)
 const showFolderSelect = ref(false)
@@ -285,6 +287,7 @@ watch([leftRoot, rightRoot], () => {
 const summary = computed(() => ({
   total: rows.value.length,
   different: rows.value.filter((row) => row.status === 'Different').length,
+  minor: rows.value.filter((row) => row.unimportant === true).length,
   orphans: rows.value.filter((row) => row.status === 'Left only' || row.status === 'Right only')
     .length,
 }))
@@ -353,7 +356,8 @@ const visibleRows = computed(() =>
       (!row.parentId || expandedDirectoryIds.value.has(row.parentId)) &&
       !excludedRowIds.value.has(row.id) &&
       (visibleStatuses.value.has(row.status) || showSuppressedFilters.value) &&
-      (!filesOnlyFilter.value || row.kind === 'file'),
+      (!filesOnlyFilter.value || row.kind === 'file') &&
+      (!minorOnly.value || row.unimportant === true),
   ),
 )
 const virtualStartIndex = computed(() =>
@@ -441,6 +445,14 @@ function folderStatusLabel(status: FolderStatus): string {
   }
 
   return t(keys[status])
+}
+
+function folderRowStatusLabel(row: FolderTreeRow): string {
+  if (row.unimportant && row.status === 'Different') {
+    return t('ui.minor')
+  }
+
+  return folderStatusLabel(row.status)
 }
 
 function syncPreviewActionLabel(action: SyncPreviewAction): string {
@@ -678,13 +690,23 @@ function swapFolderRoots(): void {
 }
 
 function showAllFolderStatuses(): void {
+  minorOnly.value = false
   visibleStatuses.value = new Set(['Same', 'Different', 'Left only', 'Right only'])
   persistDisplayFilters()
 }
 
 function showSameFolderStatuses(): void {
+  minorOnly.value = false
   visibleStatuses.value = new Set(['Same'])
   persistDisplayFilters()
+}
+
+function showMinorFolderDifferences(): void {
+  minorOnly.value = !minorOnly.value
+  if (minorOnly.value) {
+    visibleStatuses.value = new Set(['Same', 'Different', 'Left only', 'Right only'])
+    persistDisplayFilters()
+  }
 }
 
 function toggleFilesOnlyFilter(): void {
@@ -710,7 +732,7 @@ const folderSessionToolbar = computed(() =>
     home: true,
     all: true,
     same: true,
-    minor: false,
+    minor: rows.value.length > 0,
     rules: true,
     copy: canCopyToRight.value,
     expand: true,
@@ -722,7 +744,21 @@ const folderSessionToolbar = computed(() =>
     stop: folderCompareLoading.value,
     filters: true,
     peek: true,
-  }),
+  }).map((item) => ({
+    ...item,
+    active:
+      (item.id === 'all' && !minorOnly.value && visibleStatuses.value.size === 4) ||
+      (item.id === 'same' &&
+        !minorOnly.value &&
+        visibleStatuses.value.size === 1 &&
+        visibleStatuses.value.has('Same')) ||
+      (item.id === 'minor' && minorOnly.value) ||
+      (item.id === 'rules' && showFolderRules.value) ||
+      (item.id === 'filters' && showFolderFilters.value) ||
+      (item.id === 'select' && showFolderSelect.value) ||
+      (item.id === 'files' && filesOnlyFilter.value) ||
+      (item.id === 'peek' && showPeekPanel.value),
+  })),
 )
 
 function runFolderToolbarCommand(commandId: string): void {
@@ -735,6 +771,9 @@ function runFolderToolbarCommand(commandId: string): void {
       break
     case 'same':
       showSameFolderStatuses()
+      break
+    case 'minor':
+      showMinorFolderDifferences()
       break
     case 'rules':
       showFolderRules.value = !showFolderRules.value
@@ -902,6 +941,7 @@ function applyFolderCompareResponse(response: FolderCompareResponse): void {
   lastAlignmentAction.value = undefined
   currentDifferenceIndex.value = -1
   lastDifferenceNavigation.value = undefined
+  minorOnly.value = false
   scrollTop.value = 0
 }
 
@@ -921,6 +961,7 @@ function folderCompareResponseRowToTreeRow(row: FolderCompareResponseRow): Folde
     rightPath: row.right?.path,
     status: row.status,
     kind: row.left?.kind ?? row.right?.kind ?? 'file',
+    unimportant: row.unimportant === true,
   }
 }
 
@@ -2455,6 +2496,10 @@ onUnmounted(() => {
           <strong>{{ summary.different }}</strong>
           <span>{{ $t('ui.different') }}</span>
         </div>
+        <div data-testid="folder-summary-minor">
+          <strong>{{ summary.minor }}</strong>
+          <span>{{ $t('ui.minor') }}</span>
+        </div>
         <div>
           <strong>{{ summary.orphans }}</strong>
           <span>{{ $t('ui.orphans') }}</span>
@@ -2813,8 +2858,10 @@ onUnmounted(() => {
                   selected: selectedRowId === row.id,
                   checked: isRowChecked(row.id),
                   suppressed: isSuppressed(row),
+                  'status-unimportant': row.unimportant === true,
                 },
               ]"
+              :data-unimportant="row.unimportant ? 'true' : undefined"
               :style="{ gridTemplateColumns }"
               :data-row-id="row.id"
               data-testid="folder-row"
@@ -2868,7 +2915,7 @@ onUnmounted(() => {
               >
                 {{ typeLabel(row) }}
               </span>
-              <strong>{{ folderStatusLabel(row.status) }}</strong>
+              <strong>{{ folderRowStatusLabel(row) }}</strong>
               <span
                 class="name-cell"
                 :style="{ paddingLeft: rowIndent(row) }"
@@ -2970,7 +3017,7 @@ onUnmounted(() => {
             <div>
               <dt>{{ $t('ui.status') }}</dt>
               <dd :data-tone="selectedRow?.status === 'Different' ? 'modified' : 'default'">
-                {{ selectedRow ? folderStatusLabel(selectedRow.status) : '--' }}
+                {{ selectedRow ? folderRowStatusLabel(selectedRow) : '--' }}
               </dd>
             </div>
             <div>
@@ -3514,6 +3561,12 @@ onUnmounted(() => {
 
 .status-different strong {
   color: var(--diff-modified-fg);
+}
+
+.status-unimportant strong {
+  color: var(--diff-modified-fg);
+  font-style: italic;
+  opacity: 0.85;
 }
 
 .status-left-only strong,


### PR DESCRIPTION
## Summary
- Folder Compare marks same-size, content-equal files that differ only by modified time as **unimportant**, and returns that flag on each row.
- The **Minor** session toolbar button is enabled after a compare, filters the tree to unimportant rows, shows active chrome, and labels those rows as Minor in the status column / summary.

## Still short of captures
- Minor covers timestamp-only pairs under compare-modified-time; attribute-only / rule-based unimportant depth is still thinner than a full importance engine.
- Options Toolbars / Tweaks tree depth remains a separate gap (left for a follow-up).
- PR #109 Picture blend / startup workspace restore was left untouched.

## Test plan
- [x] `vitest` FolderCompareView (30 passed)
- [x] `cargo test -p folder-core`
- [x] `cargo test -p open-diff-app` timestamp tolerance + content-vs-mtime minor classification
- [x] eslint / stylelint / vue-tsc / rustfmt / clippy on touched crates
- [ ] Manual: Folder Rules → Compare timestamps on, re-compare a same-content mtime skew pair, toggle Minor